### PR TITLE
Bug-fix: elements being connected-disconnected and then connected

### DIFF
--- a/src/packages/core/section/section-default.element.ts
+++ b/src/packages/core/section/section-default.element.ts
@@ -1,7 +1,7 @@
 import type { UmbWorkspaceElement } from '../workspace/workspace.element.js';
 import type { UmbSectionViewsElement } from './section-views/section-views.element.js';
 import { UUITextStyles } from '@umbraco-cms/backoffice/external/uui';
-import { css, html, nothing , customElement, property, state } from '@umbraco-cms/backoffice/external/lit';
+import { css, html, nothing , customElement, property, state, PropertyValueMap } from '@umbraco-cms/backoffice/external/lit';
 import { map } from '@umbraco-cms/backoffice/external/rxjs';
 import {
 	ManifestSection,
@@ -28,10 +28,10 @@ export class UmbSectionDefaultElement extends UmbLitElement implements UmbSectio
 	@state()
 	private _menus?: Array<Omit<ManifestSectionSidebarApp, 'kind'>>;
 
-	connectedCallback() {
-		super.connectedCallback();
-		this.#observeSectionSidebarApps();
+	constructor() {
+		super();
 		this.#createRoutes();
+		this.#observeSectionSidebarApps();
 	}
 
 	#createRoutes() {
@@ -60,7 +60,7 @@ export class UmbSectionDefaultElement extends UmbLitElement implements UmbSectio
 				.extensionsOfType('sectionSidebarApp')
 				.pipe(
 					map((manifests) =>
-						manifests.filter((manifest) => manifest.conditions.sections.includes(this.manifest?.alias || ''))
+						manifests.filter((manifest) => manifest.conditions.sections.includes(this.manifest?.alias ?? ''))
 					)
 				),
 			(manifests) => {
@@ -78,7 +78,7 @@ export class UmbSectionDefaultElement extends UmbLitElement implements UmbSectio
 							<umb-extension-slot
 								type="sectionSidebarApp"
 								.filter=${(items: ManifestSectionSidebarApp) =>
-									items.conditions.sections.includes(this.manifest?.alias || '')}></umb-extension-slot>
+									items.conditions.sections.includes(this.manifest?.alias ?? '')}></umb-extension-slot>
 						</umb-section-sidebar>
 				  `
 				: nothing}

--- a/src/packages/core/tree/tree.context.ts
+++ b/src/packages/core/tree/tree.context.ts
@@ -44,7 +44,6 @@ export class UmbTreeContextBase<TreeItemType extends TreeItemPresentationModel>
 	public selectableFilter?: (item: TreeItemType) => boolean = () => true;
 
 	#treeAlias?: string;
-	#treeManifestObserver?: UmbObserverController<any>;
 
 	#initResolver?: () => void;
 	#initialized = false;
@@ -141,9 +140,8 @@ export class UmbTreeContextBase<TreeItemType extends TreeItemPresentationModel>
 	}
 
 	#observeTreeManifest() {
-		this.#treeManifestObserver?.destroy();
 
-		this.#treeManifestObserver = new UmbObserverController<any>(
+		new UmbObserverController<any>(
 			this.host,
 			umbExtensionsRegistry
 				.extensionsOfType('tree')
@@ -151,7 +149,8 @@ export class UmbTreeContextBase<TreeItemType extends TreeItemPresentationModel>
 			async (treeManifest) => {
 				if (!treeManifest) return;
 				this.#observeRepository(treeManifest);
-			}
+			},
+			'_observeTreeManifest'
 		);
 	}
 
@@ -172,7 +171,8 @@ export class UmbTreeContextBase<TreeItemType extends TreeItemPresentationModel>
 				} catch (error) {
 					throw new Error('Could not create repository with alias: ' + repositoryAlias + '');
 				}
-			}
+			},
+			'_observeRepository'
 		);
 	}
 }

--- a/src/packages/core/tree/tree.element.ts
+++ b/src/packages/core/tree/tree.element.ts
@@ -76,10 +76,11 @@ export class UmbTreeElement extends UmbLitElement {
 
 	#rootItemsObserver?: UmbObserverController<Array<TreeItemPresentationModel>>;
 
-	connectedCallback(): void {
-		super.connectedCallback();
+	constructor() {
+		super();
 		this.#requestTreeRoot();
 	}
+
 
 	async #requestTreeRoot() {
 		if (!this.#treeContext?.requestTreeRoot) throw new Error('Tree does not support root');


### PR DESCRIPTION
We had an issue of the tree not loading at first view.

this was because it was connected, disconnected and then connected.

This PR fixes so extension-slot updates at the right times, making it less likely to happen — hopefully not happen.