### PR TITLE
don't set height on scrollable router-slot

### DIFF
--- a/src/backoffice/shared/components/section/section-dashboards/section-dashboards.element.ts
+++ b/src/backoffice/shared/components/section/section-dashboards/section-dashboards.element.ts
@@ -38,7 +38,6 @@ export class UmbSectionDashboardsElement extends UmbLitElement {
 
 			#router-slot {
 				width: 100%;
-				height: 100%;
 				box-sizing: border-box;
 				display: block;
 				padding:var(--uui-size-5);

--- a/src/backoffice/shared/components/section/section-dashboards/section-dashboards.element.ts
+++ b/src/backoffice/shared/components/section/section-dashboards/section-dashboards.element.ts
@@ -8,7 +8,6 @@ import { createExtensionElement } from '@umbraco-cms/extensions-api';
 import type {
 	ManifestDashboard,
 	ManifestDashboardCollection,
-	ManifestSection,
 	ManifestWithMeta,
 } from '@umbraco-cms/models';
 import { umbExtensionsRegistry } from '@umbraco-cms/extensions-registry';
@@ -23,7 +22,6 @@ export class UmbSectionDashboardsElement extends UmbLitElement {
 				display: flex;
 				flex-direction: column;
 				height: 100%;
-				width: 100%;
 			}
 
 			#tabs {
@@ -32,12 +30,10 @@ export class UmbSectionDashboardsElement extends UmbLitElement {
 			}
 
 			#scroll-container {
-				width: 100%;
-				height: 100%;
+				flex:1;
 			}
 
 			#router-slot {
-				width: 100%;
 				box-sizing: border-box;
 				display: block;
 				padding:var(--uui-size-5);


### PR DESCRIPTION
Setting `height:100%` on `router-slot` inside `uui-scroll-container` causes UI issues when scrolling to the bottom of the scrollable container, as the router-slot padding-bottom is lost. slot should have its natural height, with overflow controlled by the parent scrollable container.

Also tidies other CSS in the component - no need to set width on block-level elements, flexing `#scroll-container` saves a rule.