### PR TITLE
Use wca to generate the JSON format for VSCode for HTMLCustomData

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -38,6 +38,8 @@ jobs:
           node-version: 18
           cache: 'npm'
       - run: npm ci
+      - run: npm run wc-analyze
+      - run: npm run wc-analyze:vscode
       - run: npm run build:libs
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -13,6 +13,7 @@ on:
       - 'package-lock.json'
       - '.github/workflows/npm-publish-github-packages.yml'
       - './rollup-libs.config.js'
+      - 'src/**/*.element.ts'
   pull_request:
     branches: [ main ]
     paths:
@@ -21,6 +22,7 @@ on:
       - 'package-lock.json'
       - '.github/workflows/npm-publish-github-packages.yml'
       - './rollup-libs.config.js'
+      - 'src/**/*.element.ts'
   workflow_dispatch:
 
 env:

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,8 @@ playwright/.cache/
 storybook-static/
 
 custom-elements.json
+
+# JSON for HTML Custom Data
+# https://github.com/runem/web-component-analyzer#vscode
+# https://github.com/microsoft/vscode-custom-data
+vscode-html-custom-data.json

--- a/libs/package.json
+++ b/libs/package.json
@@ -26,5 +26,6 @@
 		"@types/uuid": "^9.0.1",
 		"@umbraco-ui/uui": "^1.2.0-rc.0",
 		"rxjs": "^7.8.0"
-	}
+	},
+	"customElements": "custom-elements.json"
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
 		"build-storybook": "npm run wc-analyze && storybook build",
 		"generate:icons": "node ./devops/icons/index.js",
 		"wc-analyze": "wca **/*.element.ts --outFile custom-elements.json",
+		"wc-analyze:vscode": "wca **/*.element.ts --format vscode --outFile vscode-html-custom-data.json",
 		"new-extension": "plop  --plopfile ./devops/plop/plop.js",
 		"compile": "tsc",
 		"check": "npm run lint && npm run compile && npm run build-storybook"

--- a/utils/move-libs.js
+++ b/utils/move-libs.js
@@ -15,6 +15,7 @@
 
 import { readdirSync, readFileSync, writeFileSync, cpSync, mkdirSync } from 'fs';
 
+const rootDir = './';
 const srcDir = './libs';
 const inputDir = './dist/libs';
 const outputDir = '../Umbraco.Cms.StaticAssets/wwwroot/umbraco/backoffice/libs';
@@ -22,8 +23,8 @@ const outputDir = '../Umbraco.Cms.StaticAssets/wwwroot/umbraco/backoffice/libs';
 // Copy package files
 cpSync(`${srcDir}/package.json`, `${inputDir}/package.json`, { recursive: true });
 cpSync(`${srcDir}/README.md`, `${inputDir}/README.md`, { recursive: true });
-cpSync(`${srcDir}/custom-elements.json`, `${inputDir}/custom-elements.json`, { recursive: true });
-cpSync(`${srcDir}/vscode-html-custom-data.json`, `${inputDir}/vscode-html-custom-data.json`, { recursive: true });
+cpSync(`${rootDir}/custom-elements.json`, `${inputDir}/custom-elements.json`, { recursive: true });
+cpSync(`${rootDir}/vscode-html-custom-data.json`, `${inputDir}/vscode-html-custom-data.json`, { recursive: true });
 
 const libs = readdirSync(inputDir);
 

--- a/utils/move-libs.js
+++ b/utils/move-libs.js
@@ -10,6 +10,9 @@
 // Note: This script is not used in the build process, it is only used to transform the d.ts files
 //       when the d.ts files are copied to the dist folder
 
+// Note: Updated to help copy the two JSON files generated from webcomponant analyzer tool
+// One is specific to VSCode HTMLCutomData for intellisense and the other is a more broad format used in storybook etc
+
 import { readdirSync, readFileSync, writeFileSync, cpSync, mkdirSync } from 'fs';
 
 const srcDir = './libs';
@@ -19,6 +22,8 @@ const outputDir = '../Umbraco.Cms.StaticAssets/wwwroot/umbraco/backoffice/libs';
 // Copy package files
 cpSync(`${srcDir}/package.json`, `${inputDir}/package.json`, { recursive: true });
 cpSync(`${srcDir}/README.md`, `${inputDir}/README.md`, { recursive: true });
+cpSync(`${srcDir}/custom-elements.json`, `${inputDir}/custom-elements.json`, { recursive: true });
+cpSync(`${srcDir}/vscode-html-custom-data.json`, `${inputDir}/vscode-html-custom-data.json`, { recursive: true });
 
 const libs = readdirSync(inputDir);
 


### PR DESCRIPTION
Use `web-component-analyzer` to generate the JSON format for VSCode for HTMLCustomData to help with completions.

## Web Component Analyzer Tool
`wca analyze src --format vscode --outFile vscode-html-custom-data.json`

## VSCode Custom HTML Data

https://github.com/microsoft/vscode-custom-data
https://github.com/microsoft/vscode-custom-data/tree/main/samples/webcomponents
https://code.visualstudio.com/api/extension-guides/custom-data-extension

## Usage
The JSON file would need to be shipped as part of a NPM package then people would need to update their VSCode workspace settings file at `.vscode/settings.json`

## Problems
This will only work in .html files and NOT inside other Lit based WebComponents in the html tagged literal.
I have raised an issue on the popular VSCode plugin `lit-plugin` to see if this would work.

https://github.com/runem/lit-analyzer/issues/300

