### PR TITLE
Feature/entrypoint types

### DIFF
--- a/libs/extensions-api/rollup.config.js
+++ b/libs/extensions-api/rollup.config.js
@@ -1,0 +1,3 @@
+import config from '../../utils/rollup.config.js';
+
+export default config;

--- a/libs/extensions-api/umb-lifecycle.interface.ts
+++ b/libs/extensions-api/umb-lifecycle.interface.ts
@@ -1,9 +1,11 @@
-import type { UmbExtensionRegistry } from "./registry/extension.registry";
-import type { UmbControllerHostInterface } from "@umbraco-cms/controller";
+import type { UmbExtensionRegistry } from './registry/extension.registry';
+import type { UmbControllerHostInterface } from '@umbraco-cms/controller';
+
+export type UmbEntrypointOnInit = (host: UmbControllerHostInterface, extensionRegistry: UmbExtensionRegistry) => void;
 
 /**
  * Interface containing supported life-cycle functions for ESModule entrypoints
  */
 export interface UmbEntrypointModule {
-	onInit: (host: UmbControllerHostInterface, extensionRegistry: UmbExtensionRegistry) => void
+	onInit: UmbEntrypointOnInit;
 }


### PR DESCRIPTION
## Changes
1. Add rollup to extensions-api lib to access its types from a package point-of-view
2. Add new type specifically for the `onInit` function so extensions can reference that