### PR TITLE
use the asPromise() method for generating await init promises

### DIFF
--- a/src/packages/core/picker-input/picker-input.context.ts
+++ b/src/packages/core/picker-input/picker-input.context.ts
@@ -49,7 +49,7 @@ export class UmbPickerInputContext<ItemType extends ItemResponseModelBaseModel> 
 		this.selectedItems = this.#itemManager.items;
 
 		this.#init = Promise.all([
-			this.#itemManager.init,
+			this.#itemManager.#init,
 			new UmbContextConsumerController(this.host, UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
 				this.modalManager = instance;
 			}).asPromise(),

--- a/src/packages/core/picker-input/picker-input.context.ts
+++ b/src/packages/core/picker-input/picker-input.context.ts
@@ -49,7 +49,7 @@ export class UmbPickerInputContext<ItemType extends ItemResponseModelBaseModel> 
 		this.selectedItems = this.#itemManager.items;
 
 		this.#init = Promise.all([
-			this.#itemManager.#init,
+			this.#itemManager.init,
 			new UmbContextConsumerController(this.host, UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
 				this.modalManager = instance;
 			}).asPromise(),

--- a/src/packages/settings/logviewer/repository/log-viewer.repository.ts
+++ b/src/packages/settings/logviewer/repository/log-viewer.repository.ts
@@ -13,47 +13,31 @@ export class UmbLogViewerRepository {
 	#searchDataSource: UmbLogSearchesServerDataSource;
 	#messagesDataSource: UmbLogMessagesServerDataSource;
 	#notificationService?: UmbNotificationContext;
-	#initResolver?: () => void;
-	#initialized = false;
+	#init;
 
 	constructor(host: UmbControllerHostElement) {
 		this.#host = host;
 		this.#searchDataSource = new UmbLogSearchesServerDataSource(this.#host);
 		this.#messagesDataSource = new UmbLogMessagesServerDataSource(this.#host);
 
-		new UmbContextConsumerController(this.#host, UMB_NOTIFICATION_CONTEXT_TOKEN, (instance) => {
+		this.#init = new UmbContextConsumerController(this.#host, UMB_NOTIFICATION_CONTEXT_TOKEN, (instance) => {
 			this.#notificationService = instance;
-			this.#checkIfInitialized();
-		});
-	}
-
-	#init() {
-		// TODO: This would only works with one user of this method. If two, the first one would be forgotten, but maybe its alright for now as I guess this is temporary.
-		return new Promise<void>((resolve) => {
-			this.#initialized ? resolve() : (this.#initResolver = resolve);
-		});
-	}
-
-	#checkIfInitialized() {
-		if (this.#notificationService) {
-			this.#initialized = true;
-			this.#initResolver?.();
-		}
+		}).asPromise();
 	}
 
 	async getSavedSearches({ skip, take }: { skip: number; take: number }) {
-		await this.#init();
+		await this.#init;
 
 		return this.#searchDataSource.getAllSavedSearches({ skip, take });
 	}
 
 	async saveSearch({ name, query }: SavedLogSearchPresenationBaseModel) {
-		await this.#init();
+		await this.#init;
 		this.#searchDataSource.postLogViewerSavedSearch({ name, query });
 	}
 
 	async removeSearch({ name }: { name: string }) {
-		await this.#init();
+		await this.#init;
 		this.#searchDataSource.deleteSavedSearchByName({ name });
 	}
 
@@ -68,13 +52,13 @@ export class UmbLogViewerRepository {
 		startDate?: string;
 		endDate?: string;
 	}) {
-		await this.#init();
+		await this.#init;
 
 		return this.#messagesDataSource.getLogViewerMessageTemplate({ skip, take, startDate, endDate });
 	}
 
 	async getLogCount({ startDate, endDate }: { startDate?: string; endDate?: string }) {
-		await this.#init();
+		await this.#init;
 
 		return this.#messagesDataSource.getLogViewerLevelCount({ startDate, endDate });
 	}
@@ -96,7 +80,7 @@ export class UmbLogViewerRepository {
 		startDate?: string;
 		endDate?: string;
 	}) {
-		await this.#init();
+		await this.#init;
 
 		return this.#messagesDataSource.getLogViewerLogs({
 			skip,
@@ -110,12 +94,12 @@ export class UmbLogViewerRepository {
 	}
 
 	async getLogLevels({ skip = 0, take = 100 }: { skip: number; take: number }) {
-		await this.#init();
+		await this.#init;
 		return this.#messagesDataSource.getLogViewerLevel({ skip, take });
 	}
 
 	async getLogViewerValidateLogsSize({ startDate, endDate }: { startDate?: string; endDate?: string }) {
-		await this.#init();
+		await this.#init;
 		return this.#messagesDataSource.getLogViewerValidateLogsSize({ startDate, endDate });
 	}
 }

--- a/src/packages/templating/stylesheets/repository/stylesheet.repository.ts
+++ b/src/packages/templating/stylesheets/repository/stylesheet.repository.ts
@@ -2,7 +2,6 @@ import { UmbStylesheetTreeStore, UMB_STYLESHEET_TREE_STORE_CONTEXT_TOKEN } from 
 import { UmbStylesheetTreeServerDataSource } from './sources/stylesheet.tree.server.data.js';
 import { UmbStylesheetServerDataSource } from './sources/stylesheet.server.data.js';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
-import { UmbNotificationContext, UMB_NOTIFICATION_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/notification';
 import { UmbContextConsumerController } from '@umbraco-cms/backoffice/context-api';
 import { UmbTreeRepository } from '@umbraco-cms/backoffice/repository';
 import { FileSystemTreeItemPresentationModel } from '@umbraco-cms/backoffice/backend-api';
@@ -15,9 +14,7 @@ export class UmbStylesheetRepository
 	#dataSource;
 	#treeDataSource;
 	#treeStore?: UmbStylesheetTreeStore;
-	#notificationContext?: UmbNotificationContext;
-	#initResolver?: () => void;
-	#initialized = false;
+	#init;
 
 	constructor(host: UmbControllerHostElement) {
 		this.#host = host;
@@ -26,26 +23,9 @@ export class UmbStylesheetRepository
 		this.#dataSource = new UmbStylesheetServerDataSource(this.#host);
 		this.#treeDataSource = new UmbStylesheetTreeServerDataSource(this.#host);
 
-		new UmbContextConsumerController(this.#host, UMB_STYLESHEET_TREE_STORE_CONTEXT_TOKEN, (instance) => {
+		this.#init = new UmbContextConsumerController(this.#host, UMB_STYLESHEET_TREE_STORE_CONTEXT_TOKEN, (instance) => {
 			this.#treeStore = instance;
-			this.#checkIfInitialized();
-		});
-
-		new UmbContextConsumerController(this.#host, UMB_NOTIFICATION_CONTEXT_TOKEN, (instance) => {
-			this.#notificationContext = instance;
-			this.#checkIfInitialized();
-		});
-	}
-
-	#init = new Promise<void>((resolve) => {
-		this.#initialized ? resolve() : (this.#initResolver = resolve);
-	});
-
-	#checkIfInitialized() {
-		if (this.#treeStore && this.#notificationContext) {
-			this.#initialized = true;
-			this.#initResolver?.();
-		}
+		}).asPromise();
 	}
 
 	// TREE:

--- a/src/shared/repository/repository-items.manager.ts
+++ b/src/shared/repository/repository-items.manager.ts
@@ -9,7 +9,7 @@ export class UmbRepositoryItemsManager<ItemType extends ItemResponseModelBaseMod
 	repository?: UmbItemRepository<ItemType>;
 	#getUnique: (entry: ItemType) => string | undefined;
 
-	init: Promise<unknown>;
+	#init: Promise<unknown>;
 
 	#uniques = new UmbArrayState<string>([]);
 	uniques = this.#uniques.asObservable();
@@ -29,7 +29,7 @@ export class UmbRepositoryItemsManager<ItemType extends ItemResponseModelBaseMod
 		this.host = host;
 		this.#getUnique = getUniqueMethod || ((entry) => entry.id || '');
 
-		this.init = new UmbExtensionClassInitializer(host, 'repository', repositoryAlias, (repository) => {
+		this.#init = new UmbExtensionClassInitializer(host, 'repository', repositoryAlias, (repository) => {
 			// TODO: Some test that this repository is a items repository?
 			this.repository = repository as UmbItemRepository<ItemType>;
 		}).asPromise();
@@ -51,7 +51,7 @@ export class UmbRepositoryItemsManager<ItemType extends ItemResponseModelBaseMod
 	}
 
 	async #requestItems() {
-		await this.init;
+		await this.#init;
 		if (!this.repository) throw new Error('Repository is not initialized');
 		if (this.itemsObserver) this.itemsObserver.destroy();
 

--- a/src/shared/repository/repository-items.manager.ts
+++ b/src/shared/repository/repository-items.manager.ts
@@ -11,6 +11,11 @@ export class UmbRepositoryItemsManager<ItemType extends ItemResponseModelBaseMod
 
 	#init: Promise<unknown>;
 
+	// the init promise is used externally for recognizing when the manager is ready.
+	public get init() {
+		return this.#init;
+	}
+
 	#uniques = new UmbArrayState<string>([]);
 	uniques = this.#uniques.asObservable();
 


### PR DESCRIPTION
Cleans up old ways of making a init promise, instead using the asPromise() method for generating await init promises.