### PR TITLE
Fixes label binding as description

### DIFF
--- a/src/backoffice/shared/components/workspace-property/workspace-property.element.ts
+++ b/src/backoffice/shared/components/workspace-property/workspace-property.element.ts
@@ -146,7 +146,7 @@ export class UmbWorkspacePropertyElement extends UmbLitElement {
 		this.observe(this._propertyContext.label, (label) => {
 			this._label = label;
 		});
-		this.observe(this._propertyContext.label, (description) => {
+		this.observe(this._propertyContext.description, (description) => {
 			this._description = description;
 		});
 


### PR DESCRIPTION
Fixes observing label to set description => should observe _propertyContext.description