### PR TITLE
Change order of sidebar-menu-items aka Trees in Settings section

### DIFF
--- a/src/backoffice/documents/document-blueprints/sidebar-menu-item/manifests.ts
+++ b/src/backoffice/documents/document-blueprints/sidebar-menu-item/manifests.ts
@@ -4,7 +4,7 @@ const sidebarMenuItem: ManifestSidebarMenuItem = {
 	type: 'sidebarMenuItem',
 	alias: 'Umb.SidebarMenuItem.DocumentBlueprints',
 	name: 'Document Blueprints Sidebar Menu Item',
-	weight: 400,
+	weight: 90,
 	meta: {
 		label: 'Document Blueprints',
 		icon: 'umb:blueprint',

--- a/src/backoffice/documents/document-types/sidebar-menu-item/manifests.ts
+++ b/src/backoffice/documents/document-types/sidebar-menu-item/manifests.ts
@@ -4,7 +4,7 @@ const sidebarMenuItem: ManifestSidebarMenuItem = {
 	type: 'sidebarMenuItem',
 	alias: 'Umb.SidebarMenuItem.DocumentTypes',
 	name: 'Document Types Sidebar Menu Item',
-	weight: 400,
+	weight: 10,
 	loader: () => import('./document-types-sidebar-menu-item.element'),
 	meta: {
 		label: 'Document Types',

--- a/src/backoffice/media/media-types/sidebar-menu-item/manifests.ts
+++ b/src/backoffice/media/media-types/sidebar-menu-item/manifests.ts
@@ -4,7 +4,7 @@ const sidebarMenuItem: ManifestSidebarMenuItem = {
 	type: 'sidebarMenuItem',
 	alias: 'Umb.SidebarMenuItem.MediaTypes',
 	name: 'Media Types Sidebar Menu Item',
-	weight: 200,
+	weight: 20,
 	loader: () => import('./media-types-sidebar-menu-item.element'),
 	meta: {
 		label: 'Media Types',

--- a/src/backoffice/members/member-types/sidebar-menu-item/manifests.ts
+++ b/src/backoffice/members/member-types/sidebar-menu-item/manifests.ts
@@ -4,12 +4,12 @@ const sidebarMenuItem: ManifestSidebarMenuItem = {
 	type: 'sidebarMenuItem',
 	alias: 'Umb.SidebarMenuItem.MemberTypes',
 	name: 'Member Types Sidebar Menu Item',
-	weight: 400,
+	weight: 30,
 	loader: () => import('./member-types-sidebar-menu-item.element'),
 	meta: {
 		label: 'Member Types',
 		icon: 'umb:folder',
-		sections: ['Umb.Section.Members'],
+		sections: ['Umb.Section.Settings'],
 	},
 };
 

--- a/src/backoffice/settings/data-types/sidebar-menu-item/manifests.ts
+++ b/src/backoffice/settings/data-types/sidebar-menu-item/manifests.ts
@@ -4,7 +4,7 @@ const sidebarMenuItem: ManifestSidebarMenuItem = {
 	type: 'sidebarMenuItem',
 	alias: 'Umb.SidebarMenuItem.DataTypes',
 	name: 'Data Types Sidebar Menu Item',
-	weight: 400,
+	weight: 40,
 	loader: () => import('./data-types-sidebar-menu-item.element'),
 	meta: {
 		label: 'Data Types',

--- a/src/backoffice/settings/extensions/sidebar-menu-item/manifests.ts
+++ b/src/backoffice/settings/extensions/sidebar-menu-item/manifests.ts
@@ -4,7 +4,7 @@ const sidebarMenuItem: ManifestSidebarMenuItem = {
 	type: 'sidebarMenuItem',
 	alias: 'Umb.SidebarMenuItem.Extensions',
 	name: 'Extensions Sidebar Menu Item',
-	weight: 400,
+	weight: 100,
 	meta: {
 		label: 'Extensions',
 		icon: 'umb:wand',

--- a/src/backoffice/settings/languages/sidebar-menu-item/manifests.ts
+++ b/src/backoffice/settings/languages/sidebar-menu-item/manifests.ts
@@ -4,7 +4,7 @@ const sidebarMenuItem: ManifestSidebarMenuItem = {
 	type: 'sidebarMenuItem',
 	alias: 'Umb.SidebarMenuItem.Languages',
 	name: 'Languages Sidebar Menu Item',
-	weight: 400,
+	weight: 80,
 	meta: {
 		label: 'Languages',
 		icon: 'umb:globe',


### PR DESCRIPTION
Change sidebar-menu-item manifest for Setting trees to match same order as current backoffice

## Note
I moved the Member Types menu-item into the Settings section as before.