### PR TITLE
Bugfix: add all props to scaffold model

### DIFF
--- a/src/backoffice/settings/data-types/repository/sources/data-type.server.data.ts
+++ b/src/backoffice/settings/data-types/repository/sources/data-type.server.data.ts
@@ -56,6 +56,10 @@ export class UmbDataTypeServerDataSource
 		const data: CreateDataTypeRequestModel = {
 			id: uuidv4(),
 			parentId,
+			name: '',
+			propertyEditorAlias: undefined,
+			propertyEditorUiAlias: null,
+			values: [],
 		};
 
 		return { data };


### PR DESCRIPTION
The server complained about a missing values prop when creating new data types. I have added it to the scaffold so you can create a new data type without updating any of the config values in the UI.