### PR TITLE
Fixes broken workspace scroll

### DIFF
--- a/src/backoffice/documents/dashboards/redirect-management/dashboard-redirect-management.element.ts
+++ b/src/backoffice/documents/dashboards/redirect-management/dashboard-redirect-management.element.ts
@@ -5,7 +5,11 @@ import { UUIButtonState, UUIPaginationElement, UUIPaginationEvent } from '@umbra
 import { UMB_CONFIRM_MODAL_TOKEN } from '../../../shared/modals/confirm';
 import { UmbModalContext, UMB_MODAL_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/modal';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
-import { RedirectManagementResource, RedirectStatusModel, RedirectUrlResponseModel } from '@umbraco-cms/backoffice/backend-api';
+import {
+	RedirectManagementResource,
+	RedirectStatusModel,
+	RedirectUrlResponseModel,
+} from '@umbraco-cms/backoffice/backend-api';
 import { tryExecuteAndNotify } from '@umbraco-cms/backoffice/resources';
 
 @customElement('umb-dashboard-redirect-management')
@@ -13,6 +17,11 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 	static styles = [
 		UUITextStyles,
 		css`
+			:host {
+				display: block;
+				margin: var(--uui-size-layout-1);
+			}
+			
 			.actions {
 				display: flex;
 				gap: var(--uui-size-space-1);

--- a/src/backoffice/documents/dashboards/welcome/dashboard-welcome.element.ts
+++ b/src/backoffice/documents/dashboards/welcome/dashboard-welcome.element.ts
@@ -9,7 +9,6 @@ export class UmbDashboardWelcomeElement extends LitElement {
 		css`
 			:host {
 				display: block;
-				position: relative;
 				margin: var(--uui-size-layout-1);
 			}
 		`,

--- a/src/backoffice/documents/documents/workspace/document-workspace-split-view.element.ts
+++ b/src/backoffice/documents/documents/workspace/document-workspace-split-view.element.ts
@@ -24,7 +24,7 @@ export class UmbDocumentWorkspaceSplitViewElement extends UmbLitElement {
 			#splitViews {
 				display: flex;
 				width: 100%;
-				height: 100%;
+				height: calc(100% - var(--umb-footer-layout-height));
 			}
 
 			#breadcrumbs {

--- a/src/backoffice/documents/documents/workspace/views/edit/document-workspace-view-edit-tab.element.ts
+++ b/src/backoffice/documents/documents/workspace/views/edit/document-workspace-view-edit-tab.element.ts
@@ -17,8 +17,8 @@ export class UmbDocumentWorkspaceViewEditTabElement extends UmbLitElement {
 				margin: var(--uui-size-layout-1);
 			}
 
-			uui-box {
-				margin-bottom: var(--uui-size-layout-1);
+			uui-box + uui-box {
+				margin-top: var(--uui-size-layout-1);
 			}
 		`,
 	];

--- a/src/backoffice/members/dashboards/welcome/dashboard-members-welcome.element.ts
+++ b/src/backoffice/members/dashboards/welcome/dashboard-members-welcome.element.ts
@@ -4,7 +4,15 @@ import { customElement } from 'lit/decorators.js';
 
 @customElement('umb-dashboard-members-welcome')
 export class UmbDashboardMembersWelcomeElement extends LitElement {
-	static styles = [UUITextStyles, css``];
+	static styles = [
+		UUITextStyles,
+		css`
+			:host {
+				display: block;
+				margin: var(--uui-size-layout-1);
+			}
+		`,
+	];
 
 	render() {
 		return html`

--- a/src/backoffice/members/member-groups/workspace/manifests.ts
+++ b/src/backoffice/members/member-groups/workspace/manifests.ts
@@ -33,22 +33,21 @@ const workspaceViews: Array<ManifestWorkspaceView> = [
 	},
 ];
 
-// TODO => registering the save action results in two save buttons? Where does #2 come from?
 const workspaceActions: Array<ManifestWorkspaceAction> = [
-	// {
-	// 	type: 'workspaceAction',
-	// 	alias: 'Umb.WorkspaceAction.MemberGroup.Save',
-	// 	name: 'Save Member Group Workspace Action',
-	// 	meta: {
-	// 		label: 'Save',
-	// 		look: 'primary',
-	// 		color: 'positive',
-	// 		api: UmbSaveWorkspaceAction,
-	// 	},
-	// 	conditions: {
-	// 		workspaces: ['Umb.Workspace.MemberGroup'],
-	// 	},
-	// },
+	{
+		type: 'workspaceAction',
+		alias: 'Umb.WorkspaceAction.MemberGroup.Save',
+		name: 'Save Member Group Workspace Action',
+		meta: {
+			label: 'Save',
+			look: 'primary',
+			color: 'positive',
+			api: UmbSaveWorkspaceAction,
+		},
+		conditions: {
+			workspaces: ['Umb.Workspace.MemberGroup'],
+		},
+	},
 ];
 
 export const manifests = [workspace, ...workspaceViews, ...workspaceActions];

--- a/src/backoffice/members/member-groups/workspace/manifests.ts
+++ b/src/backoffice/members/member-groups/workspace/manifests.ts
@@ -33,21 +33,22 @@ const workspaceViews: Array<ManifestWorkspaceView> = [
 	},
 ];
 
+// TODO => registering the save action results in two save buttons? Where does #2 come from?
 const workspaceActions: Array<ManifestWorkspaceAction> = [
-	{
-		type: 'workspaceAction',
-		alias: 'Umb.WorkspaceAction.MemberGroup.SaveAndPublish',
-		name: 'Save Member Group Workspace Action',
-		meta: {
-			label: 'Save',
-			look: 'primary',
-			color: 'positive',
-			api: UmbSaveWorkspaceAction,
-		},
-		conditions: {
-			workspaces: ['Umb.Workspace.MemberGroup'],
-		},
-	},
+	// {
+	// 	type: 'workspaceAction',
+	// 	alias: 'Umb.WorkspaceAction.MemberGroup.Save',
+	// 	name: 'Save Member Group Workspace Action',
+	// 	meta: {
+	// 		label: 'Save',
+	// 		look: 'primary',
+	// 		color: 'positive',
+	// 		api: UmbSaveWorkspaceAction,
+	// 	},
+	// 	conditions: {
+	// 		workspaces: ['Umb.Workspace.MemberGroup'],
+	// 	},
+	// },
 ];
 
 export const manifests = [workspace, ...workspaceViews, ...workspaceActions];

--- a/src/backoffice/members/member-groups/workspace/member-group-workspace-edit.element.ts
+++ b/src/backoffice/members/member-groups/workspace/member-group-workspace-edit.element.ts
@@ -1,7 +1,10 @@
 import { UUITextStyles } from '@umbraco-ui/uui-css/lib';
 import { css, html } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, state } from 'lit/decorators.js';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
+import type { MemberGroupDetails } from '@umbraco-cms/backoffice/models';
+import { UUIInputElement, UUIInputEvent } from '@umbraco-ui/uui';
+import { UmbWorkspaceMemberGroupContext } from './member-group-workspace.context';
 
 /**
  * @element umb-member-group-edit-workspace
@@ -17,11 +20,56 @@ export class UmbMemberGroupWorkspaceEditElement extends UmbLitElement {
 				width: 100%;
 				height: 100%;
 			}
+
+			#header {
+				margin: 0 var(--uui-size-layout-1);
+				flex: 1 1 auto;
+			}
+			
+			#name {
+				width: 100%;
+				flex: 1 1 auto;
+				align-items: center;
+			}
 		`,
 	];
 
+	#workspaceContext?: UmbWorkspaceMemberGroupContext;
+
+	@state()
+	private _memberGroup?: MemberGroupDetails;
+
+	constructor() {
+		super();
+
+		this.consumeContext<UmbWorkspaceMemberGroupContext>('umbWorkspaceContext', (instance) => {
+			this.#workspaceContext = instance;
+			this.#observeMemberGroup();
+		});
+	}
+
+	#observeMemberGroup() {
+		if (!this.#workspaceContext) return;
+		this.observe(this.#workspaceContext.data, (data) => (this._memberGroup = data));
+	}
+
+	// TODO. find a way where we don't have to do this for all workspaces.
+	#handleInput(event: UUIInputEvent) {
+		if (event instanceof UUIInputEvent) {
+			const target = event.composedPath()[0] as UUIInputElement;
+
+			if (typeof target?.value === 'string') {
+				this.#workspaceContext?.setName(target.value);
+			}
+		}
+	}
+
 	render() {
-		return html` <umb-workspace-layout alias="Umb.Workspace.MemberGroup"> Member Group </umb-workspace-layout> `;
+		return html`<umb-workspace-layout alias="Umb.Workspace.MemberGroup">
+			<div id="header" slot="header">
+				<uui-input id="name" .value=${this._memberGroup?.name} @input="${this.#handleInput}"> </uui-input>
+			</div>
+		</umb-workspace-layout> `;
 	}
 }
 

--- a/src/backoffice/packages/package-section/views/market-place/packages-market-place-section-view.element.ts
+++ b/src/backoffice/packages/package-section/views/market-place/packages-market-place-section-view.element.ts
@@ -3,21 +3,27 @@ import { customElement, property } from 'lit/decorators.js';
 
 @customElement('umb-packages-market-place-section-view')
 export class UmbPackagesMarketPlaceSectionViewElement extends LitElement {
-	static styles = [css`
-		#container {
-			height: 100%;
-			display: flex;
-			align-items: stretch;
-		}
+	static styles = [
+		css`
+			:host {
+				height: calc(100% - var(--umb-header-layout-height));
+				display: block;
+			}
 
+			#container {
+				height: 100%;
+				display: flex;
+				align-items: stretch;
+			}
 
-		iframe {
-			width: 100%;
-  			height: 100%;
-  			overflow: hidden;
-			border: none;
-		}
-	`];
+			iframe {
+				width: 100%;
+				height: 100%;
+				overflow: hidden;
+				border: none;
+			}
+		`,
+	];
 
 	// TODO: This URL comes from the server
 	// Was previously found in 'Umbraco.Sys.ServerVariables.umbracoUrls.marketplaceUrl'
@@ -25,15 +31,14 @@ export class UmbPackagesMarketPlaceSectionViewElement extends LitElement {
 	marketplaceUrl = 'https://marketplace.umbraco.com/?umbversion=11.1.0&style=backoffice';
 
 	render() {
-		return html`
-			<div id="container">
-				<iframe
-					src="${this.marketplaceUrl}"
-					title="Umbraco Marketplace"
-					allowfullscreen
-					allow="geolocation; autoplay; clipboard-write; encrypted-media">
-				</iframe>
-			</div>`;
+		return html` <div id="container">
+			<iframe
+				src="${this.marketplaceUrl}"
+				title="Umbraco Marketplace"
+				allowfullscreen
+				allow="geolocation; autoplay; clipboard-write; encrypted-media">
+			</iframe>
+		</div>`;
 	}
 }
 

--- a/src/backoffice/settings/dashboards/examine-management/views/section-view-examine-overview.ts
+++ b/src/backoffice/settings/dashboards/examine-management/views/section-view-examine-overview.ts
@@ -17,6 +17,11 @@ export class UmbDashboardExamineOverviewElement extends UmbLitElement {
 	static styles = [
 		UUITextStyles,
 		css`
+			:host {
+				display:block;
+				margin:var(--uui-size-layout-1);
+			}
+
 			uui-box + uui-box {
 				margin-top: var(--uui-size-space-5);
 			}

--- a/src/backoffice/settings/dashboards/health-check/views/health-check-group.element.ts
+++ b/src/backoffice/settings/dashboards/health-check/views/health-check-group.element.ts
@@ -26,8 +26,13 @@ export class UmbDashboardHealthCheckGroupElement extends UmbLitElement {
 	static styles = [
 		UUITextStyles,
 		css`
-			uui-box {
-				margin-bottom: var(--uui-size-space-5);
+			:host {
+				display: block;
+				margin: var(--uui-size-layout-1);
+			}
+
+			uui-box + uui-box {
+				margin-top: var(--uui-size-space-5);
 			}
 
 			p {

--- a/src/backoffice/settings/dashboards/health-check/views/health-check-overview.element.ts
+++ b/src/backoffice/settings/dashboards/health-check/views/health-check-overview.element.ts
@@ -3,14 +3,11 @@ import { css, html } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { UUIButtonState } from '@umbraco-ui/uui';
 
+import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 import {
 	UmbHealthCheckDashboardContext,
 	UMB_HEALTHCHECK_DASHBOARD_CONTEXT_TOKEN,
 } from '../health-check-dashboard.context';
-import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
-
-import { ManifestHealthCheck } from '@umbraco-cms/backoffice/extensions-registry';
-import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extensions-api';
 
 import './health-check-group-box-overview.element';
 
@@ -19,6 +16,11 @@ export class UmbDashboardHealthCheckOverviewElement extends UmbLitElement {
 	static styles = [
 		UUITextStyles,
 		css`
+			:host {
+				display: block;
+				margin: var(--uui-size-layout-1);
+			}
+
 			uui-box + uui-box {
 				margin-top: var(--uui-size-space-5);
 			}
@@ -26,6 +28,7 @@ export class UmbDashboardHealthCheckOverviewElement extends UmbLitElement {
 			.flex {
 				display: flex;
 				justify-content: space-between;
+				align-items:center;
 			}
 
 			.grid {

--- a/src/backoffice/settings/dashboards/models-builder/dashboard-models-builder.element.ts
+++ b/src/backoffice/settings/dashboards/models-builder/dashboard-models-builder.element.ts
@@ -3,7 +3,11 @@ import { UUITextStyles } from '@umbraco-ui/uui-css/lib';
 import { css, html, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 
-import { ModelsBuilderResponseModel, ModelsBuilderResource, ModelsModeModel } from '@umbraco-cms/backoffice/backend-api';
+import {
+	ModelsBuilderResponseModel,
+	ModelsBuilderResource,
+	ModelsModeModel,
+} from '@umbraco-cms/backoffice/backend-api';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 import { tryExecuteAndNotify } from '@umbraco-cms/backoffice/resources';
 
@@ -12,6 +16,11 @@ export class UmbDashboardModelsBuilderElement extends UmbLitElement {
 	static styles = [
 		UUITextStyles,
 		css`
+			:host {
+				display: block;
+				margin: var(--uui-size-layout-1);
+			}
+
 			.headline {
 				display: flex;
 				justify-content: space-between;

--- a/src/backoffice/settings/dashboards/performance-profiling/dashboard-performance-profiling.element.ts
+++ b/src/backoffice/settings/dashboards/performance-profiling/dashboard-performance-profiling.element.ts
@@ -10,6 +10,11 @@ export class UmbDashboardPerformanceProfilingElement extends UmbLitElement {
 	static styles = [
 		UUITextStyles,
 		css`
+			:host {
+				display: block;
+				margin: var(--uui-size-layout-1);
+			}
+			
 			uui-toggle {
 				font-weight: bold;
 			}

--- a/src/backoffice/settings/dashboards/published-status/dashboard-published-status.element.ts
+++ b/src/backoffice/settings/dashboards/published-status/dashboard-published-status.element.ts
@@ -13,6 +13,11 @@ export class UmbDashboardPublishedStatusElement extends UmbLitElement {
 	static styles = [
 		UUITextStyles,
 		css`
+			:host {
+				display:block;
+				margin:var(--uui-size-layout-1);
+			}
+			
 			uui-box + uui-box {
 				margin-top: var(--uui-size-space-5);
 			}

--- a/src/backoffice/settings/dashboards/settings-welcome/dashboard-settings-welcome.element.ts
+++ b/src/backoffice/settings/dashboards/settings-welcome/dashboard-settings-welcome.element.ts
@@ -11,6 +11,7 @@ export class UmbDashboardSettingsWelcomeElement extends LitElement {
 				display: grid;
 				grid-gap: var(--uui-size-7);
 				grid-template-columns: repeat(3, 1fr);
+				margin: var(--uui-size-layout-1);
 			}
 
 			@media (max-width: 1200px) {

--- a/src/backoffice/settings/dashboards/telemetry/dashboard-telemetry.element.ts
+++ b/src/backoffice/settings/dashboards/telemetry/dashboard-telemetry.element.ts
@@ -12,8 +12,9 @@ export class UmbDashboardTelemetryElement extends UmbLitElement {
 	static styles = [
 		UUITextStyles,
 		css`
-			.italic {
-				font-style: italic;
+			:host {
+				display: block;
+				margin: var(--uui-size-layout-1);
 			}
 		`,
 	];
@@ -120,7 +121,7 @@ export class UmbDashboardTelemetryElement extends UmbLitElement {
 		return html`
 			<uui-box>
 				<h1>Consent for telemetry data</h1>
-				<div style="max-width:580px">
+				<div style="max-width:75ch">
 					<p>
 						In order to improve Umbraco and add new functionality based on as relevant information as possible, we would
 						like to collect system- and usage information from your installation. Aggregate data will be shared on a

--- a/src/backoffice/settings/data-types/workspace/manifests.ts
+++ b/src/backoffice/settings/data-types/workspace/manifests.ts
@@ -5,9 +5,11 @@ import type {
 	ManifestWorkspaceView,
 } from '@umbraco-cms/backoffice/extensions-registry';
 
+const DATA_TYPE_WORKSPACE_ALIAS = 'Umb.Workspace.DataType';
+
 const workspace: ManifestWorkspace = {
 	type: 'workspace',
-	alias: 'Umb.Workspace.DataType',
+	alias: DATA_TYPE_WORKSPACE_ALIAS,
 	name: 'Data Type Workspace',
 	loader: () => import('./data-type-workspace.element'),
 	meta: {
@@ -28,7 +30,7 @@ const workspaceViews: Array<ManifestWorkspaceView> = [
 			icon: 'edit',
 		},
 		conditions: {
-			workspaces: ['Umb.Workspace.DataType'],
+			workspaces: [DATA_TYPE_WORKSPACE_ALIAS],
 		},
 	},
 	{
@@ -43,7 +45,7 @@ const workspaceViews: Array<ManifestWorkspaceView> = [
 			icon: 'info',
 		},
 		conditions: {
-			workspaces: ['Umb.Workspace.DataType'],
+			workspaces: [DATA_TYPE_WORKSPACE_ALIAS],
 		},
 	},
 ];
@@ -60,7 +62,7 @@ const workspaceActions: Array<ManifestWorkspaceAction> = [
 			api: UmbSaveWorkspaceAction,
 		},
 		conditions: {
-			workspaces: ['Umb.Workspace.MemberGroup'],
+			workspaces: [DATA_TYPE_WORKSPACE_ALIAS],
 		},
 	},
 ];

--- a/src/backoffice/settings/extensions/workspace/extension-root-workspace.element.ts
+++ b/src/backoffice/settings/extensions/workspace/extension-root-workspace.element.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit';
+import { css, html } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { map } from 'rxjs';
 import { UMB_CONFIRM_MODAL_TOKEN } from '../../../shared/modals/confirm';
@@ -9,6 +9,12 @@ import { UmbModalContext, UMB_MODAL_CONTEXT_TOKEN } from '@umbraco-cms/backoffic
 
 @customElement('umb-extension-root-workspace')
 export class UmbExtensionRootWorkspaceElement extends UmbLitElement {
+	static styles = [css`
+		uui-box {
+			margin: var(--uui-size-layout-1);
+		}
+	`]
+
 	@state()
 	private _extensions?: Array<ManifestTypes> = undefined;
 
@@ -57,7 +63,7 @@ export class UmbExtensionRootWorkspaceElement extends UmbLitElement {
 
 	render() {
 		return html`
-			<umb-workspace-layout headline="Extensions" alias="Umb.Workspace.ExtensionRoot">
+			<umb-workspace-layout headline="Extensions" alias="Umb.Workspace.ExtensionRoot" .enforceNoFooter=${true}>
 				<uui-box>
 					<uui-table>
 						<uui-table-head>

--- a/src/backoffice/settings/logviewer/workspace/logviewer-root/logviewer-root-workspace.element.ts
+++ b/src/backoffice/settings/logviewer/workspace/logviewer-root/logviewer-root-workspace.element.ts
@@ -37,10 +37,6 @@ export class UmbLogViewerWorkspaceElement extends UmbLitElement {
 				align-items: center;
 			}
 
-			#router-slot {
-				height: 100%;
-			}
-
 			uui-tab-group {
 				--uui-tab-divider: var(--uui-color-border);
 				border-left: 1px solid var(--uui-color-border);

--- a/src/backoffice/settings/logviewer/workspace/views/overview/log-overview-view.element.ts
+++ b/src/backoffice/settings/logviewer/workspace/views/overview/log-overview-view.element.ts
@@ -11,14 +11,14 @@ export class UmbLogViewerOverviewViewElement extends UmbLitElement {
 		css`
 			:host {
 				display: block;
+				margin: var(--uui-size-layout-1);
 			}
 
 			#logviewer-layout {
-				margin: 20px;
-				height: calc(100vh - 160px);
+				padding-bottom: var(--uui-size-layout-1);
 				display: grid;
 				grid-template-columns: 7fr 2fr;
-				grid-template-rows: 1fr 1fr;
+				grid-template-rows: auto auto;
 				gap: 20px 20px;
 				grid-auto-flow: row;
 				grid-template-areas:

--- a/src/backoffice/shared/components/backoffice-frame/backoffice-main.element.ts
+++ b/src/backoffice/shared/components/backoffice-frame/backoffice-main.element.ts
@@ -2,13 +2,13 @@ import { defineElement } from '@umbraco-ui/uui-base/lib/registration';
 import { UUITextStyles } from '@umbraco-ui/uui-css/lib';
 import { css, html } from 'lit';
 import { state } from 'lit/decorators.js';
-import { UmbSectionContext, UMB_SECTION_CONTEXT_TOKEN } from '../section/section.context';
-import { UmbSectionElement } from '../section/section.element';
-import { UmbBackofficeContext, UMB_BACKOFFICE_CONTEXT_TOKEN } from './backoffice.context';
-import type { IRoutingInfo, UmbRouterSlotChangeEvent } from '@umbraco-cms/internal/router';
+import type { UmbRouterSlotChangeEvent } from '@umbraco-cms/internal/router';
 import type { ManifestSection } from '@umbraco-cms/backoffice/extensions-registry';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 import { createExtensionElementOrFallback } from '@umbraco-cms/backoffice/extensions-api';
+import { UmbSectionElement } from '../section/section.element';
+import { UmbSectionContext, UMB_SECTION_CONTEXT_TOKEN } from '../section/section.context';
+import { UmbBackofficeContext, UMB_BACKOFFICE_CONTEXT_TOKEN } from './backoffice.context';
 
 @defineElement('umb-backoffice-main')
 export class UmbBackofficeMain extends UmbLitElement {
@@ -18,12 +18,7 @@ export class UmbBackofficeMain extends UmbLitElement {
 			:host {
 				background-color: var(--uui-color-background);
 				display: block;
-				width: 100%;
-				height: 100%;
-				overflow: hidden;
-			}
-			router-slot {
-				height: 100%;
+				height: calc(100% - 60px); // 60 => top header height
 			}
 		`,
 	];

--- a/src/backoffice/shared/components/body-layout/body-layout.element.ts
+++ b/src/backoffice/shared/components/body-layout/body-layout.element.ts
@@ -32,7 +32,7 @@ export class UmbBodyLayout extends LitElement {
 				align-items: center;
 				justify-content: space-between;
 				width: 100%;
-				height: 70px;
+				height: var(--umb-header-layout-height);
 				background-color: var(--uui-color-surface);
 				border-bottom: 1px solid var(--uui-color-border);
 				box-sizing: border-box;

--- a/src/backoffice/shared/components/debug/debug.element.ts
+++ b/src/backoffice/shared/components/debug/debug.element.ts
@@ -1,16 +1,20 @@
 import { UUITextStyles } from '@umbraco-ui/uui-css/lib';
 import { css, html, nothing, TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import { UMB_CONTEXT_DEBUGGER_MODAL_TOKEN } from './modals/debug';
 import { UmbContextDebugRequest } from '@umbraco-cms/backoffice/context-api';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 import { UmbModalContext, UMB_MODAL_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/modal';
+import { UMB_CONTEXT_DEBUGGER_MODAL_TOKEN } from './modals/debug';
 
 @customElement('umb-debug')
 export class UmbDebug extends UmbLitElement {
 	static styles = [
 		UUITextStyles,
 		css`
+			:host {
+				float: right;
+			}
+
 			#container {
 				display: block;
 				font-family: monospace;

--- a/src/backoffice/shared/components/section/section-main/section-main.element.ts
+++ b/src/backoffice/shared/components/section/section-main/section-main.element.ts
@@ -12,6 +12,7 @@ export class UmbSectionMainElement extends LitElement {
 				height: 100%;
 			}
 
+			main,
 			slot {
 				display: flex;
 				flex-direction: column;

--- a/src/backoffice/shared/components/section/section-views/section-views.element.ts
+++ b/src/backoffice/shared/components/section/section-views/section-views.element.ts
@@ -21,6 +21,8 @@ export class UmbSectionViewsElement extends UmbLitElement {
 				display: flex;
 				justify-content: space-between;
 				align-items: center;
+				height:var(--umb-header-layout-height);
+				box-sizing: border-box;
 			}
 
 			#views {

--- a/src/backoffice/shared/components/section/section.element.ts
+++ b/src/backoffice/shared/components/section/section.element.ts
@@ -27,11 +27,6 @@ export class UmbSectionElement extends UmbLitElement {
 				display: flex;
 			}
 
-			#router-slot {
-				overflow: auto;
-				height: 100%;
-			}
-
 			h3 {
 				padding: var(--uui-size-4) var(--uui-size-8);
 			}

--- a/src/backoffice/shared/components/workspace/workspace-layout/workspace-layout.element.ts
+++ b/src/backoffice/shared/components/workspace/workspace-layout/workspace-layout.element.ts
@@ -39,6 +39,12 @@ export class UmbWorkspaceLayout extends UmbLitElement {
 				height: 100%;
 			}
 
+			#router-slot {
+				display:flex;
+				flex-direction:column;
+				height:100%;
+			}
+
 			uui-input {
 				width: 100%;
 			}

--- a/src/backoffice/translation/dashboards/dictionary/dashboard-translation-dictionary.element.ts
+++ b/src/backoffice/translation/dashboards/dictionary/dashboard-translation-dictionary.element.ts
@@ -19,6 +19,7 @@ export class UmbDashboardTranslationDictionaryElement extends UmbLitElement {
 				display: flex;
 				flex-direction: column;
 				height: 100%;
+				margin: var(--uui-size-layout-1);
 			}
 
 			#dictionary-top-bar {

--- a/src/backoffice/users/user-section/views/user-groups/section-view-user-groups.element.ts
+++ b/src/backoffice/users/user-section/views/user-groups/section-view-user-groups.element.ts
@@ -1,10 +1,24 @@
-import { html, LitElement } from 'lit';
+import { UUITextStyles } from '@umbraco-ui/uui-css';
+import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
 import './workspace-view-user-groups.element';
 
 @customElement('umb-section-view-user-groups')
 export class UmbSectionViewUserGroupsElement extends LitElement {
+	static styles = [
+		UUITextStyles,
+		css`
+			:host {
+				height: 100%;
+			}
+
+			#router-slot {
+				height: calc(100% - var(--umb-header-layout-height) - var(--umb-footer-layout-height));
+			}
+		`,
+	];
+
 	render() {
 		return html`<umb-workspace-view-user-groups></umb-workspace-view-user-groups>`;
 	}

--- a/src/backoffice/users/user-section/views/user-groups/workspace-view-user-groups.element.ts
+++ b/src/backoffice/users/user-section/views/user-groups/workspace-view-user-groups.element.ts
@@ -31,6 +31,11 @@ export class UmbWorkspaceViewUserGroupsElement extends UmbLitElement {
 				height: 100%;
 				display: flex;
 				flex-direction: column;
+				margin:var(--uui-size-layout-1);
+			}
+
+			umb-table {
+				padding:0;
 			}
 		`,
 	];

--- a/src/backoffice/users/user-section/views/users/list-view-layouts/grid/workspace-view-users-grid.element.ts
+++ b/src/backoffice/users/user-section/views/users/list-view-layouts/grid/workspace-view-users-grid.element.ts
@@ -18,7 +18,6 @@ export class UmbWorkspaceViewUsersGridElement extends UmbLitElement {
 		UUITextStyles,
 		css`
 			:host {
-				height: 100%;
 				display: flex;
 				flex-direction: column;
 			}
@@ -147,15 +146,13 @@ export class UmbWorkspaceViewUsersGridElement extends UmbLitElement {
 
 	render() {
 		return html`
-			<uui-scroll-container>
-				<div id="user-grid">
-					${repeat(
-						this._users,
-						(user) => user.key,
-						(user) => this.renderUserCard(user)
-					)}
-				</div>
-			</uui-scroll-container>
+			<div id="user-grid">
+				${repeat(
+					this._users,
+					(user) => user.key,
+					(user) => this.renderUserCard(user)
+				)}
+			</div>
 		`;
 	}
 }

--- a/src/backoffice/users/user-section/views/users/list-view-layouts/table/workspace-view-users-table.element.ts
+++ b/src/backoffice/users/user-section/views/users/list-view-layouts/table/workspace-view-users-table.element.ts
@@ -27,9 +27,13 @@ export class UmbWorkspaceViewUsersTableElement extends UmbLitElement {
 		UUITextStyles,
 		css`
 			:host {
-				height: 100%;
 				display: flex;
 				flex-direction: column;
+			}
+
+			umb-table {
+				padding: 0;
+				margin: 0 var(--uui-size-layout-1) var(--uui-size-layout-1);
 			}
 		`,
 	];

--- a/src/backoffice/users/user-section/views/users/section-view-users.element.ts
+++ b/src/backoffice/users/user-section/views/users/section-view-users.element.ts
@@ -21,6 +21,10 @@ export class UmbSectionViewUsersElement extends UmbLitElement {
 		css`
 			:host {
 				height: 100%;
+			}			
+
+			#router-slot {
+				height: calc(100% - var(--umb-header-layout-height));
 			}
 		`,
 	];
@@ -129,7 +133,7 @@ export class UmbSectionViewUsersElement extends UmbLitElement {
 	}
 
 	render() {
-		return html`<umb-router-slot .routes=${this._routes}></umb-router-slot>`;
+		return html`<umb-router-slot id="router-slot" .routes=${this._routes}></umb-router-slot>`;
 	}
 }
 

--- a/src/backoffice/users/user-section/views/users/workspace-view-users-overview.element.ts
+++ b/src/backoffice/users/user-section/views/users/workspace-view-users-overview.element.ts
@@ -28,7 +28,7 @@ export class UmbWorkspaceViewUsersOverviewElement extends UmbLitElement {
 
 			#sticky-top {
 				position: sticky;
-				top: -1px;
+				top: 0px;
 				z-index: 1;
 				box-shadow: 0 1px 3px rgba(0, 0, 0, 0), 0 1px 2px rgba(0, 0, 0, 0);
 				transition: 250ms box-shadow ease-in-out;
@@ -72,9 +72,6 @@ export class UmbWorkspaceViewUsersOverviewElement extends UmbLitElement {
 			a {
 				color: inherit;
 				text-decoration: none;
-			}
-			router-slot {
-				overflow: hidden;
 			}
 		`,
 	];
@@ -173,56 +170,58 @@ export class UmbWorkspaceViewUsersOverviewElement extends UmbLitElement {
 
 	render() {
 		return html`
-			<div id="sticky-top">
-				<div id="user-list-top-bar">
-					<uui-button
-						@click=${this._showInviteOrCreate}
-						label=${this.isCloud ? 'Invite' : 'Create' + ' user'}
-						look="outline"></uui-button>
-					<uui-input @input=${this._updateSearch} label="search" id="input-search"></uui-input>
-					<div>
-						<!-- TODO: consider making this a shared component, as we need similar for other locations, example media library, members. -->
-						<uui-popover margin="8">
-							<uui-button @click=${this._handleTogglePopover} slot="trigger" label="status">
-								Status: <b>All</b>
+			<uui-scroll-container>
+				<div id="sticky-top">
+					<div id="user-list-top-bar">
+						<uui-button
+							@click=${this._showInviteOrCreate}
+							label=${this.isCloud ? 'Invite' : 'Create' + ' user'}
+							look="outline"></uui-button>
+						<uui-input @input=${this._updateSearch} label="search" id="input-search"></uui-input>
+						<div>
+							<!-- TODO: consider making this a shared component, as we need similar for other locations, example media library, members. -->
+							<uui-popover margin="8">
+								<uui-button @click=${this._handleTogglePopover} slot="trigger" label="status">
+									Status: <b>All</b>
+								</uui-button>
+								<div slot="popover" class="filter-dropdown">
+									<uui-checkbox label="Active"></uui-checkbox>
+									<uui-checkbox label="Inactive"></uui-checkbox>
+									<uui-checkbox label="Invited"></uui-checkbox>
+									<uui-checkbox label="Disabled"></uui-checkbox>
+								</div>
+							</uui-popover>
+							<uui-popover margin="8">
+								<uui-button @click=${this._handleTogglePopover} slot="trigger" label="groups">
+									Groups: <b>All</b>
+								</uui-button>
+								<div slot="popover" class="filter-dropdown">
+									<uui-checkbox label="Active"></uui-checkbox>
+									<uui-checkbox label="Inactive"></uui-checkbox>
+									<uui-checkbox label="Invited"></uui-checkbox>
+									<uui-checkbox label="Disabled"></uui-checkbox>
+								</div>
+							</uui-popover>
+							<uui-popover margin="8">
+								<uui-button @click=${this._handleTogglePopover} slot="trigger" label="order by">
+									Order by: <b>Name (A-Z)</b>
+								</uui-button>
+								<div slot="popover" class="filter-dropdown">
+									<uui-checkbox label="Active"></uui-checkbox>
+									<uui-checkbox label="Inactive"></uui-checkbox>
+									<uui-checkbox label="Invited"></uui-checkbox>
+									<uui-checkbox label="Disabled"></uui-checkbox>
+								</div>
+							</uui-popover>
+							<uui-button label="view toggle" @click=${this._toggleViewType} compact look="outline">
+								<uui-icon name="settings"></uui-icon>
 							</uui-button>
-							<div slot="popover" class="filter-dropdown">
-								<uui-checkbox label="Active"></uui-checkbox>
-								<uui-checkbox label="Inactive"></uui-checkbox>
-								<uui-checkbox label="Invited"></uui-checkbox>
-								<uui-checkbox label="Disabled"></uui-checkbox>
-							</div>
-						</uui-popover>
-						<uui-popover margin="8">
-							<uui-button @click=${this._handleTogglePopover} slot="trigger" label="groups">
-								Groups: <b>All</b>
-							</uui-button>
-							<div slot="popover" class="filter-dropdown">
-								<uui-checkbox label="Active"></uui-checkbox>
-								<uui-checkbox label="Inactive"></uui-checkbox>
-								<uui-checkbox label="Invited"></uui-checkbox>
-								<uui-checkbox label="Disabled"></uui-checkbox>
-							</div>
-						</uui-popover>
-						<uui-popover margin="8">
-							<uui-button @click=${this._handleTogglePopover} slot="trigger" label="order by">
-								Order by: <b>Name (A-Z)</b>
-							</uui-button>
-							<div slot="popover" class="filter-dropdown">
-								<uui-checkbox label="Active"></uui-checkbox>
-								<uui-checkbox label="Inactive"></uui-checkbox>
-								<uui-checkbox label="Invited"></uui-checkbox>
-								<uui-checkbox label="Disabled"></uui-checkbox>
-							</div>
-						</uui-popover>
-						<uui-button label="view toggle" @click=${this._toggleViewType} compact look="outline">
-							<uui-icon name="settings"></uui-icon>
-						</uui-button>
+						</div>
 					</div>
 				</div>
-			</div>
 
-			<umb-router-slot .routes=${this._routes}></umb-router-slot>
+				<umb-router-slot id="router-slot" .routes=${this._routes}></umb-router-slot>
+			</uui-scroll-container>
 
 			${this._renderSelection()}
 		`;

--- a/src/core/css/custom-properties.css
+++ b/src/core/css/custom-properties.css
@@ -1,3 +1,5 @@
 :root {
 	--uui-color-positive: #1c874c;
+	--umb-footer-layout-height: 54px;
+	--umb-header-layout-height: 70px;
 }

--- a/src/core/router/router-slot.element.ts
+++ b/src/core/router/router-slot.element.ts
@@ -1,6 +1,6 @@
 import type { IRoute } from 'router-slot/model';
 import { RouterSlot } from 'router-slot';
-import { LitElement, PropertyValueMap } from 'lit';
+import { css, LitElement, PropertyValueMap } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { UmbRouterSlotInitEvent } from './router-slot-init.event';
 import { UmbRouterSlotChangeEvent } from './router-slot-change.event';
@@ -14,6 +14,18 @@ import { UmbRouterSlotChangeEvent } from './router-slot-change.event';
  */
 @customElement('umb-router-slot')
 export class UmbRouterSlotElement extends LitElement {
+	static styles = [css`
+		:host {
+			display:flex;
+			flex-direction:column;
+			height:100%;
+		}
+
+		router-slot {
+			height:100%;
+		}
+	`]
+
 	#router: RouterSlot = new RouterSlot();
 	#listening = false;
 


### PR DESCRIPTION
Revisiting changes made in #160, after introduction of `umb-router-slot` caused some layout issues

Changes here fix issues with vertical scroll in dashboards and workspaces, where previously these were not scrollable. Tried for a consistent approach where the required styling for `umb-router-slot` and its child `router-slot` is set once and works everywhere, but have still had to manage some views individually.

Also tidied up whitespace around dashboard elements, making this consistent, and cleaned up some redundant CSS.

May not be perfect just yet, but fixes the main issues with scroll