### PR TITLE
Remove Tree Picker Modal Kind

### DIFF
--- a/libs/extensions-registry/models/index.ts
+++ b/libs/extensions-registry/models/index.ts
@@ -8,7 +8,7 @@ import type { ManifestHeaderApp, ManifestHeaderAppButtonKind } from './header-ap
 import type { ManifestHealthCheck } from './health-check.model';
 import type { ManifestMenu } from './menu.model';
 import type { ManifestMenuItem, ManifestMenuItemTreeKind } from './menu-item.model';
-import type { ManifestModal, ManifestModalTreePickerKind } from './modal.model';
+import type { ManifestModal } from './modal.model';
 import type { ManifestPackageView } from './package-view.model';
 import type { ManifestPropertyAction } from './property-action.model';
 import type { ManifestPropertyEditorUI, ManifestPropertyEditorModel } from './property-editor.model';
@@ -72,7 +72,6 @@ export type ManifestTypes =
 	| ManifestMenuItem
 	| ManifestMenuItemTreeKind
 	| ManifestModal
-	| ManifestModalTreePickerKind
 	| ManifestPackageView
 	| ManifestPropertyAction
 	| ManifestPropertyEditorModel

--- a/libs/extensions-registry/models/modal.model.ts
+++ b/libs/extensions-registry/models/modal.model.ts
@@ -3,13 +3,3 @@ import type { ManifestElement } from '.';
 export interface ManifestModal extends ManifestElement {
 	type: 'modal';
 }
-
-export interface ManifestModalTreePickerKind extends ManifestModal {
-	type: 'modal';
-	kind: 'treePicker';
-	meta: MetaModalTreePickerKind;
-}
-
-export interface MetaModalTreePickerKind {
-	treeAlias: string;
-}

--- a/src/backoffice/core/index.ts
+++ b/src/backoffice/core/index.ts
@@ -19,18 +19,6 @@ export const manifests: Array<ManifestTypes | ManifestKind> = [
 	...propertyActionManifests,
 	...propertyEditorManifests,
 	...modalManifests,
-	// TODO: where should these live?
-	{
-		type: 'kind',
-		alias: 'Umb.Kind.TreePickerModal',
-		matchKind: 'treePicker',
-		matchType: 'modal',
-		manifest: {
-			type: 'modal',
-			kind: 'treePicker',
-			elementName: 'umb-tree-picker-modal',
-		},
-	},
 ];
 
 export const onInit: UmbEntrypointOnInit = (host, extensionRegistry) => {

--- a/src/backoffice/core/modals/tree-picker/tree-picker-modal.element.ts
+++ b/src/backoffice/core/modals/tree-picker/tree-picker-modal.element.ts
@@ -2,7 +2,6 @@ import { css, html } from 'lit';
 import { UUITextStyles } from '@umbraco-ui/uui-css/lib';
 import { customElement, state } from 'lit/decorators.js';
 import type { UmbTreeElement } from '../../components/tree/tree.element';
-import { ManifestModalTreePickerKind } from '@umbraco-cms/backoffice/extensions-registry';
 import { UmbTreePickerModalData, UmbPickerModalResult } from '@umbraco-cms/backoffice/modal';
 import { UmbModalBaseElement } from '@umbraco-cms/internal/modal';
 import { TreeItemPresentationModel } from '@umbraco-cms/backoffice/backend-api';
@@ -10,8 +9,7 @@ import { TreeItemPresentationModel } from '@umbraco-cms/backoffice/backend-api';
 @customElement('umb-tree-picker-modal')
 export class UmbTreePickerModalElement<TreeItemType extends TreeItemPresentationModel> extends UmbModalBaseElement<
 	UmbTreePickerModalData<TreeItemType>,
-	UmbPickerModalResult,
-	ManifestModalTreePickerKind
+	UmbPickerModalResult
 > {
 	@state()
 	_selection: Array<string | null> = [];


### PR DESCRIPTION
When doing the tree picker modals I started out with a kind type. I later switched to another solution. This is leftover files that didn't get cleanup up.