### PR TITLE
add TYPE property to UmbContextToken to get the generic type

### DIFF
--- a/libs/context-api/context-token.ts
+++ b/libs/context-api/context-token.ts
@@ -1,18 +1,22 @@
 export class UmbContextToken<T = unknown> {
 	/**
+	 * Get the type of the token
+	 *
+	 * @public
+	 * @type      {T}
+	 * @memberOf  UmbContextToken
+	 * @example   `typeof MyToken.TYPE`
+	 * @returns   undefined
+	 */
+	readonly TYPE: T = undefined as never;
+
+	/**
 	 * @param alias   Unique identifier for the token,
 	 * @param _desc   Description for the token,
 	 *                used only for debugging purposes,
 	 *                it should but does not need to be unique
 	 */
 	constructor(protected alias: string, protected _desc?: string) {}
-
-	/**
-	 * @internal
-	 */
-	get multi(): UmbContextToken<Array<T>> {
-		return this as UmbContextToken<Array<T>>;
-	}
 
 	/**
 	 * This method must always return the unique alias of the token since that

--- a/src/backoffice/users/user-groups/workspace/user-group-workspace.context.ts
+++ b/src/backoffice/users/user-groups/workspace/user-group-workspace.context.ts
@@ -10,7 +10,11 @@ export class UmbWorkspaceUserGroupContext
 	extends UmbWorkspaceContext<UmbUserGroupRepository>
 	implements UmbWorkspaceEntityContextInterface<UserGroupDetails | undefined>
 {
-	#manager = new UmbEntityWorkspaceManager(this.host, 'user-group', UMB_USER_GROUP_STORE_CONTEXT_TOKEN);
+	#manager = new UmbEntityWorkspaceManager<typeof UMB_USER_GROUP_STORE_CONTEXT_TOKEN.TYPE>(
+		this.host,
+		'user-group',
+		UMB_USER_GROUP_STORE_CONTEXT_TOKEN
+	);
 
 	public readonly data = this.#manager.state.asObservable();
 	public readonly name = this.#manager.state.getObservablePart((state) => state?.name);

--- a/src/backoffice/users/users/workspace/user-workspace.context.ts
+++ b/src/backoffice/users/users/workspace/user-workspace.context.ts
@@ -10,7 +10,11 @@ export class UmbWorkspaceUserContext
 	extends UmbWorkspaceContext<UmbUserRepository>
 	implements UmbWorkspaceEntityContextInterface<UserDetails | undefined>
 {
-	#manager = new UmbEntityWorkspaceManager(this.host, 'user', UMB_USER_STORE_CONTEXT_TOKEN);
+	#manager = new UmbEntityWorkspaceManager<typeof UMB_USER_STORE_CONTEXT_TOKEN.TYPE>(
+		this.host,
+		'user',
+		UMB_USER_STORE_CONTEXT_TOKEN
+	);
 
 	public readonly data = this.#manager.state.asObservable();
 	public readonly name = this.#manager.state.getObservablePart((state) => state?.name);


### PR DESCRIPTION
# Description

This adds a TYPE property that allows you to get the inferred/generic type of a context token without importing the actual type elsewhere.

We can now also remove the `multi` function which was just left there in order not to get warnings because the generic T parameter was not used for anything else except to hold the type.

# Example
```typescript
class MyComponent extends UmbLitElement {
  #notificationService?: typeof UMB_NOTIFICATION_SERVICE_CONTEXT_TOKEN.TYPE;

  constructor() {
    super();
    
    this.consumeContext(UMB_NOTIFICATION_SERVICE_CONTEXT_TOKEN, (_instance) => { this.#notificationService = _instance; });
  }
}
```