### PR TITLE
Add e2e tests for installer

### DIFF
--- a/e2e/installer.spec.ts
+++ b/e2e/installer.spec.ts
@@ -1,26 +1,83 @@
 import { rest } from 'msw';
 
 import umbracoPath from '../src/core/helpers/umbraco-path';
-import { StatusResponse } from '../src/core/models';
+import { ProblemDetails, StatusResponse } from '../src/core/models';
 import { expect, test } from '../test';
 
-test('installer is shown', async ({ page, worker }) => {
-	await worker.use(
-		// Override the server status to be "must-install"
-		rest.get(umbracoPath('/server/status'), (_req, res, ctx) => {
-			return res(
-				// Respond with a 200 status code
-				ctx.status(200),
-				ctx.json<StatusResponse>({
-					serverStatus: 'must-install',
+test.describe('installer tests', () => {
+	test.beforeEach(async ({ page, worker }) => {
+		await worker.use(
+			// Override the server status to be "must-install"
+			rest.get(umbracoPath('/server/status'), (_req, res, ctx) => {
+				return res(
+					// Respond with a 200 status code
+					ctx.status(200),
+					ctx.json<StatusResponse>({
+						serverStatus: 'must-install',
+					})
+				);
+			})
+		);
+
+		await page.goto('/install');
+
+		await page.waitForSelector('[data-test="installer"]');
+	});
+
+	test('installer is shown', async ({ page }) => {
+		await expect(page).toHaveURL('/install');
+	});
+
+	test.describe('test success and failure', () => {
+		test.beforeEach(async ({ page }) => {
+			// User form
+			await expect(page.locator('[data-test="installer-user"]')).toBeVisible();
+			await page.type('input[name="name"]', 'Test');
+			await page.type('input[name="email"]', 'test@umbraco');
+			await page.type('input[name="password"]', 'test123456');
+			await page.click('[name="subscribeToNewsletter"]');
+
+			// Go to the next step
+			await page.click('[aria-label="Next"]');
+
+			// Set telemetry
+			await expect(page.locator('[data-test="installer-telemetry"]')).toBeVisible();
+			expect(page.locator('[name="telemetryLevel"]')).toHaveAttribute('value', '2');
+
+			// Click [aria-label="Next"]
+			await page.click('[aria-label="Next"]');
+
+			// Database form
+			await expect(page.locator('[data-test="installer-database"]')).toBeVisible();
+		});
+
+		test('installer completes successfully', async ({ page }) => {
+			await page.click('[aria-label="Install"]');
+			await page.waitForSelector('umb-backoffice', { timeout: 30000 });
+		});
+
+		test('installer fails', async ({ page, worker }) => {
+			await worker.use(
+				// Override the server status to be "must-install"
+				rest.post(umbracoPath('/install/setup'), (_req, res, ctx) => {
+					return res(
+						// Respond with a 200 status code
+						ctx.status(400),
+						ctx.json<ProblemDetails>({
+							status: 400,
+							type: 'validation',
+							detail: 'Something went wrong',
+							errors: {
+								databaseName: ['The database name is required'],
+							},
+						})
+					);
 				})
 			);
-		})
-	);
 
-	await page.goto('/install');
-
-	await page.waitForSelector('[data-test="installer"]');
-
-	await expect(page).toHaveURL('/install');
+			await page.click('[aria-label="Install"]');
+			const errorTxt = page.locator('#error-message');
+			await expect(errorTxt).toHaveText('Something went wrong', { useInnerText: true });
+		});
+	});
 });

--- a/e2e/installer.spec.ts
+++ b/e2e/installer.spec.ts
@@ -30,25 +30,24 @@ test.describe('installer tests', () => {
 
 	test.describe('test success and failure', () => {
 		test.beforeEach(async ({ page }) => {
-			// User form
-			await expect(page.locator('[data-test="installer-user"]')).toBeVisible();
-			await page.type('input[name="name"]', 'Test');
-			await page.type('input[name="email"]', 'test@umbraco');
-			await page.type('input[name="password"]', 'test123456');
+			await page.waitForSelector('[data-test="installer-user"]');
+			await page.fill('[aria-label="name"]', 'Test');
+			await page.fill('[aria-label="email"]', 'test@umbraco');
+			await page.fill('[aria-label="password"]', 'test123456');
 			await page.click('[name="subscribeToNewsletter"]');
 
 			// Go to the next step
 			await page.click('[aria-label="Next"]');
 
 			// Set telemetry
-			await expect(page.locator('[data-test="installer-telemetry"]')).toBeVisible();
-			expect(page.locator('[name="telemetryLevel"]')).toHaveAttribute('value', '2');
+			await page.waitForSelector('[data-test="installer-telemetry"]');
+			await page.waitForSelector('uui-slider[name="telemetryLevel"]');
 
 			// Click [aria-label="Next"]
 			await page.click('[aria-label="Next"]');
 
 			// Database form
-			await expect(page.locator('[data-test="installer-database"]')).toBeVisible();
+			await page.waitForSelector('[data-test="installer-database"]');
 		});
 
 		test('installer completes successfully', async ({ page }) => {
@@ -86,7 +85,7 @@ test.describe('installer tests', () => {
 			// Click reset button
 			await page.click('#button-reset');
 
-			await expect(page.locator('[data-test="installer-user"]')).toBeVisible();
+			await page.waitForSelector('[data-test="installer-user"]');
 		});
 	});
 });

--- a/e2e/installer.spec.ts
+++ b/e2e/installer.spec.ts
@@ -76,8 +76,17 @@ test.describe('installer tests', () => {
 			);
 
 			await page.click('[aria-label="Install"]');
-			const errorTxt = page.locator('#error-message');
-			await expect(errorTxt).toHaveText('Something went wrong', { useInnerText: true });
+
+			await page.waitForSelector('[data-test="installer-error"]');
+
+			await expect(page.locator('[data-test="error-message"]')).toHaveText('Something went wrong', {
+				useInnerText: true,
+			});
+
+			// Click reset button
+			await page.click('#button-reset');
+
+			await expect(page.locator('[data-test="installer-user"]')).toBeVisible();
 		});
 	});
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -99,9 +99,9 @@ const config: PlaywrightTestConfig = {
 
 	/* Run your local dev server before starting the tests */
 	webServer: {
-		command: 'npm run dev -- --mode e2e',
-		port: 5173,
-		reuseExistingServer: !process.env.CI,
+		command: 'npm run dev -- --port 8000 --mode e2e',
+		port: 8000,
+		reuseExistingServer: false,
 	},
 };
 

--- a/src/css/custom-properties.css
+++ b/src/css/custom-properties.css
@@ -1,4 +1,4 @@
-@import '@umbraco-ui/uui-css/dist/uui-css.css';
+@import '../../node_modules/@umbraco-ui/uui-css/dist/uui-css.css';
 
 :root {
 	--uui-color-positive: #1c874c;

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -3,4 +3,5 @@ export * from './installer-database.element';
 export * from './installer-installing.element';
 export * from './installer-user.element';
 export * from './installer-layout.element';
+export * from './installer-error.element';
 export * from './installer.element';

--- a/src/installer/installer-consent.element.ts
+++ b/src/installer/installer-consent.element.ts
@@ -125,7 +125,7 @@ export class UmbInstallerConsent extends UmbContextConsumerMixin(LitElement) {
 
 	render() {
 		return html`
-			<div id="container" class="uui-text">
+			<div id="container" class="uui-text" data-test="installer-telemetry">
 				<h1>Consent for telemetry data</h1>
 				${this._renderSlider()}
 				<div id="buttons">

--- a/src/installer/installer-error.element.ts
+++ b/src/installer/installer-error.element.ts
@@ -1,0 +1,63 @@
+import { css, CSSResultGroup, html, LitElement } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+import { ProblemDetails } from '../core/models';
+
+@customElement('umb-installer-error')
+export class UmbInstallerError extends LitElement {
+	static styles: CSSResultGroup = [
+		css`
+			:host,
+			#container {
+				display: flex;
+				flex-direction: column;
+				height: 100%;
+			}
+
+			h1 {
+				text-align: center;
+			}
+
+			#error-message {
+				color: var(--uui-color-error, red);
+			}
+		`,
+	];
+
+	@property({ type: Object })
+	error?: ProblemDetails;
+
+	private _handleSubmit(e: SubmitEvent) {
+		e.preventDefault();
+		console.log('submit');
+		this.dispatchEvent(new CustomEvent('reset', { bubbles: true, composed: true }));
+	}
+
+	render() {
+		return html` <div id="container" class="uui-text" data-test="installer-error">
+			<uui-form>
+				<form id="installer-form" @submit="${this._handleSubmit}">
+					<h1 class="uui-h3">Installing Umbraco</h1>
+					<h2>Something went wrong</h2>
+					${this.error
+						? html`<p id="error-message" data-test="error-message">${this.error.detail ?? 'Unknown error'}</p>`
+						: html``}
+					<div id="buttons">
+						<uui-button
+							id="button-reset"
+							type="submit"
+							label="Go back and try again"
+							look="primary"
+							color="positive"></uui-button>
+					</div>
+				</form>
+			</uui-form>
+		</div>`;
+	}
+}
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-installer-error': UmbInstallerError;
+	}
+}

--- a/src/installer/installer-error.element.ts
+++ b/src/installer/installer-error.element.ts
@@ -1,4 +1,4 @@
-import { css, CSSResultGroup, html, LitElement } from 'lit';
+import { css, CSSResultGroup, html, LitElement, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import { ProblemDetails } from '../core/models';
@@ -32,15 +32,29 @@ export class UmbInstallerError extends LitElement {
 		this.dispatchEvent(new CustomEvent('reset', { bubbles: true, composed: true }));
 	}
 
+	private _renderError(error: ProblemDetails) {
+		return html`
+			<p id="error-message" data-test="error-message">${error.detail ?? 'Unknown error'}</p>
+			<hr />
+			${error.errors ? this._renderErrors(error.errors) : nothing}
+		`;
+	}
+
+	private _renderErrors(errors: Record<string, unknown>) {
+		return html`
+			<ul>
+				${Object.keys(errors).map((key) => html` <li>${key}: ${(errors[key] as string[]).join(', ')}</li> `)}
+			</ul>
+		`;
+	}
+
 	render() {
 		return html` <div id="container" class="uui-text" data-test="installer-error">
 			<uui-form>
 				<form id="installer-form" @submit="${this._handleSubmit}">
 					<h1 class="uui-h3">Installing Umbraco</h1>
 					<h2>Something went wrong</h2>
-					${this.error
-						? html`<p id="error-message" data-test="error-message">${this.error.detail ?? 'Unknown error'}</p>`
-						: html``}
+					${this.error ? this._renderError(this.error) : nothing}
 					<div id="buttons">
 						<uui-button
 							id="button-reset"

--- a/src/installer/installer-error.element.ts
+++ b/src/installer/installer-error.element.ts
@@ -29,7 +29,6 @@ export class UmbInstallerError extends LitElement {
 
 	private _handleSubmit(e: SubmitEvent) {
 		e.preventDefault();
-		console.log('submit');
 		this.dispatchEvent(new CustomEvent('reset', { bubbles: true, composed: true }));
 	}
 

--- a/src/installer/installer-installing.element.ts
+++ b/src/installer/installer-installing.element.ts
@@ -1,5 +1,5 @@
-import { css, CSSResultGroup, html, LitElement, PropertyValueMap } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
+import { css, CSSResultGroup, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 
 @customElement('umb-installer-installing')
 export class UmbInstallerInstalling extends LitElement {
@@ -11,32 +11,10 @@ export class UmbInstallerInstalling extends LitElement {
 		`,
 	];
 
-	@state()
-	private _installProgress = 0;
-
-	protected firstUpdated(_changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>): void {
-		super.firstUpdated(_changedProperties);
-
-		this._updateProgress();
-	}
-
-	private async _updateProgress() {
-		this._installProgress = Math.min(this._installProgress + (Math.random() + 1) * 10, 100);
-		await new Promise((resolve) => setTimeout(resolve, (Math.random() + 1) * 1000));
-
-		if (this._installProgress >= 100) {
-			// Redirect to backoffice
-			history.replaceState(null, '', '/');
-			return;
-		}
-
-		this._updateProgress();
-	}
-
 	render() {
 		return html` <div class="uui-text" data-test="installer-installing">
 			<h1 class="uui-h3">Installing Umbraco</h1>
-			<uui-progress-bar progress=${this._installProgress}></uui-progress-bar>
+			<uui-loader-bar></uui-loader-bar>
 		</div>`;
 	}
 }

--- a/src/installer/installer-installing.element.ts
+++ b/src/installer/installer-installing.element.ts
@@ -1,5 +1,6 @@
 import { css, CSSResultGroup, html, LitElement, PropertyValueMap } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
+
 @customElement('umb-installer-installing')
 export class UmbInstallerInstalling extends LitElement {
 	static styles: CSSResultGroup = [
@@ -33,7 +34,7 @@ export class UmbInstallerInstalling extends LitElement {
 	}
 
 	render() {
-		return html` <div class="uui-text">
+		return html` <div class="uui-text" data-test="installer-installing">
 			<h1 class="uui-h3">Installing Umbraco</h1>
 			<uui-progress-bar progress=${this._installProgress}></uui-progress-bar>
 		</div>`;

--- a/src/installer/installer-user.element.ts
+++ b/src/installer/installer-user.element.ts
@@ -107,7 +107,7 @@ export class UmbInstallerUser extends UmbContextConsumerMixin(LitElement) {
 	};
 
 	render() {
-		return html` <div id="container" class="uui-text">
+		return html` <div id="container" class="uui-text" data-test="installer-user">
 			<h1>Install Umbraco</h1>
 			<uui-form>
 				<form id="LoginForm" name="login" @submit="${this._handleSubmit}">

--- a/src/installer/installer.element.ts
+++ b/src/installer/installer.element.ts
@@ -1,5 +1,6 @@
 import './installer-consent.element';
 import './installer-database.element';
+import './installer-error.element';
 import './installer-installing.element';
 import './installer-layout.element';
 import './installer-user.element';
@@ -7,7 +8,9 @@ import './installer-user.element';
 import { css, CSSResultGroup, html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 
+import { postInstallSetup } from '../core/api/fetcher';
 import { UmbContextProviderMixin } from '../core/context';
+import { ProblemDetails } from '../core/models';
 import { UmbInstallerContext } from './installer-context';
 
 @customElement('umb-installer')
@@ -17,15 +20,21 @@ export class UmbInstaller extends UmbContextProviderMixin(LitElement) {
 	@state()
 	step = 1;
 
+	private _umbInstallerContext = new UmbInstallerContext();
+
+	private _error?: ProblemDetails;
+
 	constructor() {
 		super();
-		this.provideContext('umbInstallerContext', new UmbInstallerContext());
+		this.provideContext('umbInstallerContext', this._umbInstallerContext);
 	}
 
 	connectedCallback(): void {
 		super.connectedCallback();
 		this.addEventListener('next', () => this._handleNext());
 		this.addEventListener('previous', () => this._goToPreviousStep());
+		this.addEventListener('submit', () => this._handleSubmit());
+		this.addEventListener('reset', () => this._handleReset());
 	}
 
 	private _handleNext() {
@@ -36,6 +45,37 @@ export class UmbInstaller extends UmbContextProviderMixin(LitElement) {
 		this.step--;
 	}
 
+	private _handleFulfilled() {
+		console.warn('TODO: Set up real authentication');
+		sessionStorage.setItem('is-authenticated', 'true');
+		history.replaceState(null, '', '/content');
+	}
+
+	private _handleRejected(e: unknown) {
+		if (e instanceof postInstallSetup.Error) {
+			const error = e.getActualType();
+			if (error.status === 400) {
+				this._error = error.data;
+			}
+		}
+		this._handleNext();
+	}
+
+	private _handleSubmit() {
+		this._handleNext();
+
+		this._umbInstallerContext
+			.requestInstall()
+			.then(() => this._handleFulfilled())
+			.catch((error) => this._handleRejected(error));
+	}
+
+	private _handleReset() {
+		console.log('reset');
+		this.step = 1;
+		this._error = undefined;
+	}
+
 	private _renderSection() {
 		switch (this.step) {
 			case 2:
@@ -44,6 +84,8 @@ export class UmbInstaller extends UmbContextProviderMixin(LitElement) {
 				return html`<umb-installer-database></umb-installer-database>`;
 			case 4:
 				return html`<umb-installer-installing></umb-installer-installing>`;
+			case 5:
+				return html`<umb-installer-error .error=${this._error}></umb-installer-error>`;
 
 			default:
 				return html`<umb-installer-user></umb-installer-user>`;

--- a/src/installer/installer.element.ts
+++ b/src/installer/installer.element.ts
@@ -71,7 +71,6 @@ export class UmbInstaller extends UmbContextProviderMixin(LitElement) {
 	}
 
 	private _handleReset() {
-		console.log('reset');
 		this.step = 1;
 		this._error = undefined;
 	}

--- a/src/installer/installer.stories.ts
+++ b/src/installer/installer.stories.ts
@@ -1,6 +1,7 @@
 import '../core/context/context-provider.element';
 import './installer-consent.element';
 import './installer-database.element';
+import './installer-error.element';
 import './installer-installing.element';
 import './installer-user.element';
 
@@ -8,10 +9,10 @@ import { Meta, Story } from '@storybook/web-components';
 import { html } from 'lit-html';
 import { rest } from 'msw';
 
-import { UmbInstallerUser } from '.';
-import { UmbracoInstaller } from '../core/models';
 import { UmbInstallerContext } from './installer-context';
 
+import type { UmbInstallerUser } from '.';
+import type { UmbracoInstaller } from '../core/models';
 export default {
 	title: 'Components/Installer/Steps',
 	component: 'umb-installer',
@@ -91,3 +92,11 @@ Step3DatabasePreconfigured.parameters = {
 
 export const Step4Installing: Story = () => html`<umb-installer-installing></umb-installer-installing>`;
 Step4Installing.storyName = 'Step 4: Installing';
+
+export const Step5Error: Story = () => html`<umb-installer-error></umb-installer-error>`;
+Step5Error.storyName = 'Step 5: Error';
+Step5Error.parameters = {
+	actions: {
+		handles: ['reset'],
+	},
+};

--- a/src/installer/installer.stories.ts
+++ b/src/installer/installer.stories.ts
@@ -11,7 +11,7 @@ import { rest } from 'msw';
 
 import { UmbInstallerContext } from './installer-context';
 
-import type { UmbInstallerUser } from '.';
+import type { UmbInstallerError, UmbInstallerUser } from '.';
 import type { UmbracoInstaller } from '../core/models';
 export default {
 	title: 'Components/Installer/Steps',
@@ -93,8 +93,24 @@ Step3DatabasePreconfigured.parameters = {
 export const Step4Installing: Story = () => html`<umb-installer-installing></umb-installer-installing>`;
 Step4Installing.storyName = 'Step 4: Installing';
 
-export const Step5Error: Story = () => html`<umb-installer-error></umb-installer-error>`;
+export const Step5Error: Story<UmbInstallerError> = ({ error }) =>
+	html`<umb-installer-error .error=${error}></umb-installer-error>`;
 Step5Error.storyName = 'Step 5: Error';
+Step5Error.args = {
+	error: {
+		type: 'validation',
+		status: 400,
+		detail: 'The form did not pass validation',
+		title: 'Validation error',
+		errors: {
+			'user.password': [
+				'The password must be at least 6 characters long',
+				'The password must contain at least one number',
+			],
+			databaseName: ['The database name is required'],
+		},
+	},
+};
 Step5Error.parameters = {
 	actions: {
 		handles: ['reset'],

--- a/src/mocks/domains/install.handlers.ts
+++ b/src/mocks/domains/install.handlers.ts
@@ -73,16 +73,18 @@ export const handlers = [
 		);
 	}),
 
-	rest.post<PostInstallRequest>(umbracoPath('/install/setup'), async (req, res, ctx) => {
+	rest.post(umbracoPath('/install/setup'), async (req, res, ctx) => {
 		await new Promise((resolve) => setTimeout(resolve, (Math.random() + 1) * 1000)); // simulate a delay of 1-2 seconds
+		const body = await req.json<PostInstallRequest>();
 
-		if (req.body.database?.name === 'fail') {
+		if (body.database?.name === 'fail') {
 			return res(
 				// Respond with a 200 status code
 				ctx.status(400),
 				ctx.json<ProblemDetails>({
 					type: 'validation',
 					status: 400,
+					detail: 'Something went wrong',
 					errors: {
 						name: ['Database name is invalid'],
 					},


### PR DESCRIPTION
This also introduces a new InstallerError component to display errors from the server. In the old backoffice we didn't really display validation errors but only crazy long stacktraces. This is now being handled a little more gracefully, but we might still have to introduce instance checking of the errors later on. For now we just have a `ProblemDetails` object, but we could have a `HttpValidationProblemDetails` object in the future and so on.