### PR TITLE
Do not manipulate data from a UniqueBehaviorSubject

### DIFF
--- a/src/backoffice/shared/collection/views/collection-view-media-grid.element.ts
+++ b/src/backoffice/shared/collection/views/collection-view-media-grid.element.ts
@@ -95,7 +95,7 @@ export class UmbCollectionViewsMediaGridElement extends UmbLitElement {
 		if (!this._collectionContext) return;
 
 		this.observe(this._collectionContext.data, (mediaItems) => {
-			this._mediaItems = mediaItems.sort((a, b) => (a.hasChildren === b.hasChildren ? 0 : a ? -1 : 1));
+			this._mediaItems = [...mediaItems].sort((a, b) => (a.hasChildren === b.hasChildren ? 0 : a ? -1 : 1));
 		});
 
 		this.observe(this._collectionContext.selection, (selection) => {

--- a/src/backoffice/users/current-user/current-user-history.store.ts
+++ b/src/backoffice/users/current-user/current-user-history.store.ts
@@ -9,7 +9,7 @@ export type UmbCurrentUserHistoryItem = {
 };
 
 export class UmbCurrentUserHistoryStore {
-	
+
 	#history = new UniqueBehaviorSubject(
 		<Array<UmbCurrentUserHistoryItem>>[]
 	);
@@ -40,11 +40,6 @@ export class UmbCurrentUserHistoryStore {
 		// This prevents duplicate entries in the history array.
 		if (!lastItem || lastItem.path !== historyItem.path) {
 			this.#history.next([...this.#history.getValue(), historyItem]);
-		} else {
-			//Update existing item
-			const newHistory = this.#history.getValue();
-			newHistory[history.length - 1] = historyItem;
-			this.#history.next(newHistory);
 		}
 	}
 

--- a/src/core/backend-api/core/ApiError.ts
+++ b/src/core/backend-api/core/ApiError.ts
@@ -5,20 +5,20 @@ import type { ApiRequestOptions } from './ApiRequestOptions';
 import type { ApiResult } from './ApiResult';
 
 export class ApiError extends Error {
-    public readonly url: string;
-    public readonly status: number;
-    public readonly statusText: string;
-    public readonly body: any;
-    public readonly request: ApiRequestOptions;
+	public readonly url: string;
+	public readonly status: number;
+	public readonly statusText: string;
+	public readonly body: any;
+	public readonly request: ApiRequestOptions;
 
-    constructor(request: ApiRequestOptions, response: ApiResult, message: string) {
-        super(message);
+	constructor(request: ApiRequestOptions, response: ApiResult, message: string) {
+		super(message);
 
-        this.name = 'ApiError';
-        this.url = response.url;
-        this.status = response.status;
-        this.statusText = response.statusText;
-        this.body = response.body;
-        this.request = request;
-    }
+		this.name = 'ApiError';
+		this.url = response.url;
+		this.status = response.status;
+		this.statusText = response.statusText;
+		this.body = response.body;
+		this.request = request;
+	}
 }

--- a/src/core/extensions-api/registry/extension.registry.ts
+++ b/src/core/extensions-api/registry/extension.registry.ts
@@ -8,6 +8,8 @@ type SpecificManifestTypeOrManifestBase<T extends keyof ManifestTypeMap | string
 	: ManifestBase;
 
 export class UmbExtensionRegistry {
+
+	// TODO: Use UniqueBehaviorSubject, as we don't want someone to edit data of extensions.
 	private _extensions = new BehaviorSubject<Array<ManifestBase>>([]);
 	public readonly extensions = this._extensions.asObservable();
 


### PR DESCRIPTION
Fixes runtime issues, where code is trying to manipulate data coming from Store/UniqueBehaviorSubject