### PR TITLE
#598 fix eye dropper z-index

### DIFF
--- a/src/backoffice/shared/components/workspace/workspace-property-layout/workspace-property-layout.element.ts
+++ b/src/backoffice/shared/components/workspace/workspace-property-layout/workspace-property-layout.element.ts
@@ -21,6 +21,11 @@ export class UmbWorkspacePropertyLayoutElement extends LitElement {
 				border-bottom: 1px solid var(--uui-color-divider);
 				padding: var(--uui-size-space-6) 0;
 				container-type: inline-size;
+				position: relative;
+			}
+
+			:host([alias='eyeDropper']) {
+				z-index: 2;
 			}
 
 			:host > div {
@@ -38,7 +43,7 @@ export class UmbWorkspacePropertyLayoutElement extends LitElement {
 			}
 
 			:host-context(umb-variantable-property:first-of-type) {
-				padding-top:0;
+				padding-top: 0;
 			}
 
 			p {


### PR DESCRIPTION
## Description

Make Eye Dropper popover goes on top of Property Editors and other things.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

Fix #598 issue.

## How to test?

1. Go to Content page
2. Open Eye Dropper button

Before:

![image](https://user-images.githubusercontent.com/17704558/225659155-e8d8f7c3-a476-495f-9787-e7d9f7f5f8cb.png)

After fix:

![image](https://user-images.githubusercontent.com/17704558/225658526-6efa8ea5-1a69-4387-85ed-8623107c437d.png)


## Checklist

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
