### PR TITLE
More tidying up

### DIFF
--- a/src/packages/core/property-actions/common/copy/property-action-copy.element.ts
+++ b/src/packages/core/property-actions/common/copy/property-action-copy.element.ts
@@ -5,6 +5,7 @@ import {
 	UmbNotificationContext,
 	UMB_NOTIFICATION_CONTEXT_TOKEN,
 } from '@umbraco-cms/backoffice/notification';
+import { UMB_WORKSPACE_PROPERTY_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/workspace';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 
 @customElement('umb-property-action-copy')
@@ -17,9 +18,9 @@ export class UmbPropertyActionCopyElement extends UmbLitElement implements UmbPr
 	constructor() {
 		super();
 
-		// TODO implement a property context
-		this.consumeContext('umbProperty', (property) => {
-			console.log('PROPERTY', property);
+		this.consumeContext(UMB_WORKSPACE_PROPERTY_CONTEXT_TOKEN, (property) => {
+			//console.log('Got a reference to the editor element', property.getEditor());
+			// Be aware that the element might switch, so using the direct reference is not recommended, instead observe the .element Observable()
 		});
 
 		this.consumeContext(UMB_NOTIFICATION_CONTEXT_TOKEN, (instance) => {

--- a/src/packages/core/workspace/workspace-property/workspace-property.context.ts
+++ b/src/packages/core/workspace/workspace-property/workspace-property.context.ts
@@ -1,4 +1,6 @@
 import { UmbWorkspaceVariableEntityContextInterface } from '../workspace-context/workspace-variable-entity-context.interface.js';
+import { UmbPropertyEditorExtensionElement } from '../../extension-registry/interfaces/property-editor-ui-extension-element.interface.js';
+import { BehaviorSubject } from '@umbraco-cms/backoffice/external/rxjs';
 import { UMB_WORKSPACE_VARIANT_CONTEXT_TOKEN, UMB_ENTITY_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/workspace';
 import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 import type { DataTypeResponseModel } from '@umbraco-cms/backoffice/backend-api';
@@ -36,6 +38,15 @@ export class UmbWorkspacePropertyContext<ValueType = any> {
 	public readonly description = this._data.getObservablePart((data) => data.description);
 	public readonly value = this._data.getObservablePart((data) => data.value);
 	public readonly config = this._data.getObservablePart((data) => data.config);
+
+	private _editor = new BehaviorSubject<UmbPropertyEditorExtensionElement | undefined>(undefined);
+	public readonly editor = this._editor.asObservable();
+	setEditor(editor: UmbPropertyEditorExtensionElement | undefined) {
+		this._editor.next(editor ?? undefined);
+	}
+	getEditor() {
+		return this._editor.getValue();
+	}
 
 	#workspaceVariantId?: UmbVariantId;
 

--- a/src/packages/core/workspace/workspace-property/workspace-property.element.ts
+++ b/src/packages/core/workspace/workspace-property/workspace-property.element.ts
@@ -165,6 +165,8 @@ export class UmbWorkspacePropertyElement extends UmbLitElement {
 	}
 
 	private _gotEditorUI(manifest?: ManifestPropertyEditorUi | null) {
+		this._propertyContext.setEditor(undefined);
+
 		if (!manifest) {
 			// TODO: if propertyEditorUiAlias didn't exist in store, we should do some nice fail UI.
 			return;
@@ -177,6 +179,8 @@ export class UmbWorkspacePropertyElement extends UmbLitElement {
 				oldValue?.removeEventListener('change', this._onPropertyEditorChange as any as EventListener);
 
 				this._element = el as ManifestPropertyEditorUi['ELEMENT_TYPE'];
+
+				this._propertyContext.setEditor(this._element);
 
 				this._valueObserver?.destroy();
 				this._configObserver?.destroy();

--- a/src/packages/documents/document-types/workspace/views/structure/document-type-workspace-view-structure.element.ts
+++ b/src/packages/documents/document-types/workspace/views/structure/document-type-workspace-view-structure.element.ts
@@ -34,9 +34,11 @@ export class UmbDocumentTypeWorkspaceViewStructureElement
 		if (!this.#workspaceContext) return;
 		this.observe(this.#workspaceContext.allowedAsRoot, (allowedAsRoot) => (this._allowedAsRoot = allowedAsRoot));
 		this.observe(this.#workspaceContext.allowedContentTypes, (allowedContentTypes) => {
+			const oldValue = this._allowedContentTypeIDs;
 			this._allowedContentTypeIDs = allowedContentTypes
 				?.map((x) => x.id)
 				.filter((x) => x !== undefined) as Array<string>;
+			this.requestUpdate('_allowedContentTypeIDs', oldValue);
 		});
 	}
 

--- a/src/packages/documents/document-types/workspace/views/templates/document-type-workspace-view-templates.element.ts
+++ b/src/packages/documents/document-types/workspace/views/templates/document-type-workspace-view-templates.element.ts
@@ -31,11 +31,22 @@ export class UmbDocumentTypeWorkspaceViewTemplatesElement
 		if (!this.#workspaceContext) return;
 		this.observe(
 			this.#workspaceContext.defaultTemplateId,
-			(defaultTemplateId) => (this._defaultTemplateId = defaultTemplateId)
+			(defaultTemplateId) => {
+				const oldValue = this._defaultTemplateId;
+				this._defaultTemplateId = defaultTemplateId;
+				this.requestUpdate('_defaultTemplateId', oldValue);
+			},
+			'defaultTemplate'
 		);
-		this.observe(this.#workspaceContext.allowedTemplateIds, (allowedTemplateIds) => {
-			this._allowedTemplateIds = allowedTemplateIds;
-		});
+		this.observe(
+			this.#workspaceContext.allowedTemplateIds,
+			(allowedTemplateIds) => {
+				const oldValue = this._allowedTemplateIds;
+				this._allowedTemplateIds = allowedTemplateIds;
+				this.requestUpdate('_allowedTemplateIds', oldValue);
+			},
+			'allowedTemplateIds'
+		);
 	}
 
 	#templateInputChange(e: CustomEvent) {

--- a/src/packages/documents/documents/workspace/document-workspace.context.ts
+++ b/src/packages/documents/documents/workspace/document-workspace.context.ts
@@ -54,15 +54,7 @@ export class UmbDocumentWorkspaceContext
 		new UmbObserverController(this.host, this.documentTypeKey, (id) => this.structure.loadType(id));
 
 		/*
-		TODO: Concept for ensure variant values:
-		new UmbObserverController(this.host, this.variants, (variants) => {
-			if (!variants) return;
-			const draft = this.#draft.getValue();
-			if (!draft) return;
-
-			// Gather all properties from all document types.
-			// Loop through all properties for each variant and insert missing value objects.
-		}
+		TODO: Make something to ensure all variants are present in data? Seems like a good idea?.
 		*/
 	}
 

--- a/src/packages/documents/documents/workspace/views/edit/document-workspace-view-edit.element.ts
+++ b/src/packages/documents/documents/workspace/views/edit/document-workspace-view-edit.element.ts
@@ -116,9 +116,9 @@ export class UmbDocumentWorkspaceViewEditElement
 		if (!this._routes || !this._tabs) return;
 		return html`
 			<umb-body-layout header-fit-height>
-				${this._routerPath && this._tabs.length > 1
+				${this._routerPath && (this._tabs.length > 0 || this._hasRootGroups)
 					? html` <uui-tab-group slot="header">
-							${this._hasRootGroups && this._tabs.length > 1
+							${this._hasRootGroups && this._tabs.length > 0
 								? html`
 										<uui-tab
 											label="Content"

--- a/src/packages/templating/templates/components/input-template/input-template.element.ts
+++ b/src/packages/templating/templates/components/input-template/input-template.element.ts
@@ -67,6 +67,7 @@ export class UmbInputTemplateElement extends FormControlMixin(UmbLitElement) {
 	public set defaultId(newId: string) {
 		this._defaultId = newId;
 		super.value = newId;
+		this.#observePickedTemplates();
 	}
 
 	private _modalContext?: UmbModalManagerContext;
@@ -87,9 +88,11 @@ export class UmbInputTemplateElement extends FormControlMixin(UmbLitElement) {
 		this.observe(
 			await this._templateRepository.itemsLegacy(this._selectedIds),
 			(data) => {
+				const oldValue = this._pickedTemplates;
 				this._pickedTemplates = data;
+				this.requestUpdate('_pickedTemplates', oldValue);
 			},
-			'_templateRepositoryTreeItems'
+			'_pickedTemplates'
 		);
 	}
 

--- a/src/packages/templating/templates/components/input-template/input-template.element.ts
+++ b/src/packages/templating/templates/components/input-template/input-template.element.ts
@@ -9,7 +9,7 @@ import {
 	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
 } from '@umbraco-cms/backoffice/modal';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
-import { TemplateResponseModel } from '@umbraco-cms/backoffice/backend-api';
+import { ItemResponseModelBaseModel, TemplateResponseModel } from '@umbraco-cms/backoffice/backend-api';
 
 @customElement('umb-input-template')
 export class UmbInputTemplateElement extends FormControlMixin(UmbLitElement) {
@@ -49,12 +49,12 @@ export class UmbInputTemplateElement extends FormControlMixin(UmbLitElement) {
 	@property({ type: String, attribute: 'min-message' })
 	maxMessage = 'This field exceeds the allowed amount of items';
 
-	_selectedIds: Array<string | null> = [];
-	@property({ type: Array<string | null> })
+	_selectedIds: Array<string> = [];
+	@property({ type: Array<string> })
 	public get selectedIds() {
 		return this._selectedIds;
 	}
-	public set selectedIds(newKeys: Array<string | null>) {
+	public set selectedIds(newKeys: Array<string>) {
 		this._selectedIds = newKeys;
 		this.#observePickedTemplates();
 	}
@@ -74,7 +74,7 @@ export class UmbInputTemplateElement extends FormControlMixin(UmbLitElement) {
 	private _templateRepository: UmbTemplateRepository = new UmbTemplateRepository(this);
 
 	@state()
-	_pickedTemplates: TemplateResponseModel[] = [];
+	_pickedTemplates: ItemResponseModelBaseModel[] = [];
 
 	constructor() {
 		super();
@@ -86,13 +86,13 @@ export class UmbInputTemplateElement extends FormControlMixin(UmbLitElement) {
 
 	async #observePickedTemplates() {
 		this.observe(
-			await this._templateRepository.itemsLegacy(this._selectedIds),
+			(await this._templateRepository.requestItems(this._selectedIds)).asObservable(),
 			(data) => {
 				const oldValue = this._pickedTemplates;
 				this._pickedTemplates = data;
 				this.requestUpdate('_pickedTemplates', oldValue);
 			},
-			'_pickedTemplates'
+			'_observeTemplates'
 		);
 	}
 
@@ -112,11 +112,12 @@ export class UmbInputTemplateElement extends FormControlMixin(UmbLitElement) {
 		const modalContext = this._modalContext?.open(UMB_TEMPLATE_PICKER_MODAL, {
 			multiple: true,
 			selection: [...this.selectedIds],
+			pickableFilter: (template: TemplateResponseModel) => template.id !== null,
 		});
 
 		modalContext?.onSubmit().then((data) => {
 			if (!data.selection) return;
-			this.selectedIds = data.selection;
+			this.selectedIds = data.selection.filter((x) => x !== null) as Array<string>;
 			this.dispatchEvent(new CustomEvent('change'));
 		});
 	}

--- a/src/packages/templating/templates/repository/manifests.ts
+++ b/src/packages/templating/templates/repository/manifests.ts
@@ -1,7 +1,13 @@
 import { UmbTemplateRepository } from '../repository/template.repository.js';
 import { UmbTemplateTreeStore } from './template.tree.store.js';
 import { UmbTemplateStore } from './template.store.js';
-import { ManifestStore, ManifestTreeStore, ManifestRepository } from '@umbraco-cms/backoffice/extension-registry';
+import { UmbTemplateItemStore } from './template-item.store.js';
+import {
+	ManifestStore,
+	ManifestTreeStore,
+	ManifestRepository,
+	ManifestItemStore,
+} from '@umbraco-cms/backoffice/extension-registry';
 
 export const TEMPLATE_REPOSITORY_ALIAS = 'Umb.Repository.Template';
 
@@ -14,6 +20,7 @@ const repository: ManifestRepository = {
 
 export const TEMPLATE_STORE_ALIAS = 'Umb.Store.Template';
 export const TEMPLATE_TREE_STORE_ALIAS = 'Umb.Store.TemplateTree';
+export const TEMPLATE_ITEM_STORE_ALIAS = 'Umb.Store.TemplateItem';
 
 const store: ManifestStore = {
 	type: 'store',
@@ -29,4 +36,11 @@ const treeStore: ManifestTreeStore = {
 	class: UmbTemplateTreeStore,
 };
 
-export const manifests = [repository, store, treeStore];
+const itemStore: ManifestItemStore = {
+	type: 'itemStore',
+	alias: TEMPLATE_ITEM_STORE_ALIAS,
+	name: 'Template Item Store',
+	class: UmbTemplateItemStore,
+};
+
+export const manifests = [repository, store, treeStore, itemStore];

--- a/src/packages/templating/templates/repository/sources/template.item.server.data.ts
+++ b/src/packages/templating/templates/repository/sources/template.item.server.data.ts
@@ -1,0 +1,39 @@
+import type { UmbItemDataSource } from '@umbraco-cms/backoffice/repository';
+import { TemplateItemResponseModel, TemplateResource } from '@umbraco-cms/backoffice/backend-api';
+import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
+import { tryExecuteAndNotify } from '@umbraco-cms/backoffice/resources';
+
+/**
+ * A data source for Data Type items that fetches data from the server
+ * @export
+ * @class UmbTemplateItemServerDataSource
+ * @implements {DocumentTreeDataSource}
+ */
+export class UmbTemplateItemServerDataSource implements UmbItemDataSource<TemplateItemResponseModel> {
+	#host: UmbControllerHostElement;
+
+	/**
+	 * Creates an instance of UmbTemplateItemServerDataSource.
+	 * @param {UmbControllerHostElement} host
+	 * @memberof UmbTemplateItemServerDataSource
+	 */
+	constructor(host: UmbControllerHostElement) {
+		this.#host = host;
+	}
+
+	/**
+	 * Fetches the items for the given ids from the server
+	 * @param {Array<string>} ids
+	 * @return {*}
+	 * @memberof UmbTemplateItemServerDataSource
+	 */
+	async getItems(ids: Array<string>) {
+		if (!ids) throw new Error('Ids are missing');
+		return tryExecuteAndNotify(
+			this.#host,
+			TemplateResource.getTemplateItem({
+				id: ids,
+			})
+		);
+	}
+}

--- a/src/packages/templating/templates/repository/template-item.store.ts
+++ b/src/packages/templating/templates/repository/template-item.store.ts
@@ -1,0 +1,36 @@
+import { TemplateItemResponseModel } from '@umbraco-cms/backoffice/backend-api';
+import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
+import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
+import { UmbItemStore, UmbStoreBase } from '@umbraco-cms/backoffice/store';
+import { UmbArrayState } from '@umbraco-cms/backoffice/observable-api';
+
+/**
+ * @export
+ * @class UmbTemplateItemStore
+ * @extends {UmbStoreBase}
+ * @description - Data Store for Template items
+ */
+
+export class UmbTemplateItemStore
+	extends UmbStoreBase<TemplateItemResponseModel>
+	implements UmbItemStore<TemplateItemResponseModel>
+{
+	/**
+	 * Creates an instance of UmbTemplateItemStore.
+	 * @param {UmbControllerHostElement} host
+	 * @memberof UmbTemplateItemStore
+	 */
+	constructor(host: UmbControllerHostElement) {
+		super(
+			host,
+			UMB_TEMPLATE_ITEM_STORE_CONTEXT_TOKEN.toString(),
+			new UmbArrayState<TemplateItemResponseModel>([], (x) => x.id)
+		);
+	}
+
+	items(ids: Array<string>) {
+		return this._data.getObservablePart((items) => items.filter((item) => ids.includes(item.id ?? '')));
+	}
+}
+
+export const UMB_TEMPLATE_ITEM_STORE_CONTEXT_TOKEN = new UmbContextToken<UmbTemplateItemStore>('UmbTemplateItemStore');


### PR DESCRIPTION
Its not possible to Publish with current end-points.

Instead this covers:

Displaying allowed child items
Display picked templates (And items store/Source for template item models)
Display tabs when 'root tab'(Content) and one tab.
How can Property Actions talk to the Property Editor.