### PR TITLE
Bugfix: Load plugins from mocked App_Plugins folder

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,10 @@ export const plugins: PluginOption[] = [
 				src: 'public-assets/icons/*.js',
 				dest: 'icons',
 			},
+			{
+				src: 'public-assets/App_Plugins/*.js',
+				dest: 'App_Plugins',
+			},
 		],
 	}),
 	viteTSConfigPaths(),


### PR DESCRIPTION
Vite couldn't load the mocked extension beacuse the files were not copied to the public folder. The PR adds the App_Plugin files to be copied to bypass Vites dynamic import limit.