### PR TITLE
Feature/general styling v2

### DIFF
--- a/src/packages/core/components/body-layout/body-layout.element.ts
+++ b/src/packages/core/components/body-layout/body-layout.element.ts
@@ -37,6 +37,9 @@ export class UmbBodyLayoutElement extends LitElement {
 	public headerTransparent = false;
 
 	@state()
+	private _preSlotHasChildren = false;
+
+	@state()
 	private _headerSlotHasChildren = false;
 
 	@state()
@@ -79,12 +82,20 @@ export class UmbBodyLayoutElement extends LitElement {
 			<div
 				id="header"
 				style="display: ${this.headline ||
+				this._preSlotHasChildren ||
 				this._headerSlotHasChildren ||
 				this._actionsMenuSlotHasChildren ||
 				this._navigationSlotHasChildren
 					? ''
 					: 'none'}">
 				${this.headline ? html`<h3 id="headline">${this.headline}</h3>` : nothing}
+
+				<slot
+					id="pre-slot"
+					name="pre"
+					@slotchange=${(e: Event) => {
+						this._preSlotHasChildren = this.#hasNodes(e);
+					}}></slot>
 
 				<slot
 					id="header-slot"
@@ -141,8 +152,8 @@ export class UmbBodyLayoutElement extends LitElement {
 
 			#header {
 				display: flex;
-				align-items: center;
 				justify-content: space-between;
+				align-items: center;
 				width: 100%;
 				height: var(--umb-header-layout-height);
 				background-color: var(--uui-color-surface);
@@ -183,6 +194,7 @@ export class UmbBodyLayoutElement extends LitElement {
 				padding: 0;
 			}
 
+			#pre-slot,
 			#header-slot,
 			#tabs-slot,
 			#action-menu-slot,

--- a/src/packages/core/workspace/workspace-editor/workspace-editor.element.ts
+++ b/src/packages/core/workspace/workspace-editor/workspace-editor.element.ts
@@ -132,6 +132,7 @@ export class UmbWorkspaceEditorElement extends UmbLitElement {
 	render() {
 		return html`
 			<umb-body-layout main-no-padding .headline=${this.headline}>
+				<slot name="pre" slot="pre"></slot>
 				<slot name="header" slot="header"></slot>
 				${this.#renderViews()}
 				<slot name="action-menu" slot="action-menu"></slot>

--- a/src/packages/documents/dashboards/redirect-management/dashboard-redirect-management.element.ts
+++ b/src/packages/documents/dashboards/redirect-management/dashboard-redirect-management.element.ts
@@ -290,7 +290,6 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 				gap: var(--uui-size-space-1);
 				justify-content: space-between;
 				width: 100%;
-				padding: 0 var(--uui-size-layout-1);
 			}
 
 			#header uui-icon {

--- a/src/packages/documents/document-types/workspace/document-type-workspace-editor.element.ts
+++ b/src/packages/documents/document-types/workspace/document-type-workspace-editor.element.ts
@@ -115,11 +115,12 @@ export class UmbDocumentTypeWorkspaceEditorElement extends UmbLitElement {
 	render() {
 		return html`
 			<umb-workspace-editor alias="Umb.Workspace.DocumentType">
-				<div id="header" slot="header">
-					<uui-button id="icon" @click=${this._handleIconClick} compact>
+				<div id="icon" slot="pre">
+					<uui-button @click=${this._handleIconClick} compact look="placeholder">
 						<uui-icon name="${this._icon}" style="color: ${this._iconColorAlias}"></uui-icon>
 					</uui-button>
-
+				</div>
+				<div id="header" slot="header">
 					<uui-input id="name" .value=${this._name} @input="${this.#onNameChange}">
 						<!-- TODO: should use UUI-LOCK-INPUT, but that does not fire an event when its locked/unlocked -->
 						<uui-input
@@ -166,6 +167,12 @@ export class UmbDocumentTypeWorkspaceEditorElement extends UmbLitElement {
 			#header {
 				display: flex;
 				flex: 1 1 auto;
+				height: 100%;
+				align-items: center;
+				justify-content: center;
+				box-sizing: border-box;
+				margin-left: calc(var(--uui-size-layout-1) * -1);
+				margin-right: calc(var(--uui-size-space-2) * -1);
 			}
 
 			#name {
@@ -186,8 +193,15 @@ export class UmbDocumentTypeWorkspaceEditorElement extends UmbLitElement {
 
 			#icon {
 				font-size: calc(var(--uui-size-layout-3) / 2);
-				margin-right: var(--uui-size-space-2);
-				margin-left: calc(var(--uui-size-space-4) * -1);
+				height: var(--umb-header-layout-height);
+				aspect-ratio: 1;
+				box-sizing: border-box;
+				padding: var(--uui-size-space-3);
+			}
+
+			#icon uui-button {
+				height: 100%;
+				width: 100%;
 			}
 		`,
 	];

--- a/src/packages/translation/dictionary/workspace/dictionary-workspace-editor.element.ts
+++ b/src/packages/translation/dictionary/workspace/dictionary-workspace-editor.element.ts
@@ -38,12 +38,15 @@ export class UmbDictionaryWorkspaceEditorElement extends UmbLitElement {
 	render() {
 		return html`
 			<umb-workspace-editor alias="Umb.Workspace.Dictionary">
-				<div id="header" slot="header">
-					<uui-button href="/section/translation/dashboard" label="Back to list" compact>
-						<uui-icon name="umb:arrow-left"></uui-icon>
-					</uui-button>
-					<uui-input .value=${this._name} @input="${this.#handleInput}" label="Dictionary name"></uui-input>
-				</div>
+				<uui-button id="back-nav" slot="pre" href="/section/translation/dashboard" label="Back to list" compact>
+					<uui-icon name="umb:arrow-left"></uui-icon>
+				</uui-button>
+				<uui-input
+					id="name-input"
+					slot="header"
+					.value=${this._name}
+					@input="${this.#handleInput}"
+					label="Dictionary name"></uui-input>
 			</umb-workspace-editor>
 		`;
 	}
@@ -51,10 +54,14 @@ export class UmbDictionaryWorkspaceEditorElement extends UmbLitElement {
 	static styles = [
 		UUITextStyles,
 		css`
-			#header {
-				display: flex;
-				gap: var(--uui-size-space-4);
-				width: 100%;
+			#back-nav {
+				height: 100%;
+				aspect-ratio: 1;
+			}
+
+			#name-input {
+				margin-left: calc(var(--uui-size-layout-1) * -1);
+				width: calc(100% + var(--uui-size-layout-1));
 			}
 			uui-input {
 				width: 100%;

--- a/src/packages/users/user-groups/modals/user-group-picker/user-group-picker-modal.element.ts
+++ b/src/packages/users/user-groups/modals/user-group-picker/user-group-picker-modal.element.ts
@@ -73,7 +73,7 @@ export class UmbUserGroupPickerModalElement extends UmbModalBaseElement<any, any
 								@selected=${() => this.#selectionManager.select(item.id!)}
 								@deselected=${() => this.#selectionManager.deselect(item.id!)}
 								?selected=${this.#selectionManager.isSelected(item.id!)}>
-								<uui-icon .name=${item.icon} slot="icon"></uui-icon>
+								<uui-icon name=${item.icon} slot="icon"></uui-icon>
 							</uui-menu-item>
 						`
 					)}

--- a/src/packages/users/user-groups/workspace/user-group-workspace-editor.element.ts
+++ b/src/packages/users/user-groups/workspace/user-group-workspace-editor.element.ts
@@ -92,16 +92,16 @@ export class UmbUserGroupWorkspaceEditorElement extends UmbLitElement {
 
 	#renderHeader() {
 		return html`
-			<div id="header" slot="header">
-				<a href="/section/users/view/user-groups">
-					<uui-icon name="umb:arrow-left"></uui-icon>
-				</a>
-				<uui-input
-					id="name"
-					label="name"
-					.value=${this._userGroup?.name ?? ''}
-					@input="${this.#onNameChange}"></uui-input>
-			</div>
+			<uui-button id="back-nav" href="/section/users/view/user-groups" slot="pre">
+				<uui-icon name="umb:arrow-left"></uui-icon>
+			</uui-button>
+
+			<uui-input
+				id="name-input"
+				label="name"
+				slot="header"
+				.value=${this._userGroup?.name ?? ''}
+				@input="${this.#onNameChange}"></uui-input>
 		`;
 	}
 
@@ -165,10 +165,13 @@ export class UmbUserGroupWorkspaceEditorElement extends UmbLitElement {
 				display: block;
 				height: 100%;
 			}
-			#header {
-				width: 100%;
-				display: grid;
-				grid-template-columns: var(--uui-size-layout-1) 1fr;
+			#back-nav {
+				height: 100%;
+				aspect-ratio: 1;
+			}
+			#name-input {
+				margin-left: calc(var(--uui-size-layout-1) * -1);
+				width: calc(100% + var(--uui-size-layout-1));
 			}
 			#main {
 				display: grid;
@@ -190,9 +193,6 @@ export class UmbUserGroupWorkspaceEditorElement extends UmbLitElement {
 			hr {
 				border: none;
 				border-bottom: 1px solid var(--uui-color-divider);
-				width: 100%;
-			}
-			uui-input {
 				width: 100%;
 			}
 		`,

--- a/src/packages/users/users/modals/create/user-create-modal.element.ts
+++ b/src/packages/users/users/modals/create/user-create-modal.element.ts
@@ -185,6 +185,7 @@ export class UmbUserCreateModalElement extends UmbModalBaseElement {
 				justify-content: center;
 				height: 100%;
 				width: 100%;
+				max-width: 500px;
 			}
 			uui-box {
 				max-width: 500px;

--- a/src/packages/users/users/workspace/user-workspace-editor.element.ts
+++ b/src/packages/users/users/workspace/user-workspace-editor.element.ts
@@ -136,12 +136,15 @@ export class UmbUserWorkspaceEditorElement extends UmbLitElement {
 
 	#renderHeader() {
 		return html`
-			<div id="header" slot="header">
-				<a href="/section/users">
-					<uui-icon name="umb:arrow-left"></uui-icon>
-				</a>
-				<uui-input id="name" .value=${this._user?.name ?? ''} @input="${this.#onNameChange}"></uui-input>
-			</div>
+			<uui-button id="back-nav" href="/section/users" slot="pre">
+				<uui-icon name="umb:arrow-left"></uui-icon>
+			</uui-button>
+
+			<uui-input
+				slot="header"
+				id="name-input"
+				.value=${this._user?.name ?? ''}
+				@input="${this.#onNameChange}"></uui-input>
 		`;
 	}
 
@@ -320,10 +323,14 @@ export class UmbUserWorkspaceEditorElement extends UmbLitElement {
 				height: 100%;
 			}
 
-			#header {
-				width: 100%;
-				display: grid;
-				grid-template-columns: var(--uui-size-layout-1) 1fr;
+			#back-nav {
+				height: 100%;
+				aspect-ratio: 1;
+			}
+
+			#name-input {
+				margin-left: calc(var(--uui-size-layout-1) * -1);
+				width: calc(100% + var(--uui-size-layout-1));
 			}
 
 			#main {


### PR DESCRIPTION

Added a pre slot to the umb-body-layout that sits before the header slot. This slot is currently used for the icon picker and back navigation arrows:
<img width="288" alt="image" src="https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/26099018/2b696522-e0b9-4ffe-b39d-85b8aaabd1f3"> <img width="156" alt="image" src="https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/26099018/77b06126-a11c-48f3-a781-796735ea89aa">



