### PR TITLE
Feature: UmbId Lib

### DIFF
--- a/libs/id/index.ts
+++ b/libs/id/index.ts
@@ -1,0 +1,11 @@
+import { v4, validate } from 'uuid';
+
+export class UmbId {
+	public static new() {
+		return v4();
+	}
+
+	public static validate(id: string) {
+		return validate(id);
+	}
+}

--- a/libs/modal/modal-handler.ts
+++ b/libs/modal/modal-handler.ts
@@ -4,7 +4,7 @@ import type {
 	UUIModalSidebarElement,
 	UUIModalSidebarSize,
 } from '@umbraco-ui/uui';
-import { v4 as uuidv4 } from 'uuid';
+import { UmbId } from '@umbraco-cms/backoffice/id';
 import { BehaviorSubject } from 'rxjs';
 import { UmbModalConfig, UmbModalType } from './modal.context';
 import { UmbModalToken } from './token/modal-token';
@@ -62,7 +62,7 @@ export class UmbModalHandlerClass<ModalData extends object = object, ModalResult
 		config?: UmbModalConfig
 	) {
 		this.#host = host;
-		this.key = config?.key || uuidv4();
+		this.key = config?.key || UmbId.new();
 
 		if (modalAlias instanceof UmbModalToken) {
 			this.type = modalAlias.getDefaultConfig()?.type || this.type;

--- a/libs/modal/modal-route-registration.ts
+++ b/libs/modal/modal-route-registration.ts
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from 'uuid';
+import { UmbId } from '@umbraco-cms/backoffice/id';
 import { UmbModalHandler } from './modal-handler';
 import { UmbModalConfig, UmbModalContext } from './modal.context';
 import { UmbModalToken } from './token/modal-token';
@@ -26,7 +26,7 @@ export class UmbModalRouteRegistration<UmbModalTokenData extends object = object
 		path: string,
 		modalConfig?: UmbModalConfig
 	) {
-		this.#key = modalConfig?.key || uuidv4();
+		this.#key = modalConfig?.key || UmbId.new();
 		this.#modalAlias = modalAlias;
 		this.#path = path;
 		this.#modalConfig = { ...modalConfig, key: this.#key };

--- a/libs/notification/notification-handler.test.ts
+++ b/libs/notification/notification-handler.test.ts
@@ -1,8 +1,6 @@
 import { assert, expect } from '@open-wc/testing';
-import { validate as uuidValidate } from 'uuid';
-
+import { UmbId } from '@umbraco-cms/backoffice/id';
 import { UmbNotificationHandler } from './notification-handler';
-
 import type { UmbNotificationOptions } from './notification.context';
 
 describe('UmbNotificationHandler', () => {
@@ -17,7 +15,7 @@ describe('UmbNotificationHandler', () => {
 		describe('properties', () => {
 			it('has a key property', () => {
 				expect(notificationHandler).to.have.property('key');
-				expect(uuidValidate(notificationHandler.key)).to.be.true;
+				expect(UmbId.validate(notificationHandler.key)).to.be.true;
 			});
 
 			it('has an element property', () => {

--- a/libs/notification/notification-handler.ts
+++ b/libs/notification/notification-handler.ts
@@ -1,5 +1,5 @@
 import { UUIToastNotificationElement } from '@umbraco-ui/uui';
-import { v4 as uuidv4 } from 'uuid';
+import { UmbId } from '@umbraco-cms/backoffice/id';
 import type { UmbNotificationOptions, UmbNotificationColor, UmbNotificationDefaultData } from './notification.context';
 
 /**
@@ -27,7 +27,7 @@ export class UmbNotificationHandler {
 	 * @memberof UmbNotificationHandler
 	 */
 	constructor(options: UmbNotificationOptions) {
-		this.key = uuidv4();
+		this.key = UmbId.new();
 		this.color = options.color || this._defaultColor;
 		this.duration = options.duration !== undefined ? options.duration : this._defaultDuration;
 

--- a/libs/utils/generate-guid.ts
+++ b/libs/utils/generate-guid.ts
@@ -1,4 +1,0 @@
-import { v4 as uuid } from 'uuid';
-export function generateGuid() {
-	return uuid();
-}

--- a/libs/utils/index.ts
+++ b/libs/utils/index.ts
@@ -1,3 +1,2 @@
 export * from './umbraco-path';
 export * from './udi-service';
-export * from './generate-guid';

--- a/src/backoffice/documents/documents/repository/sources/document.server.data.ts
+++ b/src/backoffice/documents/documents/repository/sources/document.server.data.ts
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from 'uuid';
+import { UmbId } from '@umbraco-cms/backoffice/id';
 import type { UmbDataSource } from '@umbraco-cms/backoffice/repository';
 import {
 	DocumentResource,
@@ -59,7 +59,7 @@ export class UmbDocumentServerDataSource
 		const data: DocumentResponseModel = {
 			urls: [],
 			templateId: null,
-			id: uuidv4(),
+			id: UmbId.new(),
 			contentTypeId: documentTypeId,
 			values: [],
 			variants: [

--- a/src/backoffice/settings/data-types/repository/sources/data-type-folder.server.data.ts
+++ b/src/backoffice/settings/data-types/repository/sources/data-type-folder.server.data.ts
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from 'uuid';
+import { UmbId } from '@umbraco-cms/backoffice/id';
 import { UmbFolderDataSource } from '@umbraco-cms/backoffice/repository';
 import {
 	DataTypeResource,
@@ -37,7 +37,7 @@ export class UmbDataTypeFolderServerDataSource implements UmbFolderDataSource {
 		const scaffold: FolderReponseModel = {
 			$type: 'FolderReponseModel',
 			name: '',
-			id: uuidv4(),
+			id: UmbId.new(),
 			parentId,
 		};
 

--- a/src/backoffice/settings/data-types/repository/sources/data-type.server.data.ts
+++ b/src/backoffice/settings/data-types/repository/sources/data-type.server.data.ts
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from 'uuid';
+import { UmbId } from '@umbraco-cms/backoffice/id';
 import { UmbDataSource } from '@umbraco-cms/backoffice/repository';
 import {
 	DataTypeResource,
@@ -54,7 +54,7 @@ export class UmbDataTypeServerDataSource
 	 */
 	async createScaffold(parentId?: string | null) {
 		const data: CreateDataTypeRequestModel = {
-			id: uuidv4(),
+			id: UmbId.new(),
 			parentId,
 			name: '',
 			propertyEditorAlias: undefined,

--- a/src/backoffice/shared/components/table/table.stories.ts
+++ b/src/backoffice/shared/components/table/table.stories.ts
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/web-components';
 import './table.element';
-import { v4 as uuidv4 } from 'uuid';
+import { UmbId } from '@umbraco-cms/backoffice/id';
 import type { UmbTableElement, UmbTableColumn, UmbTableConfig, UmbTableItem } from './table.element';
 
 const meta: Meta<UmbTableElement> = {
@@ -26,7 +26,7 @@ const columns: Array<UmbTableColumn> = [
 
 const items: Array<UmbTableItem> = [
 	{
-		id: uuidv4(),
+		id: UmbId.new(),
 		icon: 'umb:wand',
 		data: [
 			{
@@ -40,7 +40,7 @@ const items: Array<UmbTableItem> = [
 		],
 	},
 	{
-		id: uuidv4(),
+		id: UmbId.new(),
 		icon: 'umb:document',
 		data: [
 			{
@@ -54,7 +54,7 @@ const items: Array<UmbTableItem> = [
 		],
 	},
 	{
-		id: uuidv4(),
+		id: UmbId.new(),
 		icon: 'umb:user',
 		data: [
 			{

--- a/src/backoffice/shared/components/workspace/workspace-context/entity-manager-controller.ts
+++ b/src/backoffice/shared/components/workspace/workspace-context/entity-manager-controller.ts
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from 'uuid';
+import { UmbId } from '@umbraco-cms/backoffice/id';
 import { UmbContextConsumerController, UmbContextToken } from '@umbraco-cms/backoffice/context-api';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller';
 import {
@@ -90,7 +90,7 @@ export class UmbEntityWorkspaceManager<
 
 	create = (parentId: string | null) => {
 		this.#isNew = true;
-		this._entityId = uuidv4();
+		this._entityId = UmbId.new();
 		this._createAtParentKey = parentId;
 	};
 

--- a/src/backoffice/shared/components/workspace/workspace-context/workspace-structure-manager.class.ts
+++ b/src/backoffice/shared/components/workspace/workspace-context/workspace-structure-manager.class.ts
@@ -1,5 +1,5 @@
+import { UmbId } from '@umbraco-cms/backoffice/id';
 import { UmbDocumentTypeRepository } from '../../../../documents/document-types/repository/document-type.repository';
-import { generateGuid } from '@umbraco-cms/backoffice/utils';
 import {
 	DocumentTypeResponseModel,
 	DocumentTypePropertyTypeResponseModel,
@@ -162,7 +162,7 @@ export class UmbWorkspacePropertyStructureManager<R extends UmbDocumentTypeRepos
 		documentTypeKey = documentTypeKey ?? this.#rootDocumentTypeId!;
 
 		const container: PropertyTypeContainerResponseModelBaseModel = {
-			id: generateGuid(),
+			id: UmbId.new(),
 			parentId: parentId,
 			name: 'New',
 			type: type,
@@ -207,7 +207,7 @@ export class UmbWorkspacePropertyStructureManager<R extends UmbDocumentTypeRepos
 		documentTypeId = documentTypeId ?? this.#rootDocumentTypeId!;
 
 		const property: PropertyTypeResponseModelBaseModel = {
-			id: generateGuid(),
+			id: UmbId.new(),
 			containerId: containerId,
 			//sortOrder: sortOrder ?? 0,
 		};

--- a/src/backoffice/templating/templates/repository/sources/template.detail.server.data.ts
+++ b/src/backoffice/templating/templates/repository/sources/template.detail.server.data.ts
@@ -1,4 +1,4 @@
-import { v4 as uuid } from 'uuid';
+import { UmbId } from '@umbraco-cms/backoffice/id';
 import {
 	TemplateResponseModel,
 	TemplateResource,
@@ -49,7 +49,7 @@ export class UmbTemplateDetailServerDataSource
 		const error = undefined;
 		const data: TemplateResponseModel = {
 			$type: '',
-			id: uuid(),
+			id: UmbId.new(),
 			name: '',
 			alias: '',
 			content: '',

--- a/src/backoffice/translation/dictionary/repository/sources/dictionary.detail.server.data.ts
+++ b/src/backoffice/translation/dictionary/repository/sources/dictionary.detail.server.data.ts
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from 'uuid';
+import { UmbId } from '@umbraco-cms/backoffice/id';
 import type { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller';
 import { tryExecuteAndNotify } from '@umbraco-cms/backoffice/resources';
 import {
@@ -35,7 +35,7 @@ export class UmbDictionaryDetailServerDataSource
 	 */
 	async createScaffold(parentId?: string | null, name?: string) {
 		const data = {
-			id: uuidv4(),
+			id: UmbId.new(),
 			parentId,
 			name,
 			translations: [],

--- a/src/core/mocks/data/entity.data.ts
+++ b/src/core/mocks/data/entity.data.ts
@@ -1,4 +1,4 @@
-import { v4 as uuid } from 'uuid';
+import { UmbId } from '@umbraco-cms/backoffice/id';
 import { UmbData } from './data';
 import type { Entity } from '@umbraco-cms/backoffice/models';
 
@@ -71,7 +71,7 @@ export class UmbEntityData<T extends Entity> extends UmbData<T> {
 			return {
 				...item,
 				name: item.name + ' Copy',
-				id: uuid(),
+				id: UmbId.new(),
 				parentId: destinationKey,
 			};
 		});

--- a/src/core/mocks/data/template.data.ts
+++ b/src/core/mocks/data/template.data.ts
@@ -1,4 +1,4 @@
-import { v4 as uuid } from 'uuid';
+import { UmbId } from '@umbraco-cms/backoffice/id';
 import { UmbEntityData } from './entity.data';
 import { createEntityTreeItem } from './utils';
 import {
@@ -101,7 +101,7 @@ class UmbTemplateData extends UmbEntityData<TemplateDBItem> {
 	create(templateData: TemplateModelBaseModel) {
 		const template = {
 			$type: '',
-			id: uuid(),
+			id: UmbId.new(),
 			...templateData,
 		};
 		this.data.push(template);

--- a/src/core/mocks/domains/package.handlers.ts
+++ b/src/core/mocks/domains/package.handlers.ts
@@ -1,5 +1,5 @@
+import { UmbId } from '@umbraco-cms/backoffice/id';
 import { rest } from 'msw';
-import { v4 as uuidv4 } from 'uuid';
 
 import { umbracoPath } from '@umbraco-cms/backoffice/utils';
 import {
@@ -54,7 +54,7 @@ export const handlers = [
 	rest.post(umbracoPath('/package/created'), async (_req, res, ctx) => {
 		//save
 		const data: PackageMigrationStatusResponseModel = await _req.json();
-		const newPackage: PackageDefinitionResponseModel = { ...data, id: uuidv4() };
+		const newPackage: PackageDefinitionResponseModel = { ...data, id: UmbId.new() };
 		packageArray.push(newPackage);
 		return res(ctx.status(200), ctx.json<PackageDefinitionResponseModel>(newPackage));
 	}),

--- a/src/core/mocks/domains/users.handlers.ts
+++ b/src/core/mocks/domains/users.handlers.ts
@@ -1,5 +1,4 @@
 import { rest } from 'msw';
-import { v4 as uuidv4 } from 'uuid';
 
 import { umbUsersData } from '../data/users.data';
 import { umbracoPath } from '@umbraco-cms/backoffice/utils';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,7 @@
 			"@umbraco-cms/backoffice/utils": ["libs/utils"],
 			"@umbraco-cms/backoffice/workspace": ["libs/workspace"],
 			"@umbraco-cms/backoffice/picker-input": ["libs/picker-input"],
+			"@umbraco-cms/backoffice/id": ["libs/id"],
 			"@umbraco-cms/internal/lit-element": ["src/core/lit-element"],
 			"@umbraco-cms/internal/modal": ["src/core/modal"],
 			"@umbraco-cms/internal/router": ["src/core/router"],

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -57,6 +57,7 @@ export default {
 						'@umbraco-cms/backoffice/utils': './libs/utils/index.ts',
 						'@umbraco-cms/backoffice/workspace': './libs/workspace/index.ts',
 						'@umbraco-cms/backoffice/picker-input': './libs/picker-input/index.ts',
+						'@umbraco-cms/backoffice/id': './libs/id/index.ts',
 						'@umbraco-cms/internal/lit-element': './src/core/lit-element/index.ts',
 						'@umbraco-cms/internal/modal': './src/core/modal/index.ts',
 						'@umbraco-cms/internal/router': './src/core/router/index.ts',


### PR DESCRIPTION
A small util to generate and validate ids. 

I realised too late that we already had one, but it was only used in a few places.

I have kept the naming to id, so it matches the code where we need to generate an id.

The util is made so we only have one reference to the uuid external package.

### usage

```ts
import { UmbId } from '@umbraco-cms/backoffice/id'

const id = UmbId.new();
const validId = UmbId.validate(id);
```