### PR TITLE
Keep other setInitStatus in app.ts

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -63,7 +63,6 @@ export class UmbAppElement extends UmbLitElement {
 		super();
 		this.#umbIconRegistry.attach(this);
 		this.#uuiIconRegistry.attach(this);
-		this.#setInitStatus();
 	}
 
 	connectedCallback() {
@@ -76,6 +75,7 @@ export class UmbAppElement extends UmbLitElement {
 		OpenAPI.WITH_CREDENTIALS = true;
 
 		this.provideContext('UMBRACOBASE', OpenAPI.BASE);
+		this.#setInitStatus();
 
 		// Listen for the debug event from the <umb-debug> component
 		this.addEventListener(umbDebugContextEventType, (event: any) => {


### PR DESCRIPTION
#647 removed the duplicate `setInitStatus` call in the app element, but we need to keep the one in `connectedCallback` rather than the constructor as we need the OpenAPI configuration to be completed before attempting to fetch the initial status, else we don't have the base URL set.