### PR TITLE
Remove invalid dot from email and URL validation strings

### DIFF
--- a/src/backoffice/shared/modals/property-settings/property-settings-modal.element.ts
+++ b/src/backoffice/shared/modals/property-settings/property-settings-modal.element.ts
@@ -123,7 +123,7 @@ export class UmbPropertySettingsModalElement extends UmbModalBaseElement<undefin
 		{
 			name: 'Validate as an email address',
 			value: 'email',
-			validation: '[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+.[a-zA-Z0-9-.]+',
+			validation: '[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+',
 		},
 		{
 			name: 'Validate as a number',
@@ -133,7 +133,7 @@ export class UmbPropertySettingsModalElement extends UmbModalBaseElement<undefin
 		{
 			name: 'Validate as an URL',
 			value: 'url',
-			validation: 'https?://[a-zA-Z0-9-.]+.[a-zA-Z]{2,}',
+			validation: 'https?://[a-zA-Z0-9-.]+\\.[a-zA-Z]{2,}',
 		},
 		{
 			name: '...or enter a custom validation',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This removes the dot from the default email and URL regexes that can result in bad email addresses/URLs

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and context

The default validation allows _any_ character (UTF-8, emoji etc.) that are not valid in TLDs - I've seen a few instances of this being missed in the wild (it's been a problem in the Backoffice for a long time).

The old Backoffice actually defines this regex in code like this: `[a-zA-Z0-9_\.\+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-\.]+` but it's not properly escaped and gets transformed by the gulp build into `[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+.[a-zA-Z0-9-.]+`, which is wrong.

<!--- Why is this change required? What problem does it solve? -->

## How to test?
Create a new property editor, choose email or URL custom validation.

## Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/7151793/225604184-980b3dc5-a940-43ea-8c45-6f85c88ecf07.png)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.

## N.B - this is an opinionated regex!

I appreciate that we want a best-case regex suitable for most users, and no regex is 100% for these kinds of things, but my edge-case spider-sense is tingling 🕷️

### Email addresses
Technically, an email address such as `name@tld` is perfectly valid, and there are TLDs with MX records in the wild ([like guatemala's .gt](https://mxtoolbox.com/SuperTool.aspx?action=mx%3agt&run=toolpage)).

I'd imagine, as when this was first written, that most users would want to make sure that there is a dot in the second part of the email... but maybe we want to take this opportunity to remove that?

### URLs
The previous URL regex does allow for `localhost`, when this is fixed it wont. I'm not sure if that's a problem? I'd imagine that most people validating a URL in the backoffice would want to make sure it's "real", which localhost technically isn't , but I'm not 100% on that.
