### PR TITLE
ElementType & ClassType causing WAY too much info in JSON Schema

### DIFF
--- a/src/libs/extension-api/types.ts
+++ b/src/libs/extension-api/types.ts
@@ -71,6 +71,10 @@ export interface ManifestWithLoader<LoaderReturnType> extends ManifestBase {
  */
 export interface ManifestClass<ClassType = unknown>
 	extends ManifestWithLoader<{ default: ClassConstructor<ClassType> }> {
+	
+	/**
+	 * @TJS-ignore
+	 */
 	readonly CLASS_TYPE?: ClassType;
 
 	/**
@@ -97,6 +101,10 @@ export interface ManifestClassWithClassConstructor<T = unknown> extends Manifest
 
 export interface ManifestElement<ElementType extends HTMLElement = HTMLElement>
 	extends ManifestWithLoader<{ default: ClassConstructor<ElementType> } | Omit<object, 'default'>> {
+
+	/**
+	 * @TJS-ignore
+	 */
 	readonly ELEMENT_TYPE?: ElementType;
 
 	/**


### PR DESCRIPTION
34K lines down to about 2K lines.
Originally it was including a lot about HTMLElements, Window, Document, CSS attributes etc was way too generic and too much info.

Still need to improve the JSON Schema and ensure all properties have good descriptions or examples etc...