### PR TITLE
Feature: Data Type Picker

### DIFF
--- a/libs/extensions-registry/models.ts
+++ b/libs/extensions-registry/models.ts
@@ -24,7 +24,7 @@ import type { ManifestWorkspaceView } from './workspace-view.models';
 import type { ManifestWorkspaceViewCollection } from './workspace-view-collection.models';
 import type { ManifestRepository } from './repository.models';
 import type { ManifestModal } from './modal.models';
-import type { ManifestStore, ManifestTreeStore } from './store.models';
+import type { ManifestStore, ManifestTreeStore, ManifestItemStore } from './store.models';
 import type { ClassConstructor } from '@umbraco-cms/backoffice/models';
 
 export * from './collection-view.models';
@@ -89,6 +89,7 @@ export type ManifestTypes =
 	| ManifestModal
 	| ManifestStore
 	| ManifestTreeStore
+	| ManifestItemStore
 	| ManifestBase;
 
 export type ManifestStandardTypes = ManifestTypes['type'];

--- a/libs/extensions-registry/store.models.ts
+++ b/libs/extensions-registry/store.models.ts
@@ -1,5 +1,5 @@
 import type { ManifestClass } from './models';
-import { UmbStoreBase, UmbTreeStore } from '@umbraco-cms/backoffice/store';
+import { UmbItemStore, UmbStoreBase, UmbTreeStore } from '@umbraco-cms/backoffice/store';
 
 export interface ManifestStore extends ManifestClass<UmbStoreBase> {
 	type: 'store';
@@ -7,4 +7,8 @@ export interface ManifestStore extends ManifestClass<UmbStoreBase> {
 
 export interface ManifestTreeStore extends ManifestClass<UmbTreeStore> {
 	type: 'treeStore';
+}
+
+export interface ManifestItemStore extends ManifestClass<UmbItemStore> {
+	type: 'itemStore';
 }

--- a/libs/modal/token/data-type-picker-modal.token.ts
+++ b/libs/modal/token/data-type-picker-modal.token.ts
@@ -2,6 +2,7 @@ import { UmbModalToken } from '@umbraco-cms/backoffice/modal';
 
 export interface UmbDataTypePickerModalData {
 	selection?: Array<string>;
+	multiple?: boolean;
 }
 
 export interface UmbDataTypePickerModalResult {

--- a/libs/modal/token/data-type-picker-modal.token.ts
+++ b/libs/modal/token/data-type-picker-modal.token.ts
@@ -1,0 +1,17 @@
+import { UmbModalToken } from '@umbraco-cms/backoffice/modal';
+
+export interface UmbDataTypePickerModalData {
+	selection?: Array<string>;
+}
+
+export interface UmbDataTypePickerModalResult {
+	selection: Array<string>;
+}
+
+export const UMB_DATA_TYPE_PICKER_MODAL = new UmbModalToken<UmbDataTypePickerModalData, UmbDataTypePickerModalResult>(
+	'Umb.Modal.DataTypePicker',
+	{
+		type: 'sidebar',
+		size: 'small',
+	}
+);

--- a/libs/modal/token/index.ts
+++ b/libs/modal/token/index.ts
@@ -26,3 +26,4 @@ export * from './template-picker-modal.token';
 export * from './user-group-picker-modal.token';
 export * from './user-picker-modal.token';
 export * from './folder-modal.token';
+export * from './data-type-picker-modal.token';

--- a/libs/picker-input/index.ts
+++ b/libs/picker-input/index.ts
@@ -1,0 +1,1 @@
+export * from './picker-input.context';

--- a/libs/picker-input/picker-input.context.ts
+++ b/libs/picker-input/picker-input.context.ts
@@ -12,7 +12,7 @@ import { UmbContextConsumerController } from '@umbraco-cms/backoffice/context-ap
 import { ItemResponseModelBaseModel } from '@umbraco-cms/backoffice/backend-api';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/events';
 
-export class UmbPickerContext<ItemType extends ItemResponseModelBaseModel> {
+export class UmbPickerInputContext<ItemType extends ItemResponseModelBaseModel> {
 	host: UmbControllerHostElement;
 	modalAlias: string | UmbModalToken;
 	repository?: UmbItemRepository<ItemType>;

--- a/libs/picker/index.ts
+++ b/libs/picker/index.ts
@@ -1,1 +1,0 @@
-export * from './picker.context';

--- a/libs/picker/index.ts
+++ b/libs/picker/index.ts
@@ -1,0 +1,1 @@
+export * from './picker.context';

--- a/libs/picker/picker.context.ts
+++ b/libs/picker/picker.context.ts
@@ -1,0 +1,94 @@
+import { UmbTreeRepository } from '../repository';
+import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller';
+import { ArrayState, UmbObserverController } from '@umbraco-cms/backoffice/observable-api';
+import { createExtensionClass, umbExtensionsRegistry } from '@umbraco-cms/backoffice/extensions-api';
+import {
+	UMB_CONFIRM_MODAL,
+	UMB_MODAL_CONTEXT_TOKEN,
+	UmbModalContext,
+	UmbModalToken,
+} from '@umbraco-cms/backoffice/modal';
+import { UmbContextConsumerController } from '@umbraco-cms/backoffice/context-api';
+
+export class UmbPickerContext<RepositoryType extends UmbTreeRepository> {
+	host: UmbControllerHostElement;
+	modalAlias: UmbModalToken | string;
+	repository?: RepositoryType;
+
+	public modalContext?: UmbModalContext;
+
+	#selection = new ArrayState<string>([]);
+	selection = this.#selection.asObservable();
+
+	#items = new ArrayState<any>([]);
+	items = this.#items.asObservable();
+
+	max = Infinity;
+	min = 0;
+
+	constructor(host: UmbControllerHostElement, repositoryAlias: string, modalAlias: UmbModalToken | string) {
+		this.host = host;
+		this.modalAlias = modalAlias;
+
+		// TODO: unsure a method can't be called before everything is initialized
+		new UmbObserverController(
+			this.host,
+
+			// TODO: this code is reused in multiple places, so it should be extracted to a function
+			umbExtensionsRegistry.getByTypeAndAlias('repository', repositoryAlias),
+			async (repositoryManifest) => {
+				if (!repositoryManifest) return;
+
+				try {
+					const result = await createExtensionClass<RepositoryType>(repositoryManifest, [this.host]);
+					this.repository = result;
+				} catch (error) {
+					throw new Error('Could not create repository with alias: ' + repositoryAlias + '');
+				}
+			}
+		);
+
+		new UmbContextConsumerController(this.host, UMB_MODAL_CONTEXT_TOKEN, (instance) => {
+			this.modalContext = instance;
+		});
+	}
+
+	getSelection() {
+		return this.#selection.value;
+	}
+
+	setSelection(selection: string[]) {
+		this.#selection.next(selection);
+	}
+
+	openPicker() {
+		if (!this.modalContext) throw new Error('Modal context is not initialized');
+
+		const modalHandler = this.modalContext.open(this.modalAlias, {
+			multiple: this.max === 1 ? false : true,
+			selection: [...this.getSelection()],
+		});
+
+		modalHandler?.onSubmit().then(({ selection }: any) => {
+			this.setSelection(selection);
+		});
+	}
+
+	async removeItem(unique: string) {
+		if (!this.repository) throw new Error('Repository is not initialized');
+
+		const { data } = await this.repository.requestTreeItems([unique]);
+		if (!data) throw new Error('Could not find item with unique id: ' + unique);
+
+		const modalHandler = this.modalContext?.open(UMB_CONFIRM_MODAL, {
+			color: 'danger',
+			headline: `Remove ${data[0].name}?`,
+			content: 'Are you sure you want to remove this item',
+			confirmLabel: 'Remove',
+		});
+
+		await modalHandler?.onSubmit();
+		const newSelection = this.getSelection().filter((value) => value !== unique);
+		this.setSelection(newSelection);
+	}
+}

--- a/libs/picker/picker.context.ts
+++ b/libs/picker/picker.context.ts
@@ -83,12 +83,13 @@ export class UmbPickerContext<ItemType extends ItemResponseModelBaseModel> {
 	async requestRemoveItem(unique: string) {
 		if (!this.repository) throw new Error('Repository is not initialized');
 
-		const { data } = await this.repository.requestTreeItems([unique]);
-		if (!data) throw new Error('Could not find item with unique id: ' + unique);
+		// TODO: id won't always be available on the model, so we need to get the unique property from somewhere. Maybe the repository?
+		const item = this.#selectedItems.value.find((item) => item.id === unique);
+		if (!item) throw new Error('Could not find item with unique: ' + unique);
 
 		const modalHandler = this.modalContext?.open(UMB_CONFIRM_MODAL, {
 			color: 'danger',
-			headline: `Remove ${data[0].name}?`,
+			headline: `Remove ${item.name}?`,
 			content: 'Are you sure you want to remove this item',
 			confirmLabel: 'Remove',
 		});

--- a/libs/picker/picker.context.ts
+++ b/libs/picker/picker.context.ts
@@ -75,6 +75,7 @@ export class UmbPickerContext<ItemType extends ItemResponseModelBaseModel> {
 	}
 
 	// TODO: revisit this method. How do we best pass picker data?
+	// If modalAlias is a ModalToken, then via TS, we should get the correct type for pickerData. Otherwise fallback to unknown.
 	openPicker(pickerData?: any) {
 		if (!this.modalContext) throw new Error('Modal context is not initialized');
 

--- a/libs/picker/picker.context.ts
+++ b/libs/picker/picker.context.ts
@@ -75,7 +75,7 @@ export class UmbPickerContext<ItemType extends ItemResponseModelBaseModel> {
 	}
 
 	// TODO: revisit this method. How do we best pass picker data?
-	openPicker(pickerData: any) {
+	openPicker(pickerData?: any) {
 		if (!this.modalContext) throw new Error('Modal context is not initialized');
 
 		const modalHandler = this.modalContext.open(this.modalAlias, {

--- a/libs/picker/picker.context.ts
+++ b/libs/picker/picker.context.ts
@@ -1,4 +1,4 @@
-import { UmbTreeRepository } from '../repository';
+import { UmbItemRepository, UmbTreeRepository } from '@umbraco-cms/backoffice/repository';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller';
 import { ArrayState, UmbObserverController } from '@umbraco-cms/backoffice/observable-api';
 import { createExtensionClass, umbExtensionsRegistry } from '@umbraco-cms/backoffice/extensions-api';
@@ -15,7 +15,7 @@ import { UmbChangeEvent } from '@umbraco-cms/backoffice/events';
 export class UmbPickerContext<ItemType extends ItemResponseModelBaseModel> {
 	host: UmbControllerHostElement;
 	modalAlias: UmbModalToken | string;
-	repository?: UmbTreeRepository<ItemType>;
+	repository?: UmbItemRepository<ItemType>;
 	#getUnique: (entry: ItemType) => string | undefined;
 
 	public modalContext?: UmbModalContext;
@@ -53,7 +53,7 @@ export class UmbPickerContext<ItemType extends ItemResponseModelBaseModel> {
 				if (!repositoryManifest) return;
 
 				try {
-					const result = await createExtensionClass<UmbTreeRepository>(repositoryManifest, [this.host]);
+					const result = await createExtensionClass<UmbItemRepository<ItemType>>(repositoryManifest, [this.host]);
 					this.repository = result;
 				} catch (error) {
 					throw new Error('Could not create repository with alias: ' + repositoryAlias + '');
@@ -113,7 +113,7 @@ export class UmbPickerContext<ItemType extends ItemResponseModelBaseModel> {
 		if (!this.repository) throw new Error('Repository is not initialized');
 		if (this.#selectedItemsObserver) this.#selectedItemsObserver.destroy();
 
-		const { asObservable } = await this.repository.requestTreeItems(this.getSelection());
+		const { asObservable } = await this.repository.requestItems(this.getSelection());
 
 		if (asObservable) {
 			this.#selectedItemsObserver = new UmbObserverController(this.host, asObservable(), (data) => {

--- a/libs/picker/picker.context.ts
+++ b/libs/picker/picker.context.ts
@@ -1,6 +1,6 @@
 import { UmbItemRepository } from '@umbraco-cms/backoffice/repository';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller';
-import { ArrayState, UmbObserverController } from '@umbraco-cms/backoffice/observable-api';
+import { UmbArrayState, UmbObserverController } from '@umbraco-cms/backoffice/observable-api';
 import { createExtensionClass, umbExtensionsRegistry } from '@umbraco-cms/backoffice/extensions-api';
 import {
 	UMB_CONFIRM_MODAL,
@@ -20,10 +20,10 @@ export class UmbPickerContext<ItemType extends ItemResponseModelBaseModel> {
 
 	public modalContext?: UmbModalContext;
 
-	#selection = new ArrayState<string>([]);
+	#selection = new UmbArrayState<string>([]);
 	selection = this.#selection.asObservable();
 
-	#selectedItems = new ArrayState<ItemType>([]);
+	#selectedItems = new UmbArrayState<ItemType>([]);
 	selectedItems = this.#selectedItems.asObservable();
 
 	#selectedItemsObserver?: UmbObserverController<ItemType[]>;

--- a/libs/picker/picker.context.ts
+++ b/libs/picker/picker.context.ts
@@ -116,9 +116,9 @@ export class UmbPickerContext<ItemType extends ItemResponseModelBaseModel> {
 		const { asObservable } = await this.repository.requestItems(this.getSelection());
 
 		if (asObservable) {
-			this.#selectedItemsObserver = new UmbObserverController(this.host, asObservable(), (data) => {
-				this.#selectedItems.next(data);
-			});
+			this.#selectedItemsObserver = new UmbObserverController(this.host, asObservable(), (data) =>
+				this.#selectedItems.next(data)
+			);
 		}
 	}
 

--- a/libs/picker/picker.context.ts
+++ b/libs/picker/picker.context.ts
@@ -1,4 +1,4 @@
-import { UmbItemRepository, UmbTreeRepository } from '@umbraco-cms/backoffice/repository';
+import { UmbItemRepository } from '@umbraco-cms/backoffice/repository';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller';
 import { ArrayState, UmbObserverController } from '@umbraco-cms/backoffice/observable-api';
 import { createExtensionClass, umbExtensionsRegistry } from '@umbraco-cms/backoffice/extensions-api';
@@ -14,7 +14,7 @@ import { UmbChangeEvent } from '@umbraco-cms/backoffice/events';
 
 export class UmbPickerContext<ItemType extends ItemResponseModelBaseModel> {
 	host: UmbControllerHostElement;
-	modalAlias: UmbModalToken | string;
+	modalAlias: string | UmbModalToken;
 	repository?: UmbItemRepository<ItemType>;
 	#getUnique: (entry: ItemType) => string | undefined;
 
@@ -36,7 +36,7 @@ export class UmbPickerContext<ItemType extends ItemResponseModelBaseModel> {
 	constructor(
 		host: UmbControllerHostElement,
 		repositoryAlias: string,
-		modalAlias: UmbModalToken | string,
+		modalAlias: string | UmbModalToken,
 		getUniqueMethod?: (entry: ItemType) => string | undefined
 	) {
 		this.host = host;
@@ -74,13 +74,14 @@ export class UmbPickerContext<ItemType extends ItemResponseModelBaseModel> {
 		this.#selection.next(selection);
 	}
 
-	// TODO: this need to accept an options object at some point to pass to the modal context
-	openPicker() {
+	// TODO: revisit this method. How do we best pass picker data?
+	openPicker(pickerData: any) {
 		if (!this.modalContext) throw new Error('Modal context is not initialized');
 
 		const modalHandler = this.modalContext.open(this.modalAlias, {
 			multiple: this.max === 1 ? false : true,
 			selection: [...this.getSelection()],
+			...pickerData,
 		});
 
 		modalHandler?.onSubmit().then(({ selection }: any) => {

--- a/libs/repository/data-source/index.ts
+++ b/libs/repository/data-source/index.ts
@@ -2,3 +2,4 @@ export * from './data-source-response.interface';
 export * from './data-source.interface';
 export * from './folder-data-source.interface';
 export * from './tree-data-source.interface';
+export * from './item-data-source.interface';

--- a/libs/repository/data-source/item-data-source.interface.ts
+++ b/libs/repository/data-source/item-data-source.interface.ts
@@ -1,0 +1,5 @@
+import type { DataSourceResponse } from '@umbraco-cms/backoffice/repository';
+
+export interface UmbItemDataSource<ItemType> {
+	getItems(unique: Array<string>): Promise<DataSourceResponse<Array<ItemType>>>;
+}

--- a/libs/repository/data-source/tree-data-source.interface.ts
+++ b/libs/repository/data-source/tree-data-source.interface.ts
@@ -3,5 +3,7 @@ import type { DataSourceResponse } from '@umbraco-cms/backoffice/repository';
 export interface UmbTreeDataSource<PagedItemsType = any, ItemsType = any> {
 	getRootItems(): Promise<DataSourceResponse<PagedItemsType>>;
 	getChildrenOf(parentUnique: string): Promise<DataSourceResponse<PagedItemsType>>;
+
+	// TODO: remove this when all repositories are migrated to the new items interface
 	getItems(unique: Array<string>): Promise<DataSourceResponse<Array<ItemsType>>>;
 }

--- a/libs/repository/index.ts
+++ b/libs/repository/index.ts
@@ -2,3 +2,4 @@ export * from './data-source';
 export * from './detail-repository.interface';
 export * from './tree-repository.interface';
 export * from './folder-repository.interface';
+export * from './item-repository.interface';

--- a/libs/repository/item-repository.interface.ts
+++ b/libs/repository/item-repository.interface.ts
@@ -1,7 +1,7 @@
 import type { Observable } from 'rxjs';
-import { ProblemDetailsModel } from '@umbraco-cms/backoffice/backend-api';
+import { ItemResponseModelBaseModel, ProblemDetailsModel } from '@umbraco-cms/backoffice/backend-api';
 
-export interface UmbItemRepository<ItemType> {
+export interface UmbItemRepository<ItemType extends ItemResponseModelBaseModel> {
 	requestItems: (uniques: string[]) => Promise<{
 		data: Array<ItemType> | undefined;
 		error: ProblemDetailsModel | undefined;

--- a/libs/repository/item-repository.interface.ts
+++ b/libs/repository/item-repository.interface.ts
@@ -1,0 +1,11 @@
+import type { Observable } from 'rxjs';
+import { ProblemDetailsModel } from '@umbraco-cms/backoffice/backend-api';
+
+export interface UmbItemRepository<ItemType> {
+	requestItems: (uniques: string[]) => Promise<{
+		data: Array<ItemType> | undefined;
+		error: ProblemDetailsModel | undefined;
+		asObservable?: () => Observable<Array<ItemType>>;
+	}>;
+	items: (uniques: string[]) => Promise<Observable<Array<ItemType>>>;
+}

--- a/libs/repository/item-repository.interface.ts
+++ b/libs/repository/item-repository.interface.ts
@@ -3,8 +3,8 @@ import { ItemResponseModelBaseModel, ProblemDetailsModel } from '@umbraco-cms/ba
 
 export interface UmbItemRepository<ItemType extends ItemResponseModelBaseModel> {
 	requestItems: (uniques: string[]) => Promise<{
-		data: Array<ItemType> | undefined;
-		error: ProblemDetailsModel | undefined;
+		data?: Array<ItemType> | undefined;
+		error?: ProblemDetailsModel | undefined;
 		asObservable?: () => Observable<Array<ItemType>>;
 	}>;
 	items: (uniques: string[]) => Promise<Observable<Array<ItemType>>>;

--- a/libs/repository/tree-repository.interface.ts
+++ b/libs/repository/tree-repository.interface.ts
@@ -19,7 +19,7 @@ export interface UmbTreeRepository<ItemType = any, PagedItemType = UmbPagedData<
 	}>;
 
 	// TODO: remove this when all repositories are migrated to the new interface items interface
-	requestTreeItems?: (uniques: string[]) => Promise<{
+	requestItemsLegacy?: (uniques: string[]) => Promise<{
 		data: Array<ItemType> | undefined;
 		error: ProblemDetailsModel | undefined;
 		asObservable?: () => Observable<ItemType[]>;
@@ -29,5 +29,5 @@ export interface UmbTreeRepository<ItemType = any, PagedItemType = UmbPagedData<
 	treeItemsOf: (parentUnique: string | null) => Promise<Observable<ItemType[]>>;
 
 	// TODO: remove this when all repositories are migrated to the new items interface
-	treeItems?: (uniques: string[]) => Promise<Observable<ItemType[]>>;
+	itemsLegacy?: (uniques: string[]) => Promise<Observable<ItemType[]>>;
 }

--- a/libs/repository/tree-repository.interface.ts
+++ b/libs/repository/tree-repository.interface.ts
@@ -17,7 +17,9 @@ export interface UmbTreeRepository<ItemType = any, PagedItemType = UmbPagedData<
 		error: ProblemDetailsModel | undefined;
 		asObservable?: () => Observable<ItemType[]>;
 	}>;
-	requestTreeItems: (uniques: string[]) => Promise<{
+
+	// TODO: remove this when all repositories are migrated to the new interface items interface
+	requestTreeItems?: (uniques: string[]) => Promise<{
 		data: Array<ItemType> | undefined;
 		error: ProblemDetailsModel | undefined;
 		asObservable?: () => Observable<ItemType[]>;
@@ -25,5 +27,7 @@ export interface UmbTreeRepository<ItemType = any, PagedItemType = UmbPagedData<
 
 	rootTreeItems: () => Promise<Observable<ItemType[]>>;
 	treeItemsOf: (parentUnique: string | null) => Promise<Observable<ItemType[]>>;
-	treeItems: (uniques: string[]) => Promise<Observable<ItemType[]>>;
+
+	// TODO: remove this when all repositories are migrated to the new items interface
+	treeItems?: (uniques: string[]) => Promise<Observable<ItemType[]>>;
 }

--- a/libs/store/entity-tree-store.ts
+++ b/libs/store/entity-tree-store.ts
@@ -1,49 +1,27 @@
 import { EntityTreeItemResponseModel } from '@umbraco-cms/backoffice/backend-api';
-import { ArrayState, partialUpdateFrozenArray } from '@umbraco-cms/backoffice/observable-api';
+import { ArrayState } from '@umbraco-cms/backoffice/observable-api';
 import { UmbStoreBase, UmbTreeStore } from '@umbraco-cms/backoffice/store';
+import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller';
 
 /**
  * @export
  * @class UmbEntityTreeStore
  * @extends {UmbStoreBase}
- * @description - General Tree Data Store
+ * @description - Entity Tree Store
  */
-export class UmbEntityTreeStore extends UmbStoreBase implements UmbTreeStore<EntityTreeItemResponseModel> {
-	#data = new ArrayState<EntityTreeItemResponseModel>([], (x) => x.id);
-
-	/**
-	 * Appends items to the store
-	 * @param {Array<EntityTreeItemResponseModel>} items
-	 * @memberof UmbEntityTreeStore
-	 */
-	appendItems(items: Array<EntityTreeItemResponseModel>) {
-		this.#data.append(items);
-	}
-
-	/**
-	 * Updates an item in the store
-	 * @param {string} id
-	 * @param {Partial<EntityTreeItemResponseModel>} data
-	 * @memberof UmbEntityTreeStore
-	 */
-	updateItem(id: string, data: Partial<EntityTreeItemResponseModel>) {
-		this.#data.next(partialUpdateFrozenArray(this.#data.getValue(), data, (entry) => entry.id === id));
-	}
-
-	/**
-	 * Removes an item from the store
-	 * @param {string} id
-	 * @memberof UmbEntityTreeStore
-	 */
-	removeItem(id: string) {
-		this.#data.removeOne(id);
+export class UmbEntityTreeStore
+	extends UmbStoreBase<EntityTreeItemResponseModel>
+	implements UmbTreeStore<EntityTreeItemResponseModel>
+{
+	constructor(host: UmbControllerHostElement, storeAlias: string) {
+		super(host, storeAlias, new ArrayState<EntityTreeItemResponseModel>([], (x) => x.id));
 	}
 
 	/**
 	 * An observable to observe the root items
 	 * @memberof UmbEntityTreeStore
 	 */
-	rootItems = this.#data.getObservablePart((items) => items.filter((item) => item.parentId === null));
+	rootItems = this._data.getObservablePart((items) => items.filter((item) => item.parentId === null));
 
 	/**
 	 * Returns an observable to observe the children of a given parent
@@ -52,7 +30,7 @@ export class UmbEntityTreeStore extends UmbStoreBase implements UmbTreeStore<Ent
 	 * @memberof UmbEntityTreeStore
 	 */
 	childrenOf(parentId: string | null) {
-		return this.#data.getObservablePart((items) => items.filter((item) => item.parentId === parentId));
+		return this._data.getObservablePart((items) => items.filter((item) => item.parentId === parentId));
 	}
 
 	/**
@@ -62,6 +40,6 @@ export class UmbEntityTreeStore extends UmbStoreBase implements UmbTreeStore<Ent
 	 * @memberof UmbEntityTreeStore
 	 */
 	items(ids: Array<string>) {
-		return this.#data.getObservablePart((items) => items.filter((item) => ids.includes(item.id ?? '')));
+		return this._data.getObservablePart((items) => items.filter((item) => ids.includes(item.id ?? '')));
 	}
 }

--- a/libs/store/file-system-tree.store.ts
+++ b/libs/store/file-system-tree.store.ts
@@ -1,49 +1,27 @@
 import { FileSystemTreeItemPresentationModel } from '@umbraco-cms/backoffice/backend-api';
-import { ArrayState, partialUpdateFrozenArray } from '@umbraco-cms/backoffice/observable-api';
+import { ArrayState } from '@umbraco-cms/backoffice/observable-api';
 import { UmbStoreBase, UmbTreeStore } from '@umbraco-cms/backoffice/store';
+import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller';
 
 /**
  * @export
  * @class UmbFileSystemTreeStore
  * @extends {UmbStoreBase}
- * @description - General Tree Data Store
+ * @description - File System Tree Store
  */
-export class UmbFileSystemTreeStore extends UmbStoreBase implements UmbTreeStore<FileSystemTreeItemPresentationModel> {
-	#data = new ArrayState<FileSystemTreeItemPresentationModel>([], (x) => x.path);
-
-	/**
-	 * Appends items to the store
-	 * @param {Array<FileSystemTreeItemPresentationModel>} items
-	 * @memberof UmbFileSystemTreeStore
-	 */
-	appendItems(items: Array<FileSystemTreeItemPresentationModel>) {
-		this.#data.append(items);
-	}
-
-	/**
-	 * Updates an item in the store
-	 * @param {string} path
-	 * @param {Partial<FileSystemTreeItemPresentationModel>} data
-	 * @memberof UmbFileSystemTreeStore
-	 */
-	updateItem(path: string, data: Partial<FileSystemTreeItemPresentationModel>) {
-		this.#data.appendOne(data);
-	}
-
-	/**
-	 * Removes an item from the store
-	 * @param {string} path
-	 * @memberof UmbFileSystemTreeStore
-	 */
-	removeItem(path: string) {
-		this.#data.removeOne(path);
+export class UmbFileSystemTreeStore
+	extends UmbStoreBase<FileSystemTreeItemPresentationModel>
+	implements UmbTreeStore<FileSystemTreeItemPresentationModel>
+{
+	constructor(host: UmbControllerHostElement, storeAlias: string) {
+		super(host, storeAlias, new ArrayState<FileSystemTreeItemPresentationModel>([], (x) => x.path));
 	}
 
 	/**
 	 * An observable to observe the root items
 	 * @memberof UmbFileSystemTreeStore
 	 */
-	rootItems = this.#data.getObservablePart((items) => items.filter((item) => item.path?.includes('/') === false));
+	rootItems = this._data.getObservablePart((items) => items.filter((item) => item.path?.includes('/') === false));
 
 	/**
 	 * Returns an observable to observe the children of a given parent
@@ -52,7 +30,7 @@ export class UmbFileSystemTreeStore extends UmbStoreBase implements UmbTreeStore
 	 * @memberof UmbFileSystemTreeStore
 	 */
 	childrenOf(parentPath: string | null) {
-		return this.#data.getObservablePart((items) => items.filter((item) => item.path?.startsWith(parentPath + '/')));
+		return this._data.getObservablePart((items) => items.filter((item) => item.path?.startsWith(parentPath + '/')));
 	}
 
 	/**
@@ -62,6 +40,6 @@ export class UmbFileSystemTreeStore extends UmbStoreBase implements UmbTreeStore
 	 * @memberof UmbFileSystemTreeStore
 	 */
 	items(paths: Array<string>) {
-		return this.#data.getObservablePart((items) => items.filter((item) => paths.includes(item.path ?? '')));
+		return this._data.getObservablePart((items) => items.filter((item) => paths.includes(item.path ?? '')));
 	}
 }

--- a/libs/store/index.ts
+++ b/libs/store/index.ts
@@ -3,3 +3,4 @@ export * from './store-base';
 export * from './entity-tree-store';
 export * from './file-system-tree.store';
 export * from './tree-store.interface';
+export * from './item-store.interface';

--- a/libs/store/item-store.interface.ts
+++ b/libs/store/item-store.interface.ts
@@ -1,0 +1,7 @@
+import type { Observable } from 'rxjs';
+import { ItemResponseModelBaseModel } from '../backend-api';
+import { UmbStore } from './store.interface';
+
+export interface UmbItemStore<T extends ItemResponseModelBaseModel> extends UmbStore<T> {
+	items: (uniques: Array<string>) => Observable<Array<T>>;
+}

--- a/libs/store/item-store.interface.ts
+++ b/libs/store/item-store.interface.ts
@@ -2,6 +2,6 @@ import type { Observable } from 'rxjs';
 import { ItemResponseModelBaseModel } from '../backend-api';
 import { UmbStore } from './store.interface';
 
-export interface UmbItemStore<T extends ItemResponseModelBaseModel> extends UmbStore<T> {
+export interface UmbItemStore<T extends ItemResponseModelBaseModel = any> extends UmbStore<T> {
 	items: (uniques: Array<string>) => Observable<Array<T>>;
 }

--- a/libs/store/store-base.ts
+++ b/libs/store/store-base.ts
@@ -1,9 +1,48 @@
+import { UmbStore } from './store.interface';
 import { UmbContextProviderController } from '@umbraco-cms/backoffice/context-api';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller';
+import { ArrayState, partialUpdateFrozenArray } from '@umbraco-cms/backoffice/observable-api';
 
 // TODO: Make a Store interface?
-export class UmbStoreBase {
-	constructor(protected _host: UmbControllerHostElement, public readonly storeAlias: string) {
+export class UmbStoreBase<StoreItemType> implements UmbStore<StoreItemType> {
+	protected _host: UmbControllerHostElement;
+	protected _data: ArrayState<StoreItemType>;
+
+	public readonly storeAlias: string;
+
+	constructor(_host: UmbControllerHostElement, storeAlias: string, data: ArrayState<StoreItemType>) {
+		this._host = _host;
+		this.storeAlias = storeAlias;
+		this._data = data;
+
 		new UmbContextProviderController(_host, storeAlias, this);
+	}
+
+	/**
+	 * Appends items to the store
+	 * @param {Array<StoreItemType>} items
+	 * @memberof UmbEntityTreeStore
+	 */
+	appendItems(items: Array<StoreItemType>) {
+		this._data.append(items);
+	}
+
+	/**
+	 * Updates an item in the store
+	 * @param {string} id
+	 * @param {Partial<StoreItemType>} data
+	 * @memberof UmbEntityTreeStore
+	 */
+	updateItem(id: string, data: Partial<StoreItemType>) {
+		this._data.next(partialUpdateFrozenArray(this._data.getValue(), data, (entry) => entry.id === id));
+	}
+
+	/**
+	 * Removes an item from the store
+	 * @param {string} id
+	 * @memberof UmbEntityTreeStore
+	 */
+	removeItem(id: string) {
+		this._data.removeOne(id);
 	}
 }

--- a/libs/store/store-base.ts
+++ b/libs/store/store-base.ts
@@ -4,7 +4,7 @@ import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller';
 import { ArrayState, partialUpdateFrozenArray } from '@umbraco-cms/backoffice/observable-api';
 
 // TODO: Make a Store interface?
-export class UmbStoreBase<StoreItemType> implements UmbStore<StoreItemType> {
+export class UmbStoreBase<StoreItemType = any> implements UmbStore<StoreItemType> {
 	protected _host: UmbControllerHostElement;
 	protected _data: ArrayState<StoreItemType>;
 

--- a/libs/store/store-base.ts
+++ b/libs/store/store-base.ts
@@ -1,7 +1,7 @@
 import { UmbStore } from './store.interface';
 import { UmbContextProviderController } from '@umbraco-cms/backoffice/context-api';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller';
-import { ArrayState, partialUpdateFrozenArray } from '@umbraco-cms/backoffice/observable-api';
+import { ArrayState } from '@umbraco-cms/backoffice/observable-api';
 
 // TODO: Make a Store interface?
 export class UmbStoreBase<StoreItemType = any> implements UmbStore<StoreItemType> {
@@ -33,8 +33,8 @@ export class UmbStoreBase<StoreItemType = any> implements UmbStore<StoreItemType
 	 * @param {Partial<StoreItemType>} data
 	 * @memberof UmbEntityTreeStore
 	 */
-	updateItem(id: string, data: Partial<StoreItemType>) {
-		this._data.next(partialUpdateFrozenArray(this._data.getValue(), data, (entry) => entry.id === id));
+	updateItem(unique: string, data: Partial<StoreItemType>) {
+		this._data.updateOne(unique, data);
 	}
 
 	/**
@@ -42,7 +42,7 @@ export class UmbStoreBase<StoreItemType = any> implements UmbStore<StoreItemType
 	 * @param {string} id
 	 * @memberof UmbEntityTreeStore
 	 */
-	removeItem(id: string) {
-		this._data.removeOne(id);
+	removeItem(unique: string) {
+		this._data.removeOne(unique);
 	}
 }

--- a/libs/store/store-base.ts
+++ b/libs/store/store-base.ts
@@ -1,16 +1,16 @@
 import { UmbStore } from './store.interface';
 import { UmbContextProviderController } from '@umbraco-cms/backoffice/context-api';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller';
-import { ArrayState } from '@umbraco-cms/backoffice/observable-api';
+import { UmbArrayState } from '@umbraco-cms/backoffice/observable-api';
 
 // TODO: Make a Store interface?
 export class UmbStoreBase<StoreItemType = any> implements UmbStore<StoreItemType> {
 	protected _host: UmbControllerHostElement;
-	protected _data: ArrayState<StoreItemType>;
+	protected _data: UmbArrayState<StoreItemType>;
 
 	public readonly storeAlias: string;
 
-	constructor(_host: UmbControllerHostElement, storeAlias: string, data: ArrayState<StoreItemType>) {
+	constructor(_host: UmbControllerHostElement, storeAlias: string, data: UmbArrayState<StoreItemType>) {
 		this._host = _host;
 		this.storeAlias = storeAlias;
 		this._data = data;

--- a/libs/store/store.interface.ts
+++ b/libs/store/store.interface.ts
@@ -1,0 +1,5 @@
+export interface UmbStore<T> {
+	appendItems: (items: Array<T>) => void;
+	updateItem: (unique: string, item: Partial<T>) => void;
+	removeItem: (unique: string) => void;
+}

--- a/libs/store/store.ts
+++ b/libs/store/store.ts
@@ -1,3 +1,4 @@
+// TODO: delete when the last usages are gone
 import type { Observable } from 'rxjs';
 
 export interface UmbDataStoreIdentifiers {

--- a/libs/store/tree-store.interface.ts
+++ b/libs/store/tree-store.interface.ts
@@ -1,12 +1,10 @@
 import type { Observable } from 'rxjs';
 import { TreeItemPresentationModel } from '../backend-api';
+import { UmbStore } from './store.interface';
 
-export interface UmbTreeStore<T extends TreeItemPresentationModel = any> {
-	appendItems: (items: Array<T>) => void;
-	updateItem: (unique: string, item: Partial<T>) => void;
-	removeItem: (unique: string) => void;
-
+export interface UmbTreeStore<T extends TreeItemPresentationModel = any> extends UmbStore<T> {
 	rootItems: Observable<Array<T>>;
 	childrenOf: (parentUnique: string | null) => Observable<Array<T>>;
+	// TODO: remove this one when all repositories are using an item store
 	items: (uniques: Array<string>) => Observable<Array<T>>;
 }

--- a/src/backoffice/backoffice.element.ts
+++ b/src/backoffice/backoffice.element.ts
@@ -71,6 +71,7 @@ export class UmbBackofficeElement extends UmbLitElement {
 		this.provideContext(UMB_CURRENT_USER_HISTORY_STORE_CONTEXT_TOKEN, new UmbCurrentUserHistoryStore());
 
 		// Register All Stores
+		// TODO: can we use kinds here so we don't have to hardcode the types?
 		this.observe(umbExtensionsRegistry.extensionsOfTypes(['store', 'treeStore', 'itemStore']), (stores) => {
 			stores.forEach((store) => createExtensionClass(store, [this]));
 		});

--- a/src/backoffice/backoffice.element.ts
+++ b/src/backoffice/backoffice.element.ts
@@ -71,7 +71,7 @@ export class UmbBackofficeElement extends UmbLitElement {
 		this.provideContext(UMB_CURRENT_USER_HISTORY_STORE_CONTEXT_TOKEN, new UmbCurrentUserHistoryStore());
 
 		// Register All Stores
-		this.observe(umbExtensionsRegistry.extensionsOfTypes(['store', 'treeStore']), (stores) => {
+		this.observe(umbExtensionsRegistry.extensionsOfTypes(['store', 'treeStore', 'itemStore']), (stores) => {
 			stores.forEach((store) => createExtensionClass(store, [this]));
 		});
 	}

--- a/src/backoffice/documents/document-blueprints/document-blueprint.detail.store.ts
+++ b/src/backoffice/documents/document-blueprints/document-blueprint.detail.store.ts
@@ -11,11 +11,12 @@ import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller';
  * @description - Data Store for Document Blueprints
  */
 export class UmbDocumentBlueprintStore extends UmbStoreBase {
-	// TODO: use the right type:
-	#data = new ArrayState<DocumentBlueprintDetails>([], (x) => x.id);
-
 	constructor(host: UmbControllerHostElement) {
-		super(host, UMB_DOCUMENT_BLUEPRINT_STORE_CONTEXT_TOKEN.toString());
+		super(
+			host,
+			UMB_DOCUMENT_BLUEPRINT_STORE_CONTEXT_TOKEN.toString(),
+			new ArrayState<DocumentBlueprintDetails>([], (x) => x.id)
+		);
 	}
 
 	/**
@@ -29,10 +30,10 @@ export class UmbDocumentBlueprintStore extends UmbStoreBase {
 		fetch(`/umbraco/management/api/v1/document-blueprint/details/${id}`)
 			.then((res) => res.json())
 			.then((data) => {
-				this.#data.append(data);
+				this._data.append(data);
 			});
 
-		return this.#data.getObservablePart((documents) => documents.find((document) => document.id === id));
+		return this._data.getObservablePart((documents) => documents.find((document) => document.id === id));
 	}
 
 	getScaffold(entityType: string, parentId: string | null) {
@@ -68,7 +69,7 @@ export class UmbDocumentBlueprintStore extends UmbStoreBase {
 		})
 			.then((res) => res.json())
 			.then((data: Array<DocumentBlueprintDetails>) => {
-				this.#data.append(data);
+				this._data.append(data);
 			});
 	}
 
@@ -89,7 +90,7 @@ export class UmbDocumentBlueprintStore extends UmbStoreBase {
 			},
 		});
 
-		this.#data.remove(ids);
+		this._data.remove(ids);
 	}
 }
 

--- a/src/backoffice/documents/document-types/repository/document-type.repository.ts
+++ b/src/backoffice/documents/document-types/repository/document-type.repository.ts
@@ -77,7 +77,7 @@ export class UmbDocumentTypeRepository implements UmbTreeRepository<ItemType>, U
 		return { data, error, asObservable: () => this.#treeStore!.childrenOf(parentId) };
 	}
 
-	async requestTreeItems(ids: Array<string>) {
+	async requestItemsLegacy(ids: Array<string>) {
 		await this.#init;
 
 		if (!ids) {
@@ -100,7 +100,7 @@ export class UmbDocumentTypeRepository implements UmbTreeRepository<ItemType>, U
 		return this.#treeStore!.childrenOf(parentId);
 	}
 
-	async treeItems(ids: Array<string>) {
+	async itemsLegacy(ids: Array<string>) {
 		await this.#init;
 		return this.#treeStore!.items(ids);
 	}

--- a/src/backoffice/documents/document-types/repository/document-type.store.ts
+++ b/src/backoffice/documents/document-types/repository/document-type.store.ts
@@ -11,15 +11,17 @@ import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller';
  * @description - Data Store for Document Types
  */
 export class UmbDocumentTypeStore extends UmbStoreBase {
-	#data = new ArrayState<DocumentTypeResponseModel>([], (x) => x.id);
-
 	/**
 	 * Creates an instance of UmbDocumentTypeStore.
 	 * @param {UmbControllerHostElement} host
 	 * @memberof UmbDocumentTypeStore
 	 */
 	constructor(host: UmbControllerHostElement) {
-		super(host, UMB_DOCUMENT_TYPE_STORE_CONTEXT_TOKEN.toString());
+		super(
+			host,
+			UMB_DOCUMENT_TYPE_STORE_CONTEXT_TOKEN.toString(),
+			new ArrayState<DocumentTypeResponseModel>([], (x) => x.id)
+		);
 	}
 
 	/**
@@ -28,7 +30,7 @@ export class UmbDocumentTypeStore extends UmbStoreBase {
 	 * @memberof UmbDocumentTypeStore
 	 */
 	append(document: DocumentTypeResponseModel) {
-		this.#data.append([document]);
+		this._data.append([document]);
 	}
 
 	/**
@@ -37,7 +39,7 @@ export class UmbDocumentTypeStore extends UmbStoreBase {
 	 * @memberof UmbDocumentTypeStore
 	 */
 	byId(id: DocumentTypeResponseModel['id']) {
-		return this.#data.getObservablePart((x) => x.find((y) => y.id === id));
+		return this._data.getObservablePart((x) => x.find((y) => y.id === id));
 	}
 
 	/**
@@ -46,7 +48,7 @@ export class UmbDocumentTypeStore extends UmbStoreBase {
 	 * @memberof UmbDocumentTypeStore
 	 */
 	remove(uniques: Array<DocumentTypeResponseModel['id']>) {
-		this.#data.remove(uniques);
+		this._data.remove(uniques);
 	}
 }
 

--- a/src/backoffice/documents/documents/repository/document.repository.ts
+++ b/src/backoffice/documents/documents/repository/document.repository.ts
@@ -82,7 +82,7 @@ export class UmbDocumentRepository implements UmbTreeRepository<ItemType>, UmbDe
 		return { data, error, asObservable: () => this.#treeStore!.childrenOf(parentId) };
 	}
 
-	async requestTreeItems(ids: Array<string>) {
+	async requestItemsLegacy(ids: Array<string>) {
 		await this.#init;
 
 		if (!ids) {
@@ -105,7 +105,7 @@ export class UmbDocumentRepository implements UmbTreeRepository<ItemType>, UmbDe
 		return this.#treeStore!.childrenOf(parentId);
 	}
 
-	async treeItems(ids: Array<string>) {
+	async itemsLegacy(ids: Array<string>) {
 		await this.#init;
 		return this.#treeStore!.items(ids);
 	}

--- a/src/backoffice/documents/documents/repository/document.store.ts
+++ b/src/backoffice/documents/documents/repository/document.store.ts
@@ -11,15 +11,13 @@ import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller';
  * @description - Data Store for Template Details
  */
 export class UmbDocumentStore extends UmbStoreBase {
-	#data = new ArrayState<DocumentResponseModel>([], (x) => x.id);
-
 	/**
 	 * Creates an instance of UmbDocumentDetailStore.
 	 * @param {UmbControllerHostElement} host
 	 * @memberof UmbDocumentDetailStore
 	 */
 	constructor(host: UmbControllerHostElement) {
-		super(host, UMB_DOCUMENT_STORE_CONTEXT_TOKEN.toString());
+		super(host, UMB_DOCUMENT_STORE_CONTEXT_TOKEN.toString(), new ArrayState<DocumentResponseModel>([], (x) => x.id));
 	}
 
 	/**
@@ -28,7 +26,7 @@ export class UmbDocumentStore extends UmbStoreBase {
 	 * @memberof UmbDocumentDetailStore
 	 */
 	append(document: DocumentResponseModel) {
-		this.#data.append([document]);
+		this._data.append([document]);
 	}
 
 	/**
@@ -37,7 +35,7 @@ export class UmbDocumentStore extends UmbStoreBase {
 	 * @memberof UmbDocumentStore
 	 */
 	byKey(id: DocumentResponseModel['id']) {
-		return this.#data.getObservablePart((x) => x.find((y) => y.id === id));
+		return this._data.getObservablePart((x) => x.find((y) => y.id === id));
 	}
 
 	/**
@@ -46,7 +44,7 @@ export class UmbDocumentStore extends UmbStoreBase {
 	 * @memberof UmbDocumentDetailStore
 	 */
 	remove(uniques: Array<DocumentResponseModel['id']>) {
-		this.#data.remove(uniques);
+		this._data.remove(uniques);
 	}
 }
 

--- a/src/backoffice/media/media-types/repository/media-type.detail.store.ts
+++ b/src/backoffice/media/media-types/repository/media-type.detail.store.ts
@@ -11,18 +11,16 @@ import type { MediaTypeDetails } from '@umbraco-cms/backoffice/models';
  * @description - Details Data Store for Media Types
  */
 export class UmbMediaTypeStore extends UmbStoreBase {
-	#data = new ArrayState<MediaTypeDetails>([], (x) => x.id);
-
 	constructor(host: UmbControllerHostElement) {
-		super(host, UMB_MEDIA_TYPE_STORE_CONTEXT_TOKEN.toString());
+		super(host, UMB_MEDIA_TYPE_STORE_CONTEXT_TOKEN.toString(), new ArrayState<MediaTypeDetails>([], (x) => x.id));
 	}
 
 	append(mediaType: MediaTypeDetails) {
-		this.#data.append([mediaType]);
+		this._data.append([mediaType]);
 	}
 
 	remove(uniques: string[]) {
-		this.#data.remove(uniques);
+		this._data.remove(uniques);
 	}
 }
 

--- a/src/backoffice/media/media-types/repository/media-type.repository.ts
+++ b/src/backoffice/media/media-types/repository/media-type.repository.ts
@@ -73,7 +73,7 @@ export class UmbMediaTypeRepository implements UmbTreeRepository {
 		return { data, error, asObservable: () => this.#treeStore!.childrenOf(parentId) };
 	}
 
-	async requestTreeItems(ids: Array<string>) {
+	async requestItemsLegacy(ids: Array<string>) {
 		await this.#init;
 
 		if (!ids) {
@@ -96,7 +96,7 @@ export class UmbMediaTypeRepository implements UmbTreeRepository {
 		return this.#treeStore!.childrenOf(parentId);
 	}
 
-	async treeItems(ids: Array<string>) {
+	async itemsLegacy(ids: Array<string>) {
 		await this.#init;
 		return this.#treeStore!.items(ids);
 	}

--- a/src/backoffice/media/media/entity-bulk-actions/trash/trash.action.ts
+++ b/src/backoffice/media/media/entity-bulk-actions/trash/trash.action.ts
@@ -21,7 +21,7 @@ export class UmbMediaTrashEntityBulkAction extends UmbEntityBulkActionBase<UmbMe
 		if (!this.#modalContext || !this.repository) return;
 
 		// TODO: should we subscribe in cases like this?
-		const { data } = await this.repository.requestTreeItems(this.selection);
+		const { data } = await this.repository.requestItemsLegacy(this.selection);
 
 		if (data) {
 			// TODO: use correct markup

--- a/src/backoffice/media/media/repository/media.repository.ts
+++ b/src/backoffice/media/media/repository/media.repository.ts
@@ -96,7 +96,7 @@ export class UmbMediaRepository
 		return { data, error, asObservable: () => this.#treeStore!.childrenOf(parentId) };
 	}
 
-	async requestTreeItems(ids: Array<string>) {
+	async requestItemsLegacy(ids: Array<string>) {
 		await this.#init;
 
 		if (!ids) {
@@ -119,7 +119,7 @@ export class UmbMediaRepository
 		return this.#treeStore!.childrenOf(parentId);
 	}
 
-	async treeItems(ids: Array<string>) {
+	async itemsLegacy(ids: Array<string>) {
 		await this.#init;
 		return this.#treeStore!.items(ids);
 	}

--- a/src/backoffice/media/media/repository/media.store.ts
+++ b/src/backoffice/media/media/repository/media.store.ts
@@ -11,15 +11,13 @@ import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller';
  * @description - Data Store for Template Details
  */
 export class UmbMediaStore extends UmbStoreBase {
-	#data = new ArrayState<MediaDetails>([], (x) => x.id);
-
 	/**
 	 * Creates an instance of UmbMediaStore.
 	 * @param {UmbControllerHostElement} host
 	 * @memberof UmbMediaStore
 	 */
 	constructor(host: UmbControllerHostElement) {
-		super(host, UMB_MEDIA_STORE_CONTEXT_TOKEN.toString());
+		super(host, UMB_MEDIA_STORE_CONTEXT_TOKEN.toString(), new ArrayState<MediaDetails>([], (x) => x.id));
 	}
 
 	/**
@@ -28,7 +26,7 @@ export class UmbMediaStore extends UmbStoreBase {
 	 * @memberof UmbMediaStore
 	 */
 	append(media: MediaDetails) {
-		this.#data.append([media]);
+		this._data.append([media]);
 	}
 
 	/**
@@ -37,7 +35,7 @@ export class UmbMediaStore extends UmbStoreBase {
 	 * @memberof UmbMediaStore
 	 */
 	remove(uniques: string[]) {
-		this.#data.remove(uniques);
+		this._data.remove(uniques);
 	}
 }
 

--- a/src/backoffice/members/member-groups/repository/member-group.repository.ts
+++ b/src/backoffice/members/member-groups/repository/member-group.repository.ts
@@ -59,7 +59,7 @@ export class UmbMemberGroupRepository implements UmbTreeRepository, UmbDetailRep
 		return { data: undefined, error };
 	}
 
-	async requestTreeItems(ids: Array<string>) {
+	async requestItemsLegacy(ids: Array<string>) {
 		await this.#init;
 
 		if (!ids) {
@@ -82,7 +82,7 @@ export class UmbMemberGroupRepository implements UmbTreeRepository, UmbDetailRep
 		return this.#treeStore!.childrenOf(parentId);
 	}
 
-	async treeItems(ids: Array<string>) {
+	async itemsLegacy(ids: Array<string>) {
 		await this.#init;
 		return this.#treeStore!.items(ids);
 	}

--- a/src/backoffice/members/member-groups/repository/member-group.store.ts
+++ b/src/backoffice/members/member-groups/repository/member-group.store.ts
@@ -11,18 +11,16 @@ import { UmbStoreBase } from '@umbraco-cms/backoffice/store';
  * @description - Data Store for Member Groups
  */
 export class UmbMemberGroupStore extends UmbStoreBase {
-	#data = new ArrayState<MemberGroupDetails>([], (x) => x.id);
-
 	constructor(host: UmbControllerHostElement) {
-		super(host, UMB_MEMBER_GROUP_STORE_CONTEXT_TOKEN.toString());
+		super(host, UMB_MEMBER_GROUP_STORE_CONTEXT_TOKEN.toString(), new ArrayState<MemberGroupDetails>([], (x) => x.id));
 	}
 
 	append(memberGroup: MemberGroupDetails) {
-		this.#data.append([memberGroup]);
+		this._data.append([memberGroup]);
 	}
 
 	remove(uniques: string[]) {
-		this.#data.remove(uniques);
+		this._data.remove(uniques);
 	}
 }
 

--- a/src/backoffice/members/member-types/repository/member-type.repository.ts
+++ b/src/backoffice/members/member-types/repository/member-type.repository.ts
@@ -77,7 +77,7 @@ export class UmbMemberTypeRepository implements UmbTreeRepository<TreeItemType>,
 		return { data, error, asObservable: () => this.#treeStore!.childrenOf(parentId) };
 	}
 
-	async requestTreeItems(ids: Array<string>) {
+	async requestItemsLegacy(ids: Array<string>) {
 		await this.#init;
 
 		if (!ids) {
@@ -100,7 +100,7 @@ export class UmbMemberTypeRepository implements UmbTreeRepository<TreeItemType>,
 		return this.#treeStore!.childrenOf(parentId);
 	}
 
-	async treeItems(ids: Array<string>) {
+	async itemsLegacy(ids: Array<string>) {
 		await this.#init;
 		return this.#treeStore!.items(ids);
 	}

--- a/src/backoffice/members/member-types/repository/member-type.store.ts
+++ b/src/backoffice/members/member-types/repository/member-type.store.ts
@@ -11,18 +11,16 @@ import type { MemberTypeDetails } from '@umbraco-cms/backoffice/models';
  * @description - Data Store for Member Types
  */
 export class UmbMemberTypeStore extends UmbStoreBase {
-	#data = new ArrayState<MemberTypeDetails>([], (x) => x.id);
-
 	constructor(host: UmbControllerHostElement) {
-		super(host, UMB_MEMBER_TYPE_STORE_CONTEXT_TOKEN.toString());
+		super(host, UMB_MEMBER_TYPE_STORE_CONTEXT_TOKEN.toString(), new ArrayState<MemberTypeDetails>([], (x) => x.id));
 	}
 
 	append(MemberType: MemberTypeDetails) {
-		this.#data.append([MemberType]);
+		this._data.append([MemberType]);
 	}
 
 	remove(uniques: string[]) {
-		this.#data.remove(uniques);
+		this._data.remove(uniques);
 	}
 }
 

--- a/src/backoffice/members/members/member.detail.store.ts
+++ b/src/backoffice/members/members/member.detail.store.ts
@@ -13,11 +13,10 @@ import { UmbEntityDetailStore, UmbStoreBase } from '@umbraco-cms/backoffice/stor
  * @description - Data Store for Members
  */
 export class UmbMemberStore extends UmbStoreBase implements UmbEntityDetailStore<MemberDetails> {
-	#data = new ArrayState<MemberDetails>([], (x) => x.id);
-	public groups = this.#data.asObservable();
+	public groups = this._data.asObservable();
 
 	constructor(private host: UmbControllerHostElement) {
-		super(host, UMB_MEMBER_STORE_CONTEXT_TOKEN.toString());
+		super(host, UMB_MEMBER_STORE_CONTEXT_TOKEN.toString(), new ArrayState<MemberDetails>([], (x) => x.id));
 	}
 
 	getScaffold(entityType: string, parentId: string | null) {
@@ -40,10 +39,10 @@ export class UmbMemberStore extends UmbStoreBase implements UmbEntityDetailStore
 		// temp until Resource is updated
 		const member = umbMemberData.getById(id);
 		if (member) {
-			this.#data.appendOne(member);
+			this._data.appendOne(member);
 		}
 
-		return createObservablePart(this.#data, (members) => members.find((member) => member.id === id) as MemberDetails);
+		return createObservablePart(this._data, (members) => members.find((member) => member.id === id) as MemberDetails);
 	}
 
 	async save(member: Array<MemberDetails>): Promise<void> {

--- a/src/backoffice/members/members/repository/member.repository.ts
+++ b/src/backoffice/members/members/repository/member.repository.ts
@@ -58,7 +58,7 @@ export class UmbMemberRepository implements UmbTreeRepository {
 		return { data: undefined, error };
 	}
 
-	async requestTreeItems(ids: Array<string>) {
+	async requestItemsLegacy(ids: Array<string>) {
 		await this.#init;
 
 		if (!ids) {
@@ -81,7 +81,7 @@ export class UmbMemberRepository implements UmbTreeRepository {
 		return this.#treeStore!.childrenOf(parentId);
 	}
 
-	async treeItems(ids: Array<string>) {
+	async itemsLegacy(ids: Array<string>) {
 		await this.#init;
 		return this.#treeStore!.items(ids);
 	}

--- a/src/backoffice/members/members/repository/member.store.ts
+++ b/src/backoffice/members/members/repository/member.store.ts
@@ -11,18 +11,16 @@ import type { MemberDetails } from '@umbraco-cms/backoffice/models';
  * @description - Data Store for Members
  */
 export class UmbMemberStore extends UmbStoreBase {
-	#data = new ArrayState<MemberDetails>([], (x) => x.id);
-
 	constructor(host: UmbControllerHostElement) {
-		super(host, UMB_MEMBER_STORE_CONTEXT_TOKEN.toString());
+		super(host, UMB_MEMBER_STORE_CONTEXT_TOKEN.toString(), new ArrayState<MemberDetails>([], (x) => x.id));
 	}
 
 	append(member: MemberDetails) {
-		this.#data.append([member]);
+		this._data.append([member]);
 	}
 
 	remove(uniques: string[]) {
-		this.#data.remove(uniques);
+		this._data.remove(uniques);
 	}
 }
 

--- a/src/backoffice/packages/package-builder/workspace/workspace-package-builder.element.ts
+++ b/src/backoffice/packages/package-builder/workspace/workspace-package-builder.element.ts
@@ -259,7 +259,7 @@ export class UmbWorkspacePackageBuilderElement extends UmbLitElement {
 
 	#renderDataTypeSection() {
 		return html`<div slot="editor">
-			<umb-input-checkbox-list></umb-input-checkbox-list>
+			<umb-data-type-input></umb-data-type-input>
 		</div>`;
 	}
 

--- a/src/backoffice/packages/repository/package.store.ts
+++ b/src/backoffice/packages/repository/package.store.ts
@@ -44,7 +44,7 @@ export class UmbPackageStore extends UmbStoreBase {
 	constructor(host: UmbControllerHostElement) {
 		// TODO: revisit this store. Is it ok to have multiple data sets?
 		// temp hack to satisfy the base class
-		super(host, UMB_PACKAGE_STORE_TOKEN.toString(), new ArrayState<UmbPackage>([], (x) => x.name));
+		super(host, UMB_PACKAGE_STORE_TOKEN.toString(), new UmbArrayState<UmbPackage>([], (x) => x.name));
 	}
 
 	/**

--- a/src/backoffice/packages/repository/package.store.ts
+++ b/src/backoffice/packages/repository/package.store.ts
@@ -42,7 +42,9 @@ export class UmbPackageStore extends UmbStoreBase {
 	 * @memberof PackageStore
 	 */
 	constructor(host: UmbControllerHostElement) {
-		super(host, UMB_PACKAGE_STORE_TOKEN.toString());
+		// TODO: revisit this store. Is it ok to have multiple data sets?
+		// temp hack to satisfy the base class
+		super(host, UMB_PACKAGE_STORE_TOKEN.toString(), new ArrayState<UmbPackage>([], (x) => x.name));
 	}
 
 	/**

--- a/src/backoffice/settings/data-types/components/data-type-input/data-type-input.context.ts
+++ b/src/backoffice/settings/data-types/components/data-type-input/data-type-input.context.ts
@@ -1,4 +1,4 @@
-import { UmbPickerInputContext } from 'libs/picker-input';
+import { UmbPickerInputContext } from '@umbraco-cms/backoffice/picker-input';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller';
 import { UMB_DATA_TYPE_PICKER_MODAL } from '@umbraco-cms/backoffice/modal';
 import { DataTypeItemResponseModel } from '@umbraco-cms/backoffice/backend-api';

--- a/src/backoffice/settings/data-types/components/data-type-input/data-type-input.context.ts
+++ b/src/backoffice/settings/data-types/components/data-type-input/data-type-input.context.ts
@@ -1,9 +1,9 @@
-import { UmbPickerContext } from '@umbraco-cms/backoffice/picker';
+import { UmbPickerInputContext } from 'libs/picker-input';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller';
 import { UMB_DATA_TYPE_PICKER_MODAL } from '@umbraco-cms/backoffice/modal';
 import { DataTypeItemResponseModel } from '@umbraco-cms/backoffice/backend-api';
 
-export class UmbDataTypePickerContext extends UmbPickerContext<DataTypeItemResponseModel> {
+export class UmbDataTypePickerContext extends UmbPickerInputContext<DataTypeItemResponseModel> {
 	constructor(host: UmbControllerHostElement) {
 		super(host, 'Umb.Repository.DataType', UMB_DATA_TYPE_PICKER_MODAL);
 	}

--- a/src/backoffice/settings/data-types/components/data-type-input/data-type-input.context.ts
+++ b/src/backoffice/settings/data-types/components/data-type-input/data-type-input.context.ts
@@ -1,9 +1,9 @@
 import { UmbPickerContext } from '@umbraco-cms/backoffice/picker';
-import { UmbDataTypeRepository } from '../../repository/data-type.repository';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller';
 import { UMB_DATA_TYPE_PICKER_MODAL } from '@umbraco-cms/backoffice/modal';
+import { DataTypeItemResponseModel } from '@umbraco-cms/backoffice/backend-api';
 
-export class UmbDataTypePickerContext extends UmbPickerContext<UmbDataTypeRepository> {
+export class UmbDataTypePickerContext extends UmbPickerContext<DataTypeItemResponseModel> {
 	constructor(host: UmbControllerHostElement) {
 		super(host, 'Umb.Repository.DataType', UMB_DATA_TYPE_PICKER_MODAL);
 	}

--- a/src/backoffice/settings/data-types/components/data-type-input/data-type-input.context.ts
+++ b/src/backoffice/settings/data-types/components/data-type-input/data-type-input.context.ts
@@ -1,0 +1,10 @@
+import { UmbPickerContext } from '@umbraco-cms/backoffice/picker';
+import { UmbDataTypeRepository } from '../../repository/data-type.repository';
+import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller';
+import { UMB_DATA_TYPE_PICKER_MODAL } from '@umbraco-cms/backoffice/modal';
+
+export class UmbDataTypePickerContext extends UmbPickerContext<UmbDataTypeRepository> {
+	constructor(host: UmbControllerHostElement) {
+		super(host, 'Umb.Repository.DataType', UMB_DATA_TYPE_PICKER_MODAL);
+	}
+}

--- a/src/backoffice/settings/data-types/components/data-type-input/data-type-input.element.ts
+++ b/src/backoffice/settings/data-types/components/data-type-input/data-type-input.element.ts
@@ -44,11 +44,16 @@ export class UmbDataTypeInputElement extends FormControlMixin(UmbLitElement) {
 	 * @attr
 	 * @default undefined
 	 */
+	private _max: number | undefined;
 	@property({ type: Number })
+	public get max(): number | undefined {
+		return this._max;
+	}
 	public set max(value: number | undefined) {
 		if (value !== undefined) {
 			this.#pickerContext.max = value;
 		}
+		this._max = value;
 	}
 
 	/**

--- a/src/backoffice/settings/data-types/components/data-type-input/data-type-input.element.ts
+++ b/src/backoffice/settings/data-types/components/data-type-input/data-type-input.element.ts
@@ -71,10 +71,8 @@ export class UmbDataTypeInputElement extends FormControlMixin(UmbLitElement) {
 
 	@property()
 	public set value(idsString: string) {
-		super.value = idsString;
-		if (idsString !== this._value) {
-			this.selectedIds = idsString.split(/[ ,]+/);
-		}
+		// Its with full purpose we don't call super.value, as thats being handled by the observation of the context selection.
+		this.selectedIds = idsString.split(/[ ,]+/);
 	}
 
 	@state()

--- a/src/backoffice/settings/data-types/components/data-type-input/data-type-input.element.ts
+++ b/src/backoffice/settings/data-types/components/data-type-input/data-type-input.element.ts
@@ -62,17 +62,16 @@ export class UmbDataTypeInputElement extends FormControlMixin(UmbLitElement) {
 	@property({ type: String, attribute: 'min-message' })
 	maxMessage = 'This field exceeds the allowed amount of items';
 
-	private _selectedIds: Array<string> = [];
 	public get selectedIds(): Array<string> {
-		return this._selectedIds;
+		return this.#pickerContext.getSelection();
 	}
 	public set selectedIds(ids: Array<string>) {
-		this._selectedIds = ids;
-		super.value = ids.join(',');
+		this.#pickerContext.setSelection(ids);
 	}
 
 	@property()
 	public set value(idsString: string) {
+		super.value = idsString;
 		if (idsString !== this._value) {
 			this.selectedIds = idsString.split(/[ ,]+/);
 		}
@@ -89,16 +88,16 @@ export class UmbDataTypeInputElement extends FormControlMixin(UmbLitElement) {
 		this.addValidator(
 			'rangeUnderflow',
 			() => this.minMessage,
-			() => !!this.min && this._selectedIds.length < this.min
+			() => !!this.min && this.#pickerContext.getSelection().length < this.min
 		);
 
 		this.addValidator(
 			'rangeOverflow',
 			() => this.maxMessage,
-			() => !!this.max && this._selectedIds.length > this.max
+			() => !!this.max && this.#pickerContext.getSelection().length > this.max
 		);
 
-		this.observe(this.#pickerContext.selection, (selection) => (this._selectedIds = selection));
+		this.observe(this.#pickerContext.selection, (selection) => (super.value = selection.join(',')));
 		this.observe(this.#pickerContext.selectedItems, (selectedItems) => (this._items = selectedItems));
 	}
 

--- a/src/backoffice/settings/data-types/components/data-type-input/data-type-input.element.ts
+++ b/src/backoffice/settings/data-types/components/data-type-input/data-type-input.element.ts
@@ -8,14 +8,6 @@ import type { DataTypeItemResponseModel } from '@umbraco-cms/backoffice/backend-
 
 @customElement('umb-data-type-input')
 export class UmbDataTypeInputElement extends FormControlMixin(UmbLitElement) {
-	static styles = [
-		UUITextStyles,
-		css`
-			#add-button {
-				width: 100%;
-			}
-		`,
-	];
 	/**
 	 * This is a minimum amount of selected items in this input.
 	 * @type {number}
@@ -126,6 +118,15 @@ export class UmbDataTypeInputElement extends FormControlMixin(UmbLitElement) {
 			</uui-ref-node-data-type>
 		`;
 	}
+
+	static styles = [
+		UUITextStyles,
+		css`
+			#add-button {
+				width: 100%;
+			}
+		`,
+	];
 }
 
 export default UmbDataTypeInputElement;

--- a/src/backoffice/settings/data-types/components/data-type-input/data-type-input.element.ts
+++ b/src/backoffice/settings/data-types/components/data-type-input/data-type-input.element.ts
@@ -20,13 +20,14 @@ export class UmbDataTypeInputElement extends FormControlMixin(UmbLitElement) {
 	 * This is a minimum amount of selected items in this input.
 	 * @type {number}
 	 * @attr
-	 * @default undefined
+	 * @default 0
 	 */
 	@property({ type: Number })
-	public set min(value: number | undefined) {
-		if (value !== undefined) {
-			this.#pickerContext.min = value;
-		}
+	public get min(): number {
+		return this.#pickerContext.min;
+	}
+	public set min(value: number) {
+		this.#pickerContext.min = value;
 	}
 
 	/**
@@ -42,18 +43,14 @@ export class UmbDataTypeInputElement extends FormControlMixin(UmbLitElement) {
 	 * This is a maximum amount of selected items in this input.
 	 * @type {number}
 	 * @attr
-	 * @default undefined
+	 * @default Infinity
 	 */
-	private _max: number | undefined;
 	@property({ type: Number })
-	public get max(): number | undefined {
-		return this._max;
+	public get max(): number {
+		return this.#pickerContext.max;
 	}
-	public set max(value: number | undefined) {
-		if (value !== undefined) {
-			this.#pickerContext.max = value;
-		}
-		this._max = value;
+	public set max(value: number) {
+		this.#pickerContext.max = value;
 	}
 
 	/**
@@ -101,7 +98,7 @@ export class UmbDataTypeInputElement extends FormControlMixin(UmbLitElement) {
 			() => !!this.max && this._selectedIds.length > this.max
 		);
 
-		this.observe(this.#pickerContext.selection, (selection) => (this.selectedIds = selection));
+		this.observe(this.#pickerContext.selection, (selection) => (this._selectedIds = selection));
 		this.observe(this.#pickerContext.selectedItems, (selectedItems) => (this._items = selectedItems));
 	}
 

--- a/src/backoffice/settings/data-types/components/data-type-input/data-type-input.element.ts
+++ b/src/backoffice/settings/data-types/components/data-type-input/data-type-input.element.ts
@@ -5,7 +5,6 @@ import { FormControlMixin } from '@umbraco-ui/uui-base/lib/mixins';
 import { UmbDataTypePickerContext } from './data-type-input.context';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 import type { DataTypeItemResponseModel } from '@umbraco-cms/backoffice/backend-api';
-import { UMB_DATA_TYPE_PICKER_MODAL } from '@umbraco-cms/backoffice/modal';
 
 @customElement('umb-data-type-input')
 export class UmbDataTypeInputElement extends FormControlMixin(UmbLitElement) {
@@ -24,7 +23,11 @@ export class UmbDataTypeInputElement extends FormControlMixin(UmbLitElement) {
 	 * @default undefined
 	 */
 	@property({ type: Number })
-	min?: number;
+	public set min(value: number | undefined) {
+		if (value !== undefined) {
+			this.#pickerContext.min = value;
+		}
+	}
 
 	/**
 	 * Min validation message.
@@ -42,7 +45,11 @@ export class UmbDataTypeInputElement extends FormControlMixin(UmbLitElement) {
 	 * @default undefined
 	 */
 	@property({ type: Number })
-	max?: number;
+	public set max(value: number | undefined) {
+		if (value !== undefined) {
+			this.#pickerContext.max = value;
+		}
+	}
 
 	/**
 	 * Max validation message.
@@ -90,7 +97,7 @@ export class UmbDataTypeInputElement extends FormControlMixin(UmbLitElement) {
 		);
 
 		this.observe(this.#pickerContext.selection, (selection) => (this.selectedIds = selection));
-		//this.observe(this.#pickerContext.items, (items) => (this._items = items));
+		this.observe(this.#pickerContext.selectedItems, (selectedItems) => (this._items = selectedItems));
 	}
 
 	protected getFormElement() {
@@ -110,7 +117,9 @@ export class UmbDataTypeInputElement extends FormControlMixin(UmbLitElement) {
 		return html`
 			<uui-ref-node-data-type name=${item.name}>
 				<uui-action-bar slot="actions">
-					<uui-button @click=${() => this.#pickerContext.removeItem(item.id)} label="Remove Data Type ${item.name}"
+					<uui-button
+						@click=${() => this.#pickerContext.requestRemoveItem(item.id)}
+						label="Remove Data Type ${item.name}"
 						>Remove</uui-button
 					>
 				</uui-action-bar>

--- a/src/backoffice/settings/data-types/components/data-type-input/data-type-input.element.ts
+++ b/src/backoffice/settings/data-types/components/data-type-input/data-type-input.element.ts
@@ -1,0 +1,128 @@
+import { css, html } from 'lit';
+import { UUITextStyles } from '@umbraco-ui/uui-css/lib';
+import { customElement, property, state } from 'lit/decorators.js';
+import { FormControlMixin } from '@umbraco-ui/uui-base/lib/mixins';
+import { UmbDataTypePickerContext } from './data-type-input.context';
+import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
+import type { DataTypeItemResponseModel } from '@umbraco-cms/backoffice/backend-api';
+import { UMB_DATA_TYPE_PICKER_MODAL } from '@umbraco-cms/backoffice/modal';
+
+@customElement('umb-data-type-input')
+export class UmbDataTypeInputElement extends FormControlMixin(UmbLitElement) {
+	static styles = [
+		UUITextStyles,
+		css`
+			#add-button {
+				width: 100%;
+			}
+		`,
+	];
+	/**
+	 * This is a minimum amount of selected items in this input.
+	 * @type {number}
+	 * @attr
+	 * @default undefined
+	 */
+	@property({ type: Number })
+	min?: number;
+
+	/**
+	 * Min validation message.
+	 * @type {boolean}
+	 * @attr
+	 * @default
+	 */
+	@property({ type: String, attribute: 'min-message' })
+	minMessage = 'This field need more items';
+
+	/**
+	 * This is a maximum amount of selected items in this input.
+	 * @type {number}
+	 * @attr
+	 * @default undefined
+	 */
+	@property({ type: Number })
+	max?: number;
+
+	/**
+	 * Max validation message.
+	 * @type {boolean}
+	 * @attr
+	 * @default
+	 */
+	@property({ type: String, attribute: 'min-message' })
+	maxMessage = 'This field exceeds the allowed amount of items';
+
+	private _selectedIds: Array<string> = [];
+	public get selectedIds(): Array<string> {
+		return this._selectedIds;
+	}
+	public set selectedIds(ids: Array<string>) {
+		this._selectedIds = ids;
+		super.value = ids.join(',');
+	}
+
+	@property()
+	public set value(idsString: string) {
+		if (idsString !== this._value) {
+			this.selectedIds = idsString.split(/[ ,]+/);
+		}
+	}
+
+	@state()
+	private _items?: Array<DataTypeItemResponseModel>;
+
+	#pickerContext = new UmbDataTypePickerContext(this);
+
+	constructor() {
+		super();
+
+		this.addValidator(
+			'rangeUnderflow',
+			() => this.minMessage,
+			() => !!this.min && this._selectedIds.length < this.min
+		);
+
+		this.addValidator(
+			'rangeOverflow',
+			() => this.maxMessage,
+			() => !!this.max && this._selectedIds.length > this.max
+		);
+
+		this.observe(this.#pickerContext.selection, (selection) => (this.selectedIds = selection));
+		//this.observe(this.#pickerContext.items, (items) => (this._items = items));
+	}
+
+	protected getFormElement() {
+		return undefined;
+	}
+
+	render() {
+		return html`
+			<uui-ref-list>${this._items?.map((item) => this._renderItem(item))}</uui-ref-list>
+			<uui-button id="add-button" look="placeholder" @click=${() => this.#pickerContext.openPicker()} label="open"
+				>Add</uui-button
+			>
+		`;
+	}
+
+	private _renderItem(item: DataTypeItemResponseModel) {
+		return html`
+			<uui-ref-node-data-type name=${item.name}>
+				<uui-action-bar slot="actions">
+					<uui-button @click=${() => this.#pickerContext.removeItem(item.id)} label="Remove Data Type ${item.name}"
+						>Remove</uui-button
+					>
+				</uui-action-bar>
+			</uui-ref-node-data-type>
+		`;
+	}
+}
+
+export default UmbDataTypeInputElement;
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-data-type-input': UmbDataTypeInputElement;
+	}
+}

--- a/src/backoffice/settings/data-types/components/data-type-input/data-type-input.element.ts
+++ b/src/backoffice/settings/data-types/components/data-type-input/data-type-input.element.ts
@@ -114,11 +114,12 @@ export class UmbDataTypeInputElement extends FormControlMixin(UmbLitElement) {
 	}
 
 	private _renderItem(item: DataTypeItemResponseModel) {
+		if (!item.id) return;
 		return html`
 			<uui-ref-node-data-type name=${item.name}>
 				<uui-action-bar slot="actions">
 					<uui-button
-						@click=${() => this.#pickerContext.requestRemoveItem(item.id)}
+						@click=${() => this.#pickerContext.requestRemoveItem(item.id!)}
 						label="Remove Data Type ${item.name}"
 						>Remove</uui-button
 					>

--- a/src/backoffice/settings/data-types/components/index.ts
+++ b/src/backoffice/settings/data-types/components/index.ts
@@ -1,0 +1,1 @@
+import './data-type-input/data-type-input.element';

--- a/src/backoffice/settings/data-types/index.ts
+++ b/src/backoffice/settings/data-types/index.ts
@@ -1,0 +1,1 @@
+import './components';

--- a/src/backoffice/settings/data-types/manifests.ts
+++ b/src/backoffice/settings/data-types/manifests.ts
@@ -3,6 +3,7 @@ import { manifests as repositoryManifests } from './repository/manifests';
 import { manifests as menuItemManifests } from './menu-item/manifests';
 import { manifests as treeManifests } from './tree/manifests';
 import { manifests as workspaceManifests } from './workspace/manifests';
+import { manifests as modalManifests } from './modal/manifests';
 
 export const manifests = [
 	...entityActions,
@@ -10,4 +11,5 @@ export const manifests = [
 	...menuItemManifests,
 	...treeManifests,
 	...workspaceManifests,
+	...modalManifests,
 ];

--- a/src/backoffice/settings/data-types/modal/data-type-picker/data-type-picker-modal.element.ts
+++ b/src/backoffice/settings/data-types/modal/data-type-picker/data-type-picker-modal.element.ts
@@ -3,8 +3,8 @@ import { UUITextStyles } from '@umbraco-ui/uui-css/lib';
 import { customElement, property, state } from 'lit/decorators.js';
 import type { UmbTreeElement } from '../../../../shared/components/tree/tree.element';
 import {
-	UmbDocumentTypePickerModalData,
-	UmbDocumentTypePickerModalResult,
+	UmbDataTypePickerModalData,
+	UmbDataTypePickerModalResult,
 	UmbModalHandler,
 } from '@umbraco-cms/backoffice/modal';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
@@ -15,55 +15,53 @@ export class UmbDataTypePickerModalElement extends UmbLitElement {
 	static styles = [UUITextStyles, css``];
 
 	@property({ attribute: false })
-	modalHandler?: UmbModalHandler<UmbDocumentTypePickerModalData, UmbDocumentTypePickerModalResult>;
+	modalHandler?: UmbModalHandler<UmbDataTypePickerModalData, UmbDataTypePickerModalResult>;
 
 	@property({ type: Object, attribute: false })
-	data?: UmbDocumentTypePickerModalData;
+	data?: UmbDataTypePickerModalData;
 
 	@state()
 	_selection: Array<string> = [];
 
 	@state()
-	_multiple = true;
+	_multiple = false;
 
 	connectedCallback() {
 		super.connectedCallback();
 		this._selection = this.data?.selection ?? [];
-		this._multiple = this.data?.multiple ?? true;
+		this._multiple = this.data?.multiple ?? false;
 	}
 
-	private _handleSelectionChange(e: CustomEvent) {
+	#onSelectionChange(e: CustomEvent) {
 		e.stopPropagation();
 		const element = e.target as UmbTreeElement;
-		//TODO: Should multiple property be implemented here or be passed down into umb-tree?
-		this._selection = this._multiple ? element.selection : [element.selection[element.selection.length - 1]];
+		this._selection = element.selection;
 	}
 
-	private _submit() {
+	#submit() {
 		this.modalHandler?.submit({ selection: this._selection });
 	}
 
-	private _close() {
+	#close() {
 		this.modalHandler?.reject();
 	}
 
 	render() {
 		return html`
-			<umb-workspace-layout headline="Select">
+			<umb-body-layout headline="Select">
 				<uui-box>
-					<uui-input></uui-input>
-					<hr />
 					<umb-tree
 						alias="Umb.Tree.DataTypes"
-						@selected=${this._handleSelectionChange}
+						@selected=${this.#onSelectionChange}
 						.selection=${this._selection}
-						selectable></umb-tree>
+						selectable
+						?multiple=${this._multiple}></umb-tree>
 				</uui-box>
 				<div slot="actions">
-					<uui-button label="Close" @click=${this._close}></uui-button>
-					<uui-button label="Submit" look="primary" color="positive" @click=${this._submit}></uui-button>
+					<uui-button label="Close" @click=${this.#close}></uui-button>
+					<uui-button label="Submit" look="primary" color="positive" @click=${this.#submit}></uui-button>
 				</div>
-			</umb-workspace-layout>
+			</umb-body-layout>
 		`;
 	}
 }

--- a/src/backoffice/settings/data-types/modal/data-type-picker/data-type-picker-modal.element.ts
+++ b/src/backoffice/settings/data-types/modal/data-type-picker/data-type-picker-modal.element.ts
@@ -1,0 +1,77 @@
+import { css, html } from 'lit';
+import { UUITextStyles } from '@umbraco-ui/uui-css/lib';
+import { customElement, property, state } from 'lit/decorators.js';
+import type { UmbTreeElement } from '../../../../shared/components/tree/tree.element';
+import {
+	UmbDocumentTypePickerModalData,
+	UmbDocumentTypePickerModalResult,
+	UmbModalHandler,
+} from '@umbraco-cms/backoffice/modal';
+import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
+
+// TODO: make use of UmbPickerLayoutBase
+@customElement('umb-data-type-picker-modal')
+export class UmbDataTypePickerModalElement extends UmbLitElement {
+	static styles = [UUITextStyles, css``];
+
+	@property({ attribute: false })
+	modalHandler?: UmbModalHandler<UmbDocumentTypePickerModalData, UmbDocumentTypePickerModalResult>;
+
+	@property({ type: Object, attribute: false })
+	data?: UmbDocumentTypePickerModalData;
+
+	@state()
+	_selection: Array<string> = [];
+
+	@state()
+	_multiple = true;
+
+	connectedCallback() {
+		super.connectedCallback();
+		this._selection = this.data?.selection ?? [];
+		this._multiple = this.data?.multiple ?? true;
+	}
+
+	private _handleSelectionChange(e: CustomEvent) {
+		e.stopPropagation();
+		const element = e.target as UmbTreeElement;
+		//TODO: Should multiple property be implemented here or be passed down into umb-tree?
+		this._selection = this._multiple ? element.selection : [element.selection[element.selection.length - 1]];
+	}
+
+	private _submit() {
+		this.modalHandler?.submit({ selection: this._selection });
+	}
+
+	private _close() {
+		this.modalHandler?.reject();
+	}
+
+	render() {
+		return html`
+			<umb-workspace-layout headline="Select">
+				<uui-box>
+					<uui-input></uui-input>
+					<hr />
+					<umb-tree
+						alias="Umb.Tree.DataTypes"
+						@selected=${this._handleSelectionChange}
+						.selection=${this._selection}
+						selectable></umb-tree>
+				</uui-box>
+				<div slot="actions">
+					<uui-button label="Close" @click=${this._close}></uui-button>
+					<uui-button label="Submit" look="primary" color="positive" @click=${this._submit}></uui-button>
+				</div>
+			</umb-workspace-layout>
+		`;
+	}
+}
+
+export default UmbDataTypePickerModalElement;
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-data-type-picker-modal': UmbDataTypePickerModalElement;
+	}
+}

--- a/src/backoffice/settings/data-types/modal/manifests.ts
+++ b/src/backoffice/settings/data-types/modal/manifests.ts
@@ -1,0 +1,12 @@
+import type { ManifestModal } from '@umbraco-cms/backoffice/extensions-registry';
+
+const modals: Array<ManifestModal> = [
+	{
+		type: 'modal',
+		alias: 'Umb.Modal.DataTypePicker',
+		name: 'Data Type Picker Modal',
+		loader: () => import('./data-type-picker/data-type-picker-modal.element'),
+	},
+];
+
+export const manifests = [...modals];

--- a/src/backoffice/settings/data-types/repository/data-type-item.store.ts
+++ b/src/backoffice/settings/data-types/repository/data-type-item.store.ts
@@ -2,7 +2,7 @@ import { DataTypeItemResponseModel } from '@umbraco-cms/backoffice/backend-api';
 import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller';
 import { UmbItemStore, UmbStoreBase } from '@umbraco-cms/backoffice/store';
-import { ArrayState } from '@umbraco-cms/backoffice/observable-api';
+import { UmbArrayState } from '@umbraco-cms/backoffice/observable-api';
 
 /**
  * @export
@@ -24,7 +24,7 @@ export class UmbDataTypeItemStore
 		super(
 			host,
 			UMB_DATA_TYPE_ITEM_STORE_CONTEXT_TOKEN.toString(),
-			new ArrayState<DataTypeItemResponseModel>([], (x) => x.id)
+			new UmbArrayState<DataTypeItemResponseModel>([], (x) => x.id)
 		);
 	}
 

--- a/src/backoffice/settings/data-types/repository/data-type-item.store.ts
+++ b/src/backoffice/settings/data-types/repository/data-type-item.store.ts
@@ -1,0 +1,36 @@
+import { DataTypeItemResponseModel } from '@umbraco-cms/backoffice/backend-api';
+import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
+import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller';
+import { UmbItemStore, UmbStoreBase } from '@umbraco-cms/backoffice/store';
+import { ArrayState } from '@umbraco-cms/backoffice/observable-api';
+
+/**
+ * @export
+ * @class UmbDataTypeItemStore
+ * @extends {UmbStoreBase}
+ * @description - Data Store for Data Type items
+ */
+
+export class UmbDataTypeItemStore
+	extends UmbStoreBase<DataTypeItemResponseModel>
+	implements UmbItemStore<DataTypeItemResponseModel>
+{
+	/**
+	 * Creates an instance of UmbDataTypeItemStore.
+	 * @param {UmbControllerHostElement} host
+	 * @memberof UmbDataTypeItemStore
+	 */
+	constructor(host: UmbControllerHostElement) {
+		super(
+			host,
+			UMB_DATA_TYPE_ITEM_STORE_CONTEXT_TOKEN.toString(),
+			new ArrayState<DataTypeItemResponseModel>([], (x) => x.id)
+		);
+	}
+
+	items(ids: Array<string>) {
+		return this._data.getObservablePart((items) => items.filter((item) => ids.includes(item.id ?? '')));
+	}
+}
+
+export const UMB_DATA_TYPE_ITEM_STORE_CONTEXT_TOKEN = new UmbContextToken<UmbDataTypeItemStore>('UmbDataTypeItemStore');

--- a/src/backoffice/settings/data-types/repository/data-type.repository.ts
+++ b/src/backoffice/settings/data-types/repository/data-type.repository.ts
@@ -197,8 +197,6 @@ export class UmbDataTypeRepository
 		return { error };
 	}
 
-	// General:
-
 	async delete(id: string) {
 		if (!id) throw new Error('Data Type id is missing');
 		await this.#init;

--- a/src/backoffice/settings/data-types/repository/data-type.store.ts
+++ b/src/backoffice/settings/data-types/repository/data-type.store.ts
@@ -13,15 +13,13 @@ export const UMB_DATA_TYPE_STORE_CONTEXT_TOKEN = new UmbContextToken<UmbDataType
  * @description - Data Store for Template Details
  */
 export class UmbDataTypeStore extends UmbStoreBase {
-	#data = new ArrayState<DataTypeResponseModel>([], (x) => x.id);
-
 	/**
 	 * Creates an instance of UmbDataTypeStore.
 	 * @param {UmbControllerHostElement} host
 	 * @memberof UmbDataTypeStore
 	 */
 	constructor(host: UmbControllerHostElement) {
-		super(host, UMB_DATA_TYPE_STORE_CONTEXT_TOKEN.toString());
+		super(host, UMB_DATA_TYPE_STORE_CONTEXT_TOKEN.toString(), new ArrayState<DataTypeResponseModel>([], (x) => x.id));
 	}
 
 	/**
@@ -30,7 +28,7 @@ export class UmbDataTypeStore extends UmbStoreBase {
 	 * @memberof UmbDataTypeStore
 	 */
 	append(dataType: DataTypeResponseModel) {
-		this.#data.append([dataType]);
+		this._data.append([dataType]);
 	}
 
 	/**
@@ -39,7 +37,7 @@ export class UmbDataTypeStore extends UmbStoreBase {
 	 * @memberof UmbDataTypeStore
 	 */
 	byId(id: DataTypeResponseModel['id']) {
-		return this.#data.getObservablePart((x) => x.find((y) => y.id === id));
+		return this._data.getObservablePart((x) => x.find((y) => y.id === id));
 	}
 
 	/**
@@ -48,6 +46,6 @@ export class UmbDataTypeStore extends UmbStoreBase {
 	 * @memberof UmbDataTypeStore
 	 */
 	remove(uniques: Array<DataTypeResponseModel['id']>) {
-		this.#data.remove(uniques);
+		this._data.remove(uniques);
 	}
 }

--- a/src/backoffice/settings/data-types/repository/manifests.ts
+++ b/src/backoffice/settings/data-types/repository/manifests.ts
@@ -1,7 +1,13 @@
 import { UmbDataTypeRepository } from '../repository/data-type.repository';
+import { UmbDataTypeItemStore } from './data-type-item.store';
 import { UmbDataTypeStore } from './data-type.store';
 import { UmbDataTypeTreeStore } from './data-type.tree.store';
-import type { ManifestStore, ManifestTreeStore, ManifestRepository } from '@umbraco-cms/backoffice/extensions-registry';
+import type {
+	ManifestStore,
+	ManifestTreeStore,
+	ManifestRepository,
+	ManifestItemStore,
+} from '@umbraco-cms/backoffice/extensions-registry';
 
 export const DATA_TYPE_REPOSITORY_ALIAS = 'Umb.Repository.DataType';
 
@@ -14,6 +20,7 @@ const repository: ManifestRepository = {
 
 export const DATA_TYPE_STORE_ALIAS = 'Umb.Store.DataType';
 export const DATA_TYPE_TREE_STORE_ALIAS = 'Umb.Store.DataTypeTree';
+export const DATA_TYPE_ITEM_STORE_ALIAS = 'Umb.Store.DataTypeItem';
 
 const store: ManifestStore = {
 	type: 'store',
@@ -29,4 +36,11 @@ const treeStore: ManifestTreeStore = {
 	class: UmbDataTypeTreeStore,
 };
 
-export const manifests = [repository, store, treeStore];
+const itemStore: ManifestItemStore = {
+	type: 'itemStore',
+	alias: DATA_TYPE_ITEM_STORE_ALIAS,
+	name: 'Data Type Item Store',
+	class: UmbDataTypeItemStore,
+};
+
+export const manifests = [repository, store, treeStore, itemStore];

--- a/src/backoffice/settings/data-types/repository/sources/data-type-item.server.data.ts
+++ b/src/backoffice/settings/data-types/repository/sources/data-type-item.server.data.ts
@@ -1,0 +1,39 @@
+import type { UmbItemDataSource } from '@umbraco-cms/backoffice/repository';
+import { DataTypeItemResponseModel, DataTypeResource } from '@umbraco-cms/backoffice/backend-api';
+import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller';
+import { tryExecuteAndNotify } from '@umbraco-cms/backoffice/resources';
+
+/**
+ * A data source for Data Type items that fetches data from the server
+ * @export
+ * @class UmbDataTypeItemServerDataSource
+ * @implements {DocumentTreeDataSource}
+ */
+export class UmbDataTypeItemServerDataSource implements UmbItemDataSource<DataTypeItemResponseModel> {
+	#host: UmbControllerHostElement;
+
+	/**
+	 * Creates an instance of UmbDataTypeItemServerDataSource.
+	 * @param {UmbControllerHostElement} host
+	 * @memberof UmbDataTypeItemServerDataSource
+	 */
+	constructor(host: UmbControllerHostElement) {
+		this.#host = host;
+	}
+
+	/**
+	 * Fetches the items for the given ids from the server
+	 * @param {Array<string>} ids
+	 * @return {*}
+	 * @memberof UmbDataTypeItemServerDataSource
+	 */
+	async getItems(ids: Array<string>) {
+		if (!ids) throw new Error('Ids are missing');
+		return tryExecuteAndNotify(
+			this.#host,
+			DataTypeResource.getDataTypeItem({
+				id: ids,
+			})
+		);
+	}
+}

--- a/src/backoffice/settings/data-types/repository/sources/data-type.server.data.ts
+++ b/src/backoffice/settings/data-types/repository/sources/data-type.server.data.ts
@@ -67,7 +67,7 @@ export class UmbDataTypeServerDataSource
 	 * @return {*}
 	 * @memberof UmbDataTypeServerDataSource
 	 */
-	async insert(dataType: CreateDataTypeRequestModel & { id: string }) {
+	async insert(dataType: CreateDataTypeRequestModel) {
 		if (!dataType) throw new Error('Data Type is missing');
 		if (!dataType.id) throw new Error('Data Type id is missing');
 

--- a/src/backoffice/settings/index.ts
+++ b/src/backoffice/settings/index.ts
@@ -11,6 +11,8 @@ import { manifests as logviewerManifests } from './logviewer/manifests';
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extensions-api';
 import { ManifestTypes } from '@umbraco-cms/backoffice/extensions-registry';
 
+import './data-types/components';
+
 export const manifests = [
 	...settingsSectionManifests,
 	...settingsMenuManifests,

--- a/src/backoffice/settings/languages/repository/language-item.store.ts
+++ b/src/backoffice/settings/languages/repository/language-item.store.ts
@@ -25,16 +25,6 @@ export class UmbLanguageItemStore
 		);
 	}
 
-	/**
-	 * Updates an item in the store
-	 * @param {string} isoCode
-	 * @param {Partial<LanguageResponseModel>} data
-	 * @memberof UmbLanguageItemStore
-	 */
-	updateItem(isoCode: string, data: Partial<LanguageResponseModel>) {
-		this._data.next(partialUpdateFrozenArray(this._data.getValue(), data, (entry) => entry.isoCode === isoCode));
-	}
-
 	items(isoCodes: Array<string>) {
 		return this._data.getObservablePart((items) => items.filter((item) => isoCodes.includes(item.isoCode ?? '')));
 	}

--- a/src/backoffice/settings/languages/repository/language-item.store.ts
+++ b/src/backoffice/settings/languages/repository/language-item.store.ts
@@ -1,0 +1,41 @@
+import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
+import { UmbStoreBase } from '@umbraco-cms/backoffice/store';
+import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller';
+import { ArrayState, partialUpdateFrozenArray } from '@umbraco-cms/backoffice/observable-api';
+import { LanguageResponseModel } from '@umbraco-cms/backoffice/backend-api';
+import type { UmbItemStore } from '@umbraco-cms/backoffice/store';
+
+export const UMB_LANGUAGE_ITEM_STORE_CONTEXT_TOKEN = new UmbContextToken<UmbLanguageItemStore>('UmbLanguageItemStore');
+
+/**
+ * @export
+ * @class UmbLanguageItemStore
+ * @extends {UmbStoreBase}
+ * @description -  Store for Languages items
+ */
+export class UmbLanguageItemStore
+	extends UmbStoreBase<LanguageResponseModel>
+	implements UmbItemStore<LanguageResponseModel>
+{
+	constructor(host: UmbControllerHostElement) {
+		super(
+			host,
+			UMB_LANGUAGE_ITEM_STORE_CONTEXT_TOKEN.toString(),
+			new ArrayState<LanguageResponseModel>([], (x) => x.isoCode)
+		);
+	}
+
+	/**
+	 * Updates an item in the store
+	 * @param {string} isoCode
+	 * @param {Partial<LanguageResponseModel>} data
+	 * @memberof UmbLanguageItemStore
+	 */
+	updateItem(isoCode: string, data: Partial<LanguageResponseModel>) {
+		this._data.next(partialUpdateFrozenArray(this._data.getValue(), data, (entry) => entry.isoCode === isoCode));
+	}
+
+	items(isoCodes: Array<string>) {
+		return this._data.getObservablePart((items) => items.filter((item) => isoCodes.includes(item.isoCode ?? '')));
+	}
+}

--- a/src/backoffice/settings/languages/repository/language-item.store.ts
+++ b/src/backoffice/settings/languages/repository/language-item.store.ts
@@ -1,7 +1,7 @@
 import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
 import { UmbStoreBase } from '@umbraco-cms/backoffice/store';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller';
-import { ArrayState, partialUpdateFrozenArray } from '@umbraco-cms/backoffice/observable-api';
+import { UmbArrayState } from '@umbraco-cms/backoffice/observable-api';
 import { LanguageResponseModel } from '@umbraco-cms/backoffice/backend-api';
 import type { UmbItemStore } from '@umbraco-cms/backoffice/store';
 
@@ -21,7 +21,7 @@ export class UmbLanguageItemStore
 		super(
 			host,
 			UMB_LANGUAGE_ITEM_STORE_CONTEXT_TOKEN.toString(),
-			new ArrayState<LanguageResponseModel>([], (x) => x.isoCode)
+			new UmbArrayState<LanguageResponseModel>([], (x) => x.isoCode)
 		);
 	}
 

--- a/src/backoffice/settings/languages/repository/language.repository.ts
+++ b/src/backoffice/settings/languages/repository/language.repository.ts
@@ -41,7 +41,6 @@ export class UmbLanguageRepository implements UmbItemRepository<LanguageItemResp
 
 			new UmbContextConsumerController(this.#host, UMB_LANGUAGE_ITEM_STORE_CONTEXT_TOKEN, (instance) => {
 				this.#languageItemStore = instance;
-				debugger;
 			}).asPromise(),
 		]);
 	}

--- a/src/backoffice/settings/languages/repository/language.store.ts
+++ b/src/backoffice/settings/languages/repository/language.store.ts
@@ -13,6 +13,8 @@ export const UMB_LANGUAGE_STORE_CONTEXT_TOKEN = new UmbContextToken<UmbLanguageS
  * @description - Details Data Store for Languages
  */
 export class UmbLanguageStore extends UmbStoreBase {
+	public data = this._data.asObservable();
+
 	constructor(host: UmbControllerHostElement) {
 		super(
 			host,

--- a/src/backoffice/settings/languages/repository/language.store.ts
+++ b/src/backoffice/settings/languages/repository/language.store.ts
@@ -13,23 +13,24 @@ export const UMB_LANGUAGE_STORE_CONTEXT_TOKEN = new UmbContextToken<UmbLanguageS
  * @description - Details Data Store for Languages
  */
 export class UmbLanguageStore extends UmbStoreBase {
-	#data = new ArrayState<LanguageResponseModel>([], (x) => x.isoCode);
-	data = this.#data.asObservable();
-
 	constructor(host: UmbControllerHostElement) {
-		super(host, UMB_LANGUAGE_STORE_CONTEXT_TOKEN.toString());
+		super(
+			host,
+			UMB_LANGUAGE_STORE_CONTEXT_TOKEN.toString(),
+			new ArrayState<LanguageResponseModel>([], (x) => x.isoCode)
+		);
 	}
 
 	append(language: LanguageResponseModel) {
-		this.#data.append([language]);
+		this._data.append([language]);
 	}
 
 	remove(uniques: string[]) {
-		this.#data.remove(uniques);
+		this._data.remove(uniques);
 	}
 
 	// TODO: how do we best handle this? They might have a smaller data set than the details
 	items(isoCodes: Array<string>) {
-		return this.#data.getObservablePart((items) => items.filter((item) => isoCodes.includes(item.isoCode ?? '')));
+		return this._data.getObservablePart((items) => items.filter((item) => isoCodes.includes(item.isoCode ?? '')));
 	}
 }

--- a/src/backoffice/settings/languages/repository/manifests.ts
+++ b/src/backoffice/settings/languages/repository/manifests.ts
@@ -1,5 +1,6 @@
 import { UmbLanguageRepository } from '../repository/language.repository';
 import { UmbLanguageStore } from './language.store';
+import { UmbLanguageItemStore } from './language-item.store';
 import type { ManifestStore, ManifestRepository } from '@umbraco-cms/backoffice/extensions-registry';
 
 export const LANGUAGE_REPOSITORY_ALIAS = 'Umb.Repository.Language';
@@ -12,6 +13,7 @@ const repository: ManifestRepository = {
 };
 
 export const LANGUAGE_STORE_ALIAS = 'Umb.Store.Language';
+export const LANGUAGE_ITEM_STORE_ALIAS = 'Umb.Store.LanguageItem';
 
 const store: ManifestStore = {
 	type: 'store',
@@ -20,4 +22,11 @@ const store: ManifestStore = {
 	class: UmbLanguageStore,
 };
 
-export const manifests = [repository, store];
+const itemStore = {
+	type: 'itemStore',
+	alias: LANGUAGE_ITEM_STORE_ALIAS,
+	name: 'Language Item Store',
+	class: UmbLanguageItemStore,
+};
+
+export const manifests = [repository, store, itemStore];

--- a/src/backoffice/settings/languages/repository/sources/language-item.server.data.ts
+++ b/src/backoffice/settings/languages/repository/sources/language-item.server.data.ts
@@ -1,0 +1,35 @@
+import { LanguageResource, LanguageItemResponseModel } from '@umbraco-cms/backoffice/backend-api';
+import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller';
+import { tryExecuteAndNotify } from '@umbraco-cms/backoffice/resources';
+import { UmbItemDataSource } from '@umbraco-cms/backoffice/repository';
+
+/**
+ * A data source for Languages that fetches Language items from the server
+ * @export
+ * @class UmbLanguageItemServerDataSource
+ * @implements {UmbItemDataSource}
+ */
+export class UmbLanguageItemServerDataSource implements UmbItemDataSource<LanguageItemResponseModel> {
+	#host: UmbControllerHostElement;
+
+	constructor(host: UmbControllerHostElement) {
+		this.#host = host;
+	}
+
+	/**
+	 * Fetches Language items the given iso codes from the server
+	 * @param {string[]} isoCodes
+	 * @return {*}
+	 * @memberof UmbLanguageItemServerDataSource
+	 */
+	async getItems(isoCodes: string[]) {
+		if (!isoCodes) throw new Error('Iso Codes are missing');
+
+		return tryExecuteAndNotify(
+			this.#host,
+			LanguageResource.getLanguageItem({
+				isoCode: isoCodes,
+			})
+		);
+	}
+}

--- a/src/backoffice/settings/relation-types/repository/relation-type.repository.ts
+++ b/src/backoffice/settings/relation-types/repository/relation-type.repository.ts
@@ -74,7 +74,7 @@ export class UmbRelationTypeRepository
 		return { data: undefined, error };
 	}
 
-	async requestTreeItems(ids: Array<string>) {
+	async requestItemsLegacy(ids: Array<string>) {
 		if (!ids) throw new Error('Ids are missing');
 		await this.#init;
 
@@ -93,7 +93,7 @@ export class UmbRelationTypeRepository
 		return this.#treeStore!.childrenOf(parentId);
 	}
 
-	async treeItems(ids: Array<string>) {
+	async itemsLegacy(ids: Array<string>) {
 		await this.#init;
 		return this.#treeStore!.items(ids);
 	}

--- a/src/backoffice/settings/relation-types/repository/relation-type.store.ts
+++ b/src/backoffice/settings/relation-types/repository/relation-type.store.ts
@@ -13,15 +13,17 @@ export const UMB_RELATION_TYPE_STORE_CONTEXT_TOKEN = new UmbContextToken<UmbRela
  * @description - Data Store for Template Details
  */
 export class UmbRelationTypeStore extends UmbStoreBase {
-	#data = new ArrayState<RelationTypeResponseModel>([], (x) => x.id);
-
 	/**
 	 * Creates an instance of UmbRelationTypeStore.
 	 * @param {UmbControllerHostElement} host
 	 * @memberof UmbRelationTypeStore
 	 */
 	constructor(host: UmbControllerHostElement) {
-		super(host, UMB_RELATION_TYPE_STORE_CONTEXT_TOKEN.toString());
+		super(
+			host,
+			UMB_RELATION_TYPE_STORE_CONTEXT_TOKEN.toString(),
+			new ArrayState<RelationTypeResponseModel>([], (x) => x.id)
+		);
 	}
 
 	/**
@@ -30,7 +32,7 @@ export class UmbRelationTypeStore extends UmbStoreBase {
 	 * @memberof UmbRelationTypeStore
 	 */
 	append(RelationType: RelationTypeResponseModel) {
-		this.#data.append([RelationType]);
+		this._data.append([RelationType]);
 	}
 
 	/**
@@ -39,7 +41,7 @@ export class UmbRelationTypeStore extends UmbStoreBase {
 	 * @memberof UmbRelationTypeStore
 	 */
 	byKey(id: RelationTypeResponseModel['id']) {
-		return this.#data.getObservablePart((x) => x.find((y) => y.id === id));
+		return this._data.getObservablePart((x) => x.find((y) => y.id === id));
 	}
 
 	/**
@@ -48,6 +50,6 @@ export class UmbRelationTypeStore extends UmbStoreBase {
 	 * @memberof UmbRelationTypeStore
 	 */
 	remove(uniques: Array<RelationTypeResponseModel['id']>) {
-		this.#data.remove(uniques);
+		this._data.remove(uniques);
 	}
 }

--- a/src/backoffice/shared/components/input-language-picker/input-language-picker.context.ts
+++ b/src/backoffice/shared/components/input-language-picker/input-language-picker.context.ts
@@ -1,4 +1,4 @@
-import { UmbPickerInputContext } from 'libs/picker-input';
+import { UmbPickerInputContext } from '@umbraco-cms/backoffice/picker-input';
 import type { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller';
 import { UMB_LANGUAGE_PICKER_MODAL } from '@umbraco-cms/backoffice/modal';
 import type { LanguageItemResponseModel } from '@umbraco-cms/backoffice/backend-api';

--- a/src/backoffice/shared/components/input-language-picker/input-language-picker.context.ts
+++ b/src/backoffice/shared/components/input-language-picker/input-language-picker.context.ts
@@ -1,0 +1,10 @@
+import { UmbPickerContext } from '@umbraco-cms/backoffice/picker';
+import type { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller';
+import { UMB_LANGUAGE_PICKER_MODAL } from '@umbraco-cms/backoffice/modal';
+import type { LanguageItemResponseModel } from '@umbraco-cms/backoffice/backend-api';
+
+export class UmbLanguagePickerContext extends UmbPickerContext<LanguageItemResponseModel> {
+	constructor(host: UmbControllerHostElement) {
+		super(host, 'Umb.Repository.Language', UMB_LANGUAGE_PICKER_MODAL, (item) => item.isoCode);
+	}
+}

--- a/src/backoffice/shared/components/input-language-picker/input-language-picker.context.ts
+++ b/src/backoffice/shared/components/input-language-picker/input-language-picker.context.ts
@@ -1,9 +1,9 @@
-import { UmbPickerContext } from '@umbraco-cms/backoffice/picker';
+import { UmbPickerInputContext } from 'libs/picker-input';
 import type { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller';
 import { UMB_LANGUAGE_PICKER_MODAL } from '@umbraco-cms/backoffice/modal';
 import type { LanguageItemResponseModel } from '@umbraco-cms/backoffice/backend-api';
 
-export class UmbLanguagePickerContext extends UmbPickerContext<LanguageItemResponseModel> {
+export class UmbLanguagePickerContext extends UmbPickerInputContext<LanguageItemResponseModel> {
 	constructor(host: UmbControllerHostElement) {
 		super(host, 'Umb.Repository.Language', UMB_LANGUAGE_PICKER_MODAL, (item) => item.isoCode);
 	}

--- a/src/backoffice/shared/components/input-language-picker/input-language-picker.element.ts
+++ b/src/backoffice/shared/components/input-language-picker/input-language-picker.element.ts
@@ -21,10 +21,15 @@ export class UmbInputLanguagePickerElement extends FormControlMixin(UmbLitElemen
 	 * This is a minimum amount of selected items in this input.
 	 * @type {number}
 	 * @attr
-	 * @default undefined
+	 * @default 0
 	 */
 	@property({ type: Number })
-	min?: number;
+	public get min(): number {
+		return this.#pickerContext.min;
+	}
+	public set min(value: number) {
+		this.#pickerContext.min = value;
+	}
 
 	/**
 	 * Min validation message.
@@ -39,10 +44,15 @@ export class UmbInputLanguagePickerElement extends FormControlMixin(UmbLitElemen
 	 * This is a maximum amount of selected items in this input.
 	 * @type {number}
 	 * @attr
-	 * @default undefined
+	 * @default Infinite
 	 */
 	@property({ type: Number })
-	max?: number;
+	public get max(): number {
+		return this.#pickerContext.max;
+	}
+	public set max(value: number) {
+		this.#pickerContext.max = value;
+	}
 
 	/**
 	 * Max validation message.
@@ -92,7 +102,7 @@ export class UmbInputLanguagePickerElement extends FormControlMixin(UmbLitElemen
 			() => !!this.max && this._selectedIsoCodes.length > this.max
 		);
 
-		this.observe(this.#pickerContext.selection, (selection) => (this.selectedIsoCodes = selection));
+		this.observe(this.#pickerContext.selection, (selection) => (this._selectedIsoCodes = selection));
 		this.observe(this.#pickerContext.selectedItems, (selectedItems) => (this._items = selectedItems));
 	}
 
@@ -101,14 +111,15 @@ export class UmbInputLanguagePickerElement extends FormControlMixin(UmbLitElemen
 	}
 
 	private _openPicker() {
-		// TODO: add filter
-		// filter: this.filter,
-		this.#pickerContext.openPicker();
+		this.#pickerContext.openPicker({
+			filter: this.filter,
+			hello: 'world',
+		});
 	}
 
 	render() {
 		return html`
-			${this._items.map((item) => this._renderItem(item))}
+			<uui-ref-list> ${this._items.map((item) => this._renderItem(item))} </uui-ref-list>
 			<uui-button
 				id="add-button"
 				look="placeholder"

--- a/src/backoffice/shared/components/input-language-picker/input-language-picker.element.ts
+++ b/src/backoffice/shared/components/input-language-picker/input-language-picker.element.ts
@@ -102,7 +102,6 @@ export class UmbInputLanguagePickerElement extends FormControlMixin(UmbLitElemen
 	private _openPicker() {
 		this.#pickerContext.openPicker({
 			filter: this.filter,
-			hello: 'world',
 		});
 	}
 

--- a/src/backoffice/shared/components/input-language-picker/input-language-picker.element.ts
+++ b/src/backoffice/shared/components/input-language-picker/input-language-picker.element.ts
@@ -66,20 +66,17 @@ export class UmbInputLanguagePickerElement extends FormControlMixin(UmbLitElemen
 	@property({ type: Object, attribute: false })
 	public filter: (language: LanguageResponseModel) => boolean = () => true;
 
-	private _selectedIsoCodes: Array<string> = [];
 	public get selectedIsoCodes(): Array<string> {
-		return this._selectedIsoCodes;
+		return this.#pickerContext.getSelection();
 	}
-	public set selectedIsoCodes(isoCodes: Array<string>) {
-		this._selectedIsoCodes = isoCodes;
-		super.value = isoCodes.join(',');
+	public set selectedIsoCodes(ids: Array<string>) {
+		this.#pickerContext.setSelection(ids);
 	}
 
 	@property()
 	public set value(isoCodesString: string) {
-		if (isoCodesString !== this._value) {
-			this.selectedIsoCodes = isoCodesString.split(/[ ,]+/);
-		}
+		// Its with full purpose we don't call super.value, as thats being handled by the observation of the context selection.
+		this.selectedIsoCodes = isoCodesString.split(/[ ,]+/);
 	}
 
 	@state()
@@ -93,16 +90,16 @@ export class UmbInputLanguagePickerElement extends FormControlMixin(UmbLitElemen
 		this.addValidator(
 			'rangeUnderflow',
 			() => this.minMessage,
-			() => !!this.min && this._selectedIsoCodes.length < this.min
+			() => !!this.min && this.#pickerContext.getSelection().length < this.min
 		);
 
 		this.addValidator(
 			'rangeOverflow',
 			() => this.maxMessage,
-			() => !!this.max && this._selectedIsoCodes.length > this.max
+			() => !!this.max && this.#pickerContext.getSelection().length > this.max
 		);
 
-		this.observe(this.#pickerContext.selection, (selection) => (this._selectedIsoCodes = selection));
+		this.observe(this.#pickerContext.selection, (selection) => (super.value = selection.join(',')));
 		this.observe(this.#pickerContext.selectedItems, (selectedItems) => (this._items = selectedItems));
 	}
 
@@ -125,7 +122,7 @@ export class UmbInputLanguagePickerElement extends FormControlMixin(UmbLitElemen
 				look="placeholder"
 				@click=${this._openPicker}
 				label="open"
-				?disabled="${this._selectedIsoCodes.length === this.max}"
+				?disabled="${this._items.length === this.max}"
 				>Add</uui-button
 			>
 		`;

--- a/src/backoffice/shared/components/input-language-picker/input-language-picker.element.ts
+++ b/src/backoffice/shared/components/input-language-picker/input-language-picker.element.ts
@@ -9,14 +9,6 @@ import type { LanguageResponseModel } from '@umbraco-cms/backoffice/backend-api'
 
 @customElement('umb-input-language-picker')
 export class UmbInputLanguagePickerElement extends FormControlMixin(UmbLitElement) {
-	static styles = [
-		UUITextStyles,
-		css`
-			#add-button {
-				width: 100%;
-			}
-		`,
-	];
 	/**
 	 * This is a minimum amount of selected items in this input.
 	 * @type {number}
@@ -141,6 +133,15 @@ export class UmbInputLanguagePickerElement extends FormControlMixin(UmbLitElemen
 			</uui-ref-node>
 		`;
 	}
+
+	static styles = [
+		UUITextStyles,
+		css`
+			#add-button {
+				width: 100%;
+			}
+		`,
+	];
 }
 
 export default UmbInputLanguagePickerElement;

--- a/src/backoffice/shared/components/input-language-picker/input-language-picker.element.ts
+++ b/src/backoffice/shared/components/input-language-picker/input-language-picker.element.ts
@@ -44,7 +44,7 @@ export class UmbInputLanguagePickerElement extends FormControlMixin(UmbLitElemen
 	 * This is a maximum amount of selected items in this input.
 	 * @type {number}
 	 * @attr
-	 * @default Infinite
+	 * @default Infinity
 	 */
 	@property({ type: Number })
 	public get max(): number {

--- a/src/backoffice/shared/components/input-media-picker/input-media-picker.element.ts
+++ b/src/backoffice/shared/components/input-media-picker/input-media-picker.element.ts
@@ -129,7 +129,7 @@ export class UmbInputMediaPickerElement extends FormControlMixin(UmbLitElement) 
 		this._pickedItemsObserver?.destroy();
 
 		// TODO: consider changing this to the list data endpoint when it is available
-		const { asObservable } = await this._repository.requestTreeItems(this._selectedIds);
+		const { asObservable } = await this._repository.requestItemsLegacy(this._selectedIds);
 
 		if (!asObservable) return;
 

--- a/src/backoffice/shared/components/input-template-picker/input-template-picker.element.ts
+++ b/src/backoffice/shared/components/input-template-picker/input-template-picker.element.ts
@@ -87,7 +87,7 @@ export class UmbInputTemplatePickerElement extends FormControlMixin(UmbLitElemen
 
 	async #observePickedTemplates() {
 		this.observe(
-			await this._templateRepository.treeItems(this._allowedKeys),
+			await this._templateRepository.itemsLegacy(this._allowedKeys),
 			(data) => {
 				this._pickedTemplates = data;
 			},

--- a/src/backoffice/shared/components/tree/tree.context.ts
+++ b/src/backoffice/shared/components/tree/tree.context.ts
@@ -1,7 +1,7 @@
 import type { Observable } from 'rxjs';
 import { UmbTreeRepository } from '@umbraco-cms/backoffice/repository';
 import type { ManifestTree } from '@umbraco-cms/backoffice/extensions-registry';
-import { DeepState, UmbObserverController } from '@umbraco-cms/backoffice/observable-api';
+import { BooleanState, DeepState, UmbObserverController } from '@umbraco-cms/backoffice/observable-api';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller';
 import { createExtensionClass, umbExtensionsRegistry } from '@umbraco-cms/backoffice/extensions-api';
 
@@ -10,6 +10,7 @@ export interface UmbTreeContext {
 	readonly selectable: Observable<boolean>;
 	readonly selection: Observable<Array<string>>;
 	setSelectable(value: boolean): void;
+	setMultiple(value: boolean): void;
 	setSelection(value: Array<string>): void;
 	select(id: string): void;
 }
@@ -18,8 +19,11 @@ export class UmbTreeContextBase implements UmbTreeContext {
 	host: UmbControllerHostElement;
 	public tree: ManifestTree;
 
-	#selectable = new DeepState(false);
+	#selectable = new BooleanState(false);
 	public readonly selectable = this.#selectable.asObservable();
+
+	#multiple = new BooleanState(false);
+	public readonly multiple = this.#multiple.asObservable();
 
 	#selection = new DeepState(<Array<string>>[]);
 	public readonly selection = this.#selection.asObservable();
@@ -69,22 +73,36 @@ export class UmbTreeContextBase implements UmbTreeContext {
 		this.#selectable.next(value);
 	}
 
+	public getSelectable() {
+		return this.#selectable.getValue();
+	}
+
+	public setMultiple(value: boolean) {
+		this.#multiple.next(value);
+	}
+
+	public getMultiple() {
+		return this.#multiple.getValue();
+	}
+
 	public setSelection(value: Array<string>) {
 		if (!value) return;
 		this.#selection.next(value);
 	}
 
-	public select(id: string) {
-		const oldSelection = this.#selection.getValue();
-		if (oldSelection.indexOf(id) !== -1) return;
+	public getSelection() {
+		return this.#selection.getValue();
+	}
 
-		const selection = [...oldSelection, id];
-		this.#selection.next(selection);
+	public select(id: string) {
+		if (!this.getSelectable()) return;
+		const newSelection = this.getMultiple() ? [...this.getSelection(), id] : [id];
+		this.#selection.next(newSelection);
 	}
 
 	public deselect(id: string) {
-		const selection = this.#selection.getValue();
-		this.#selection.next(selection.filter((x) => x !== id));
+		const newSelection = this.getSelection().filter((x) => x !== id);
+		this.#selection.next(newSelection);
 	}
 
 	public async requestRootItems() {

--- a/src/backoffice/shared/components/tree/tree.element.ts
+++ b/src/backoffice/shared/components/tree/tree.element.ts
@@ -51,6 +51,18 @@ export class UmbTreeElement extends UmbLitElement {
 		this._treeContext?.setSelection(newVal);
 	}
 
+	private _multiple = false;
+	@property({ type: Boolean, reflect: true })
+	get multiple() {
+		return this._multiple;
+	}
+	set multiple(newVal) {
+		const oldVal = this._multiple;
+		this._multiple = newVal;
+		this.requestUpdate('multiple', oldVal);
+		this._treeContext?.setMultiple(newVal);
+	}
+
 	@state()
 	private _tree?: ManifestTree;
 
@@ -86,6 +98,7 @@ export class UmbTreeElement extends UmbLitElement {
 		this._treeContext = new UmbTreeContextBase(this, this._tree);
 		this._treeContext.setSelectable(this.selectable);
 		this._treeContext.setSelection(this.selection);
+		this._treeContext.setMultiple(this.multiple);
 
 		this.#observeSelection();
 		this.#observeTreeRoot();

--- a/src/backoffice/templating/stylesheets/repository/stylesheet.repository.ts
+++ b/src/backoffice/templating/stylesheets/repository/stylesheet.repository.ts
@@ -76,7 +76,7 @@ export class UmbStylesheetRepository
 		return { data, error, asObservable: () => this.#treeStore!.childrenOf(path) };
 	}
 
-	async requestTreeItems(paths: Array<string>) {
+	async requestItemsLegacy(paths: Array<string>) {
 		if (!paths) throw new Error('Paths are missing');
 		await this.#init;
 		const { data, error } = await this.#treeDataSource.getItems(paths);
@@ -94,7 +94,7 @@ export class UmbStylesheetRepository
 		return this.#treeStore!.childrenOf(parentPath);
 	}
 
-	async treeItems(paths: Array<string>) {
+	async itemsLegacy(paths: Array<string>) {
 		if (!paths) throw new Error('Paths are missing');
 		await this.#init;
 		return this.#treeStore!.items(paths);

--- a/src/backoffice/templating/templates/repository/template.repository.ts
+++ b/src/backoffice/templating/templates/repository/template.repository.ts
@@ -82,7 +82,7 @@ export class UmbTemplateRepository
 		return { data, error, asObservable: () => this.#treeStore!.childrenOf(parentId) };
 	}
 
-	async requestTreeItems(ids: Array<string>) {
+	async requestItemsLegacy(ids: Array<string>) {
 		await this.#init;
 
 		if (!ids) {
@@ -105,7 +105,7 @@ export class UmbTemplateRepository
 		return this.#treeStore!.childrenOf(parentId);
 	}
 
-	async treeItems(ids: Array<string>) {
+	async itemsLegacy(ids: Array<string>) {
 		await this.#init;
 		return this.#treeStore!.items(ids);
 	}

--- a/src/backoffice/templating/templates/repository/template.store.ts
+++ b/src/backoffice/templating/templates/repository/template.store.ts
@@ -11,15 +11,13 @@ import type { UmbControllerHostElement } from '@umbraco-cms/backoffice/controlle
  * @description - Data Store for Templates
  */
 export class UmbTemplateStore extends UmbStoreBase {
-	#data = new ArrayState<TemplateResponseModel>([], (x) => x.id);
-
 	/**
 	 * Creates an instance of UmbTemplateStore.
 	 * @param {UmbControllerHostElement} host
 	 * @memberof UmbTemplateStore
 	 */
 	constructor(host: UmbControllerHostElement) {
-		super(host, UMB_TEMPLATE_STORE_CONTEXT_TOKEN.toString());
+		super(host, UMB_TEMPLATE_STORE_CONTEXT_TOKEN.toString(), new ArrayState<TemplateResponseModel>([], (x) => x.id));
 	}
 
 	/**
@@ -28,7 +26,7 @@ export class UmbTemplateStore extends UmbStoreBase {
 	 * @memberof UmbTemplateStore
 	 */
 	append(template: TemplateResponseModel) {
-		this.#data.append([template]);
+		this._data.append([template]);
 	}
 
 	/**
@@ -37,7 +35,7 @@ export class UmbTemplateStore extends UmbStoreBase {
 	 * @memberof UmbTemplateStore
 	 */
 	remove(uniques: string[]) {
-		this.#data.remove(uniques);
+		this._data.remove(uniques);
 	}
 }
 

--- a/src/backoffice/translation/dictionary/repository/dictionary.repository.ts
+++ b/src/backoffice/translation/dictionary/repository/dictionary.repository.ts
@@ -86,7 +86,7 @@ export class UmbDictionaryRepository
 		return { data, error, asObservable: () => this.#treeStore!.childrenOf(parentId) };
 	}
 
-	async requestTreeItems(ids: Array<string>) {
+	async requestItemsLegacy(ids: Array<string>) {
 		await this.#init;
 
 		if (!ids) {
@@ -109,7 +109,7 @@ export class UmbDictionaryRepository
 		return this.#treeStore!.childrenOf(parentId);
 	}
 
-	async treeItems(ids: Array<string>) {
+	async itemsLegacy(ids: Array<string>) {
 		await this.#init;
 		return this.#treeStore!.items(ids);
 	}

--- a/src/backoffice/translation/dictionary/repository/dictionary.store.ts
+++ b/src/backoffice/translation/dictionary/repository/dictionary.store.ts
@@ -11,18 +11,20 @@ import { DictionaryItemResponseModel } from '@umbraco-cms/backoffice/backend-api
  * @description - Data Store for Dictionary
  */
 export class UmbDictionaryStore extends UmbStoreBase {
-	#data = new ArrayState<DictionaryItemResponseModel>([], (x) => x.id);
-
 	constructor(host: UmbControllerHostElement) {
-		super(host, UMB_DICTIONARY_STORE_CONTEXT_TOKEN.toString());
+		super(
+			host,
+			UMB_DICTIONARY_STORE_CONTEXT_TOKEN.toString(),
+			new ArrayState<DictionaryItemResponseModel>([], (x) => x.id)
+		);
 	}
 
 	append(dictionary: DictionaryItemResponseModel) {
-		this.#data.append([dictionary]);
+		this._data.append([dictionary]);
 	}
 
 	remove(uniques: string[]) {
-		this.#data.remove(uniques);
+		this._data.remove(uniques);
 	}
 }
 

--- a/src/backoffice/users/user-groups/repository/user-group.store.ts
+++ b/src/backoffice/users/user-groups/repository/user-group.store.ts
@@ -20,7 +20,7 @@ export class UmbUserGroupStore extends UmbStoreBase implements UmbEntityDetailSt
 	public groups = this.#groups.asObservable();
 
 	constructor(host: UmbControllerHostElement) {
-		super(host, UMB_USER_GROUP_STORE_CONTEXT_TOKEN.toString(), new ArrayState<UserGroupDetails>([], (x) => x.id));
+		super(host, UMB_USER_GROUP_STORE_CONTEXT_TOKEN.toString(), new UmbArrayState<UserGroupDetails>([], (x) => x.id));
 	}
 
 	getScaffold(entityType: string, parentId: string | null) {

--- a/src/backoffice/users/user-groups/repository/user-group.store.ts
+++ b/src/backoffice/users/user-groups/repository/user-group.store.ts
@@ -20,7 +20,7 @@ export class UmbUserGroupStore extends UmbStoreBase implements UmbEntityDetailSt
 	public groups = this.#groups.asObservable();
 
 	constructor(host: UmbControllerHostElement) {
-		super(host, UMB_USER_GROUP_STORE_CONTEXT_TOKEN.toString());
+		super(host, UMB_USER_GROUP_STORE_CONTEXT_TOKEN.toString(), new ArrayState<UserGroupDetails>([], (x) => x.id));
 	}
 
 	getScaffold(entityType: string, parentId: string | null) {

--- a/src/backoffice/users/users/repository/user.store.ts
+++ b/src/backoffice/users/users/repository/user.store.ts
@@ -15,14 +15,13 @@ export const UMB_USER_STORE_CONTEXT_TOKEN = new UmbContextToken<UmbUserStore>('U
  * @description - Data Store for Users
  */
 export class UmbUserStore extends UmbStoreBase implements UmbEntityDetailStore<UserDetails> {
-	#users = new ArrayState<UserDetails>([], (x) => x.id);
-	public users = this.#users.asObservable();
+	public users = this._data.asObservable();
 
 	#totalUsers = new NumberState(0);
 	public readonly totalUsers = this.#totalUsers.asObservable();
 
 	constructor(host: UmbControllerHostElement) {
-		super(host, UMB_USER_STORE_CONTEXT_TOKEN.toString());
+		super(host, UMB_USER_STORE_CONTEXT_TOKEN.toString(), new ArrayState<UserDetails>([], (x) => x.id));
 	}
 
 	getScaffold(entityType: string, parentId: string | null) {
@@ -52,7 +51,7 @@ export class UmbUserStore extends UmbStoreBase implements UmbEntityDetailStore<U
 			.then((res) => res.json())
 			.then((data) => {
 				this.#totalUsers.next(data.total);
-				this.#users.next(data.items);
+				this._data.next(data.items);
 			});
 
 		return this.users;
@@ -70,10 +69,10 @@ export class UmbUserStore extends UmbStoreBase implements UmbEntityDetailStore<U
 		fetch(`/umbraco/backoffice/users/details/${id}`)
 			.then((res) => res.json())
 			.then((data) => {
-				this.#users.appendOne(data);
+				this._data.appendOne(data);
 			});
 
-		return this.#users.getObservablePart((users: Array<UmbUserStoreItemType>) =>
+		return this._data.getObservablePart((users: Array<UmbUserStoreItemType>) =>
 			users.find((user: UmbUserStoreItemType) => user.id === id)
 		);
 	}
@@ -89,10 +88,10 @@ export class UmbUserStore extends UmbStoreBase implements UmbEntityDetailStore<U
 		fetch(`/umbraco/backoffice/users/getByKeys?${params}`)
 			.then((res) => res.json())
 			.then((data) => {
-				this.#users.append(data);
+				this._data.append(data);
 			});
 
-		return this.#users.getObservablePart((users: Array<UmbUserStoreItemType>) =>
+		return this._data.getObservablePart((users: Array<UmbUserStoreItemType>) =>
 			users.filter((user: UmbUserStoreItemType) => ids.includes(user.id))
 		);
 	}
@@ -105,10 +104,10 @@ export class UmbUserStore extends UmbStoreBase implements UmbEntityDetailStore<U
 		fetch(`/umbraco/backoffice/users/getByName?${params}`)
 			.then((res) => res.json())
 			.then((data) => {
-				this.#users.append(data);
+				this._data.append(data);
 			});
 
-		return this.#users.getObservablePart((users: Array<UmbUserStoreItemType>) =>
+		return this._data.getObservablePart((users: Array<UmbUserStoreItemType>) =>
 			users.filter((user: UmbUserStoreItemType) => user.name.toLocaleLowerCase().includes(name))
 		);
 	}
@@ -124,13 +123,13 @@ export class UmbUserStore extends UmbStoreBase implements UmbEntityDetailStore<U
 				},
 			});
 			const enabledKeys = await res.json();
-			const storedUsers = this.#users.getValue().filter((user) => enabledKeys.includes(user.id));
+			const storedUsers = this._data.getValue().filter((user) => enabledKeys.includes(user.id));
 
 			storedUsers.forEach((user) => {
 				user.status = 'enabled';
 			});
 
-			this.#users.append(storedUsers);
+			this._data.append(storedUsers);
 		} catch (error) {
 			console.error('Enable Users failed', error);
 		}
@@ -147,17 +146,17 @@ export class UmbUserStore extends UmbStoreBase implements UmbEntityDetailStore<U
 				},
 			});
 			const enabledKeys = await res.json();
-			const storedUsers = this.#users.getValue().filter((user) => enabledKeys.includes(user.id));
+			const storedUsers = this._data.getValue().filter((user) => enabledKeys.includes(user.id));
 
 			storedUsers.forEach((user) => {
 				if (userKeys.includes(user.id)) {
 					user.userGroups.push(userGroup);
 				} else {
-					user.userGroups = user.userGroups.filter((group) => group !== userGroup);
+					user.userGroups = user.userGroups.filter((group: any) => group !== userGroup);
 				}
 			});
 
-			this.#users.append(storedUsers);
+			this._data.append(storedUsers);
 		} catch (error) {
 			console.error('Add user group failed', error);
 		}
@@ -174,13 +173,13 @@ export class UmbUserStore extends UmbStoreBase implements UmbEntityDetailStore<U
 				},
 			});
 			const enabledKeys = await res.json();
-			const storedUsers = this.#users.getValue().filter((user) => enabledKeys.includes(user.id));
+			const storedUsers = this._data.getValue().filter((user) => enabledKeys.includes(user.id));
 
 			storedUsers.forEach((user) => {
-				user.userGroups = user.userGroups.filter((group) => group !== userGroup);
+				user.userGroups = user.userGroups.filter((group: any) => group !== userGroup);
 			});
 
-			this.#users.append(storedUsers);
+			this._data.append(storedUsers);
 		} catch (error) {
 			console.error('Remove user group failed', error);
 		}
@@ -197,13 +196,13 @@ export class UmbUserStore extends UmbStoreBase implements UmbEntityDetailStore<U
 				},
 			});
 			const disabledKeys = await res.json();
-			const storedUsers = this.#users.getValue().filter((user) => disabledKeys.includes(user.id));
+			const storedUsers = this._data.getValue().filter((user) => disabledKeys.includes(user.id));
 
 			storedUsers.forEach((user) => {
 				user.status = 'disabled';
 			});
 
-			this.#users.append(storedUsers);
+			this._data.append(storedUsers);
 		} catch (error) {
 			console.error('Disable Users failed', error);
 		}
@@ -220,7 +219,7 @@ export class UmbUserStore extends UmbStoreBase implements UmbEntityDetailStore<U
 				},
 			});
 			const deletedKeys = await res.json();
-			this.#users.remove(deletedKeys);
+			this._data.remove(deletedKeys);
 		} catch (error) {
 			console.error('Delete Users failed', error);
 		}
@@ -237,7 +236,7 @@ export class UmbUserStore extends UmbStoreBase implements UmbEntityDetailStore<U
 				},
 			});
 			const json = await res.json();
-			this.#users.append(json);
+			this._data.append(json);
 		} catch (error) {
 			console.error('Save user error', error);
 		}
@@ -254,7 +253,7 @@ export class UmbUserStore extends UmbStoreBase implements UmbEntityDetailStore<U
 				},
 			});
 			const json = (await res.json()) as UmbUserStoreItemType[];
-			this.#users.append(json);
+			this._data.append(json);
 			return json[0];
 		} catch (error) {
 			console.error('Invite user error', error);

--- a/src/core/mocks/data/data-type.data.ts
+++ b/src/core/mocks/data/data-type.data.ts
@@ -4,21 +4,20 @@ import type {
 	FolderTreeItemResponseModel,
 	DataTypeResponseModel,
 	CreateFolderRequestModel,
+	DataTypeItemResponseModel,
 } from '@umbraco-cms/backoffice/backend-api';
 
 // TODO: investigate why we don't get an type as part of the DataTypeModel
-export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | FolderTreeItemResponseModel> = [
+export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = [
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Folder 1',
 		id: 'dt-folder1',
 		parentId: null,
 		isFolder: true,
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		id: '0cc0eba1-9960-42c9-bf9b-60e150b429ae',
 		parentId: null,
 		name: 'Textstring',
@@ -27,8 +26,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		values: [],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Text',
 		id: 'dt-textBox',
 		parentId: null,
@@ -42,8 +40,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Text Area',
 		id: 'dt-textArea',
 		parentId: null,
@@ -52,8 +49,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		values: [],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'My JS Property Editor',
 		id: 'dt-custom',
 		parentId: null,
@@ -62,8 +58,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		values: [],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Color Picker',
 		id: 'dt-colorPicker',
 		parentId: null,
@@ -118,8 +113,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Content Picker',
 		id: 'dt-contentPicker',
 		parentId: null,
@@ -133,8 +127,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Eye Dropper',
 		id: 'dt-eyeDropper',
 		parentId: null,
@@ -170,8 +163,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Multi URL Picker',
 		id: 'dt-multiUrlPicker',
 		parentId: null,
@@ -201,8 +193,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Multi Node Tree Picker',
 		id: 'dt-multiNodeTreePicker',
 		parentId: null,
@@ -211,8 +202,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		values: [],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Date Picker',
 		id: 'dt-datePicker',
 		parentId: null,
@@ -230,9 +220,8 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		],
 	},
 	{
-		$type: 'data-type',
+		$type: '',
 		name: 'Date Picker With Time',
-		type: 'data-type',
 		id: 'dt-datePicker-time',
 		parentId: null,
 		propertyEditorAlias: 'Umbraco.DateTime',
@@ -249,9 +238,8 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		],
 	},
 	{
-		$type: 'data-type',
+		$type: '',
 		name: 'Time',
-		type: 'data-type',
 		id: 'dt-time',
 		parentId: null,
 		propertyEditorAlias: 'Umbraco.DateTime',
@@ -268,8 +256,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Email',
 		id: 'dt-email',
 		parentId: null,
@@ -278,8 +265,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		values: [],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Multiple Text String',
 		id: 'dt-multipleTextString',
 		parentId: null,
@@ -297,8 +283,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Dropdown',
 		id: 'dt-dropdown',
 		parentId: null,
@@ -307,8 +292,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		values: [],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Slider',
 		id: 'dt-slider',
 		parentId: null,
@@ -342,8 +326,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Toggle',
 		id: 'dt-toggle',
 		parentId: null,
@@ -369,8 +352,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Tags',
 		id: 'dt-tags',
 		parentId: null,
@@ -379,8 +361,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		values: [],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Markdown Editor',
 		id: 'dt-markdownEditor',
 		parentId: null,
@@ -389,8 +370,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		values: [],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Radio Button List',
 		id: 'dt-radioButtonList',
 		parentId: null,
@@ -408,8 +388,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Checkbox List',
 		id: 'dt-checkboxList',
 		parentId: null,
@@ -427,8 +406,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Block List',
 		id: 'dt-blockList',
 		parentId: null,
@@ -437,8 +415,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		values: [],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Media Picker',
 		id: 'dt-mediaPicker',
 		parentId: null,
@@ -447,8 +424,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		values: [],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Image Cropper',
 		id: 'dt-imageCropper',
 		parentId: null,
@@ -457,8 +433,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		values: [],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Upload Field',
 		id: 'dt-uploadField',
 		parentId: null,
@@ -472,8 +447,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Block Grid',
 		id: 'dt-blockGrid',
 		parentId: null,
@@ -482,8 +456,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		values: [],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Collection View',
 		id: 'dt-collectionView',
 		parentId: null,
@@ -492,8 +465,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		values: [],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Icon Picker',
 		id: 'dt-iconPicker',
 		parentId: null,
@@ -502,8 +474,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		values: [],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Number Range',
 		id: 'dt-numberRange',
 		parentId: null,
@@ -512,8 +483,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		values: [],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Order Direction',
 		id: 'dt-orderDirection',
 		parentId: null,
@@ -522,8 +492,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		values: [],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Overlay Size',
 		id: 'dt-overlaySize',
 		parentId: null,
@@ -532,8 +501,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		values: [],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Rich Text Editor',
 		id: 'dt-richTextEditor',
 		parentId: null,
@@ -542,8 +510,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		values: [],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Label',
 		id: 'dt-label',
 		parentId: null,
@@ -552,8 +519,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		values: [],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Integer',
 		id: 'dt-integer',
 		parentId: null,
@@ -562,8 +528,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		values: [],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Decimal',
 		id: 'dt-decimal',
 		parentId: null,
@@ -572,8 +537,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		values: [],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'User Picker',
 		id: 'dt-userPicker',
 		parentId: null,
@@ -582,8 +546,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		values: [],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Member Picker',
 		id: 'dt-memberPicker',
 		parentId: null,
@@ -592,8 +555,7 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		values: [],
 	},
 	{
-		$type: 'data-type',
-		type: 'data-type',
+		$type: '',
 		name: 'Member Group Picker',
 		id: 'dt-memberGroupPicker',
 		parentId: null,
@@ -602,6 +564,13 @@ export const data: Array<(DataTypeResponseModel & { type: 'data-type' }) | Folde
 		values: [],
 	},
 ];
+
+const createDataTypeItem = (item: DataTypeResponseModel | FolderTreeItemResponseModel): DataTypeItemResponseModel => {
+	return {
+		id: item.id,
+		name: item.name,
+	};
+};
 
 // Temp mocked database
 // TODO: all properties are optional in the server schema. I don't think this is correct.
@@ -622,9 +591,9 @@ class UmbDataTypeData extends UmbEntityData<DataTypeResponseModel | FolderTreeIt
 		return childItems.map((item) => createFolderTreeItem(item));
 	}
 
-	getTreeItem(ids: Array<string>): Array<FolderTreeItemResponseModel> {
+	getItems(ids: Array<string>): Array<DataTypeItemResponseModel> {
 		const items = this.data.filter((item) => ids.includes(item.id ?? ''));
-		return items.map((item) => createFolderTreeItem(item));
+		return items.map((item) => createDataTypeItem(item));
 	}
 
 	createFolder(folder: CreateFolderRequestModel & { id: string | undefined }) {
@@ -632,8 +601,7 @@ class UmbDataTypeData extends UmbEntityData<DataTypeResponseModel | FolderTreeIt
 			name: folder.name,
 			id: folder.id,
 			parentId: folder.parentId,
-			$type: 'data-type',
-			type: 'data-type',
+			$type: 'FolderTreeItemResponseModel',
 			isFolder: true,
 			isContainer: false,
 		};

--- a/src/core/mocks/data/data-type.data.ts
+++ b/src/core/mocks/data/data-type.data.ts
@@ -11,6 +11,7 @@ import type {
 export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = [
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Folder 1',
 		id: 'dt-folder1',
 		parentId: null,
@@ -18,6 +19,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		id: '0cc0eba1-9960-42c9-bf9b-60e150b429ae',
 		parentId: null,
 		name: 'Textstring',
@@ -27,6 +29,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Text',
 		id: 'dt-textBox',
 		parentId: null,
@@ -41,6 +44,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Text Area',
 		id: 'dt-textArea',
 		parentId: null,
@@ -50,6 +54,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'My JS Property Editor',
 		id: 'dt-custom',
 		parentId: null,
@@ -59,6 +64,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Color Picker',
 		id: 'dt-colorPicker',
 		parentId: null,
@@ -114,6 +120,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Content Picker',
 		id: 'dt-contentPicker',
 		parentId: null,
@@ -128,6 +135,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Eye Dropper',
 		id: 'dt-eyeDropper',
 		parentId: null,
@@ -164,6 +172,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Multi URL Picker',
 		id: 'dt-multiUrlPicker',
 		parentId: null,
@@ -194,6 +203,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Multi Node Tree Picker',
 		id: 'dt-multiNodeTreePicker',
 		parentId: null,
@@ -203,6 +213,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Date Picker',
 		id: 'dt-datePicker',
 		parentId: null,
@@ -221,6 +232,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Date Picker With Time',
 		id: 'dt-datePicker-time',
 		parentId: null,
@@ -239,6 +251,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Time',
 		id: 'dt-time',
 		parentId: null,
@@ -257,6 +270,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Email',
 		id: 'dt-email',
 		parentId: null,
@@ -266,6 +280,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Multiple Text String',
 		id: 'dt-multipleTextString',
 		parentId: null,
@@ -284,6 +299,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Dropdown',
 		id: 'dt-dropdown',
 		parentId: null,
@@ -293,6 +309,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Slider',
 		id: 'dt-slider',
 		parentId: null,
@@ -327,6 +344,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Toggle',
 		id: 'dt-toggle',
 		parentId: null,
@@ -353,6 +371,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Tags',
 		id: 'dt-tags',
 		parentId: null,
@@ -362,6 +381,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Markdown Editor',
 		id: 'dt-markdownEditor',
 		parentId: null,
@@ -371,6 +391,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Radio Button List',
 		id: 'dt-radioButtonList',
 		parentId: null,
@@ -389,6 +410,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Checkbox List',
 		id: 'dt-checkboxList',
 		parentId: null,
@@ -407,6 +429,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Block List',
 		id: 'dt-blockList',
 		parentId: null,
@@ -416,6 +439,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Media Picker',
 		id: 'dt-mediaPicker',
 		parentId: null,
@@ -425,6 +449,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Image Cropper',
 		id: 'dt-imageCropper',
 		parentId: null,
@@ -434,6 +459,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Upload Field',
 		id: 'dt-uploadField',
 		parentId: null,
@@ -448,6 +474,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Block Grid',
 		id: 'dt-blockGrid',
 		parentId: null,
@@ -457,6 +484,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Collection View',
 		id: 'dt-collectionView',
 		parentId: null,
@@ -466,6 +494,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Icon Picker',
 		id: 'dt-iconPicker',
 		parentId: null,
@@ -475,6 +504,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Number Range',
 		id: 'dt-numberRange',
 		parentId: null,
@@ -484,6 +514,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Order Direction',
 		id: 'dt-orderDirection',
 		parentId: null,
@@ -493,6 +524,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Overlay Size',
 		id: 'dt-overlaySize',
 		parentId: null,
@@ -502,6 +534,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Rich Text Editor',
 		id: 'dt-richTextEditor',
 		parentId: null,
@@ -511,6 +544,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Label',
 		id: 'dt-label',
 		parentId: null,
@@ -520,6 +554,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Integer',
 		id: 'dt-integer',
 		parentId: null,
@@ -529,6 +564,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Decimal',
 		id: 'dt-decimal',
 		parentId: null,
@@ -538,6 +574,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'User Picker',
 		id: 'dt-userPicker',
 		parentId: null,
@@ -547,6 +584,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Member Picker',
 		id: 'dt-memberPicker',
 		parentId: null,
@@ -556,6 +594,7 @@ export const data: Array<DataTypeResponseModel | FolderTreeItemResponseModel> = 
 	},
 	{
 		$type: '',
+		type: 'data-type',
 		name: 'Member Group Picker',
 		id: 'dt-memberGroupPicker',
 		parentId: null,

--- a/src/core/mocks/data/document-type.data.ts
+++ b/src/core/mocks/data/document-type.data.ts
@@ -12,7 +12,7 @@ export const data: Array<DocumentTypeResponseModel> = [
 		defaultTemplateId: null,
 		id: 'all-property-editors-document-type-id',
 		alias: 'blogPost',
-		name: 'Blog Post',
+		name: 'All property editors document type',
 		description: null,
 		icon: 'umb:item-arrangement',
 		allowedAsRoot: true,

--- a/src/core/mocks/data/languages.data.ts
+++ b/src/core/mocks/data/languages.data.ts
@@ -16,6 +16,10 @@ class UmbLanguagesData extends UmbData<LanguageResponseModel> {
 		return this.data.find((item) => item.isoCode === isoCode);
 	}
 
+	getItems(isoCodes: Array<string>) {
+		return this.data.filter((item) => isoCodes.indexOf(item.isoCode || '') !== -1);
+	}
+
 	insert(language: LanguageResponseModel) {
 		const foundIndex = this.data.findIndex((item) => item.isoCode === language.isoCode);
 

--- a/src/core/mocks/data/utils.ts
+++ b/src/core/mocks/data/utils.ts
@@ -25,6 +25,7 @@ export const createEntityTreeItem = (item: any): EntityTreeItemResponseModel => 
 export const createFolderTreeItem = (item: any): FolderTreeItemResponseModel => {
 	return {
 		...createEntityTreeItem(item),
+		$type: 'FolderTreeItemResponseModel',
 		isFolder: item.isFolder,
 	};
 };

--- a/src/core/mocks/domains/data-type/item.handlers.ts
+++ b/src/core/mocks/domains/data-type/item.handlers.ts
@@ -7,7 +7,7 @@ export const itemHandlers = [
 	rest.get(umbracoPath(`${slug}/item`), (req, res, ctx) => {
 		const ids = req.url.searchParams.getAll('id');
 		if (!ids) return;
-		const items = umbDataTypeData.getTreeItem(ids);
+		const items = umbDataTypeData.getItems(ids);
 		return res(ctx.status(200), ctx.json(items));
 	}),
 ];

--- a/src/core/mocks/domains/language.handlers.ts
+++ b/src/core/mocks/domains/language.handlers.ts
@@ -5,6 +5,13 @@ import { umbracoPath } from '@umbraco-cms/backoffice/utils';
 
 // TODO: add schema
 export const handlers = [
+	rest.get(umbracoPath('/language/item'), (req, res, ctx) => {
+		const isoCodes = req.url.searchParams.getAll('isoCode');
+		if (!isoCodes) return;
+		const items = umbLanguagesData.getItems(isoCodes);
+		return res(ctx.status(200), ctx.json(items));
+	}),
+
 	rest.get(umbracoPath('/language'), (req, res, ctx) => {
 		const skip = req.url.searchParams.get('skip');
 		const skipNumber = skip ? Number.parseInt(skip) : undefined;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,10 +39,12 @@
 			"@umbraco-cms/backoffice/store": ["libs/store"],
 			"@umbraco-cms/backoffice/utils": ["libs/utils"],
 			"@umbraco-cms/backoffice/workspace": ["libs/workspace"],
+			"@umbraco-cms/backoffice/picker": ["libs/picker"],
 			"@umbraco-cms/internal/lit-element": ["src/core/lit-element"],
 			"@umbraco-cms/internal/modal": ["src/core/modal"],
 			"@umbraco-cms/internal/router": ["src/core/router"],
 			"@umbraco-cms/internal/test-utils": ["utils/test-utils.ts"]
+
 		}
 	},
 	"include": ["src/**/*.ts", "apps/**/*.ts", "libs/**/*.ts", "e2e/**/*.ts"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,7 +39,7 @@
 			"@umbraco-cms/backoffice/store": ["libs/store"],
 			"@umbraco-cms/backoffice/utils": ["libs/utils"],
 			"@umbraco-cms/backoffice/workspace": ["libs/workspace"],
-			"@umbraco-cms/backoffice/picker": ["libs/picker-input"],
+			"@umbraco-cms/backoffice/picker-input": ["libs/picker-input"],
 			"@umbraco-cms/internal/lit-element": ["src/core/lit-element"],
 			"@umbraco-cms/internal/modal": ["src/core/modal"],
 			"@umbraco-cms/internal/router": ["src/core/router"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,12 +39,11 @@
 			"@umbraco-cms/backoffice/store": ["libs/store"],
 			"@umbraco-cms/backoffice/utils": ["libs/utils"],
 			"@umbraco-cms/backoffice/workspace": ["libs/workspace"],
-			"@umbraco-cms/backoffice/picker": ["libs/picker"],
+			"@umbraco-cms/backoffice/picker": ["libs/picker-input"],
 			"@umbraco-cms/internal/lit-element": ["src/core/lit-element"],
 			"@umbraco-cms/internal/modal": ["src/core/modal"],
 			"@umbraco-cms/internal/router": ["src/core/router"],
 			"@umbraco-cms/internal/test-utils": ["utils/test-utils.ts"]
-
 		}
 	},
 	"include": ["src/**/*.ts", "apps/**/*.ts", "libs/**/*.ts", "e2e/**/*.ts"],

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -56,7 +56,7 @@ export default {
 						'@umbraco-cms/backoffice/store': './libs/store/index.ts',
 						'@umbraco-cms/backoffice/utils': './libs/utils/index.ts',
 						'@umbraco-cms/backoffice/workspace': './libs/workspace/index.ts',
-						'@umbraco-cms/backoffice/picker': './libs/picker/index.ts',
+						'@umbraco-cms/backoffice/picker-input': './libs/picker-input/index.ts',
 						'@umbraco-cms/internal/lit-element': './src/core/lit-element/index.ts',
 						'@umbraco-cms/internal/modal': './src/core/modal/index.ts',
 						'@umbraco-cms/internal/router': './src/core/router/index.ts',

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -56,10 +56,11 @@ export default {
 						'@umbraco-cms/backoffice/store': './libs/store/index.ts',
 						'@umbraco-cms/backoffice/utils': './libs/utils/index.ts',
 						'@umbraco-cms/backoffice/workspace': './libs/workspace/index.ts',
+						'@umbraco-cms/backoffice/picker': './libs/picker/index.ts',
 						'@umbraco-cms/internal/lit-element': './src/core/lit-element/index.ts',
 						'@umbraco-cms/internal/modal': './src/core/modal/index.ts',
 						'@umbraco-cms/internal/router': './src/core/router/index.ts',
-						'@umbraco-cms/internal/test-utils': './utils/test-utils.ts'
+						'@umbraco-cms/internal/test-utils': './utils/test-utils.ts',
 					},
 				},
 			},


### PR DESCRIPTION
This PR adds a Data Type input + Data Type picker.

During the development of the picker, I realised we had some redundant logic for pickers. I have therefore created a PickerContext that can be used to build pickers faster. It helps with opening a the picker modal, keep track of the selection, removing items etc.

The PR also includes update to the stores, so we now can support the new item model.

Creating a new Picker Context:

```ts
export class UmbDataTypePickerContext extends UmbPickerContext<DataTypeItemResponseModel> {
	constructor(host: UmbControllerHostElement) {
		super(host, 'Umb.Repository.DataType', UMB_DATA_TYPE_PICKER_MODAL);
	}
}
```

Using in a Custom Element

```ts
@customElement('umb-data-type-input')
export class UmbDataTypeInputElement extends UmbLitElement {

  @state()
  private _items?: Array<DataTypeItemResponseModel>;

  #pickerContext = new UmbDataTypePickerContext(this);

  constructor() {
    super();
    this.observe(this.#pickerContext.selection, (selection) => (this._selection = selection));
    this.observe(this.#pickerContext.selectedItems, (selectedItems) => (this._items = selectedItems));
  }

  #openPicker() {
    this.#pickerContext.openPicker();
  }

  #removeItem (item) {
    this.#pickerContext.requestRemoveItem(item.id)
  }

  render() {
    return html`<div>Your template</div>`;
  }
}
```