### PR TITLE
Sort Database install types by sortOrder int value from server

### DIFF
--- a/src/apps/installer/database/installer-database.element.ts
+++ b/src/apps/installer/database/installer-database.element.ts
@@ -57,7 +57,23 @@ export class UmbInstallerDatabaseElement extends UmbLitElement {
 		if (!this._installerContext) return;
 
 		this.observe(this._installerContext.settings, (settings) => {
+
 			this._databases = settings?.databases ?? [];
+
+			// Sort the databases array if not empty and by sortOrder if it exists
+			if (this._databases.length > 0) {
+				const databasesCopy = [...this._databases];
+				databasesCopy.sort((a, b) => {
+				  if (a.sortOrder === undefined) {
+					return -1;
+				  }
+				  if (b.sortOrder === undefined) {
+					return 1;
+				  }
+				  return a.sortOrder - b.sortOrder;
+				});
+				this._databases = databasesCopy;
+			}
 
 			// If there is an isConfigured database in the databases array then we can skip the database selection step
 			// and just use that.


### PR DESCRIPTION
The database types from the server has a int property designed for the sortOrder to ensure SQLite is first.

![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/1389894/b2d07987-9dea-4830-8ea7-6e297ffd3f65)


With this PR applied the installer will now show SQLite first as opposed to the Custom DB option (which is the first item in the array)

![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/1389894/b07c1b8a-5279-46ec-8607-c9b7fc4ffe41)
