### PR TITLE
rename property editor, to avoid misunderstanding

### DIFF
--- a/src/mocks/handlers/manifests.handlers.ts
+++ b/src/mocks/handlers/manifests.handlers.ts
@@ -34,7 +34,7 @@ export const manifestDevelopmentHandler = rest.get(umbracoPath('/package/manifes
 							label: 'My Custom Property',
 							icon: 'document',
 							group: 'Common',
-							propertyEditorModel: 'Umbraco.JSON',
+							propertyEditorSchema: 'Umbraco.JSON',
 						},
 					},
 				],

--- a/src/packages/core/components/property-editor-config/property-editor-config.element.ts
+++ b/src/packages/core/components/property-editor-config/property-editor-config.element.ts
@@ -45,12 +45,12 @@ export class UmbPropertyEditorConfigElement extends UmbLitElement {
 	@state()
 	private _properties: Array<PropertyEditorConfigProperty> = [];
 
-	private _propertyEditorModelConfigDefaultData: Array<PropertyEditorConfigDefaultData> = [];
+	private _propertyEditorSchemaConfigDefaultData: Array<PropertyEditorConfigDefaultData> = [];
 	private _propertyEditorUISettingsDefaultData: Array<PropertyEditorConfigDefaultData> = [];
 
 	private _configDefaultData?: Array<PropertyEditorConfigDefaultData>;
 
-	private _propertyEditorModelConfigProperties: Array<PropertyEditorConfigProperty> = [];
+	private _propertyEditorSchemaConfigProperties: Array<PropertyEditorConfigProperty> = [];
 	private _propertyEditorUISettingsProperties: Array<PropertyEditorConfigProperty> = [];
 
 	private _observePropertyEditorUIConfig() {
@@ -59,7 +59,7 @@ export class UmbPropertyEditorConfigElement extends UmbLitElement {
 		this.observe(
 			umbExtensionsRegistry.getByTypeAndAlias('propertyEditorUi', this.propertyEditorUiAlias),
 			(manifest) => {
-				this._observePropertyEditorModelConfig(manifest?.meta.propertyEditorAlias);
+				this._observePropertyEditorSchemaConfig(manifest?.meta.propertyEditorSchemaAlias);
 				this._propertyEditorUISettingsProperties = manifest?.meta.settings?.properties || [];
 				this._propertyEditorUISettingsDefaultData = manifest?.meta.settings?.defaultData || [];
 				this._mergeConfigProperties();
@@ -68,24 +68,27 @@ export class UmbPropertyEditorConfigElement extends UmbLitElement {
 		);
 	}
 
-	private _observePropertyEditorModelConfig(propertyEditorAlias?: string) {
-		if (!propertyEditorAlias) return;
+	private _observePropertyEditorSchemaConfig(propertyEditorSchemaAlias?: string) {
+		if (!propertyEditorSchemaAlias) return;
 
-		this.observe(umbExtensionsRegistry.getByTypeAndAlias('propertyEditorModel', propertyEditorAlias), (manifest) => {
-			this._propertyEditorModelConfigProperties = manifest?.meta.settings?.properties || [];
-			this._propertyEditorModelConfigDefaultData = manifest?.meta.settings?.defaultData || [];
-			this._mergeConfigProperties();
-			this._mergeConfigDefaultData();
-		});
+		this.observe(
+			umbExtensionsRegistry.getByTypeAndAlias('propertyEditorSchema', propertyEditorSchemaAlias),
+			(manifest) => {
+				this._propertyEditorSchemaConfigProperties = manifest?.meta.settings?.properties || [];
+				this._propertyEditorSchemaConfigDefaultData = manifest?.meta.settings?.defaultData || [];
+				this._mergeConfigProperties();
+				this._mergeConfigDefaultData();
+			}
+		);
 	}
 
 	private _mergeConfigProperties() {
-		this._properties = [...this._propertyEditorModelConfigProperties, ...this._propertyEditorUISettingsProperties];
+		this._properties = [...this._propertyEditorSchemaConfigProperties, ...this._propertyEditorUISettingsProperties];
 	}
 
 	private _mergeConfigDefaultData() {
 		this._configDefaultData = [
-			...this._propertyEditorModelConfigDefaultData,
+			...this._propertyEditorSchemaConfigDefaultData,
 			...this._propertyEditorUISettingsDefaultData,
 		];
 	}

--- a/src/packages/core/components/property-type-based-property/property-type-based-property.element.ts
+++ b/src/packages/core/components/property-type-based-property/property-type-based-property.element.ts
@@ -98,13 +98,13 @@ export class UmbPropertyTypeBasedPropertyElement extends UmbLitElement {
 					if (!this._propertyEditorUiAlias && dataType?.propertyEditorAlias) {
 						//use 'dataType.propertyEditorAlias' to look up the extension in the registry:
 						this.observe(
-							umbExtensionsRegistry.getByTypeAndAlias('propertyEditorModel', dataType.propertyEditorAlias),
+							umbExtensionsRegistry.getByTypeAndAlias('propertyEditorSchema', dataType.propertyEditorAlias),
 							(extension) => {
 								if (!extension) return;
 								this._propertyEditorUiAlias = extension?.meta.defaultPropertyEditorUiAlias;
-								this.removeControllerByUnique('_observePropertyEditorModel');
+								this.removeControllerByUnique('_observePropertyEditorSchema');
 							},
-							'_observePropertyEditorModel'
+							'_observePropertyEditorSchema'
 						);
 					}
 				},

--- a/src/packages/core/components/ref-property-editor-ui/ref-property-editor-ui.element.ts
+++ b/src/packages/core/components/ref-property-editor-ui/ref-property-editor-ui.element.ts
@@ -26,8 +26,8 @@ export class UmbRefPropertyEditorUIElement extends UUIRefNodeElement {
 	 * @attr
 	 * @default ''
 	 */
-	@property({ type: String, attribute: 'property-editor-model-alias' })
-	propertyEditorModelAlias = '';
+	@property({ type: String, attribute: 'property-editor-schema-alias' })
+	propertyEditorSchemaAlias = '';
 
 	protected renderDetail() {
 		const details: string[] = [];
@@ -36,8 +36,8 @@ export class UmbRefPropertyEditorUIElement extends UUIRefNodeElement {
 			details.push(this.alias);
 		}
 
-		if (this.propertyEditorModelAlias !== '') {
-			details.push(this.propertyEditorModelAlias);
+		if (this.propertyEditorSchemaAlias !== '') {
+			details.push(this.propertyEditorSchemaAlias);
 		} else {
 			details.push('Property Editor Missing');
 		}

--- a/src/packages/core/components/ref-property-editor-ui/ref-property-editor-ui.stories.ts
+++ b/src/packages/core/components/ref-property-editor-ui/ref-property-editor-ui.stories.ts
@@ -15,7 +15,7 @@ export const Overview: Story = {
 	args: {
 		name: 'Custom Property Editor UI',
 		alias: 'Umb.PropertyEditorUi.CustomUI',
-		propertyEditorModelAlias: 'Umbraco.JSON',
+		propertyEditorSchemaAlias: 'Umbraco.JSON',
 	},
 };
 
@@ -23,7 +23,7 @@ export const WithDetail: Story = {
 	args: {
 		name: 'Custom Property Editor UI',
 		alias: 'Umb.PropertyEditorUi.CustomUI',
-		propertyEditorModelAlias: 'Umbraco.JSON',
+		propertyEditorSchemaAlias: 'Umbraco.JSON',
 		detail: 'With some custom details',
 	},
 };
@@ -32,14 +32,14 @@ export const WithSlots: Story = {
 	args: {
 		name: 'Custom Property Editor UI',
 		alias: 'Umb.PropertyEditorUi.CustomUI',
-		propertyEditorModelAlias: 'Umbraco.JSON',
+		propertyEditorSchemaAlias: 'Umbraco.JSON',
 		detail: 'With some custom details',
 	},
 	render: (args) => html`
 		<umb-ref-property-editor-ui
 			.name=${args.name}
 			.alias=${args.alias}
-			.propertyEditorAlias=${args.propertyEditorModelAlias}
+			.propertyEditorSchemaAlias=${args.propertyEditorSchemaAlias}
 			.detail=${args.detail}>
 			<div slot="tag"><uui-tag color="positive">10</uui-tag></div>
 			<div slot="actions">

--- a/src/packages/core/extension-registry/models/index.ts
+++ b/src/packages/core/extension-registry/models/index.ts
@@ -11,7 +11,7 @@ import type { ManifestMenuItem, ManifestMenuItemTreeKind } from './menu-item.mod
 import type { ManifestModal } from './modal.model.js';
 import type { ManifestPackageView } from './package-view.model.js';
 import type { ManifestPropertyAction } from './property-action.model.js';
-import type { ManifestPropertyEditorUi, ManifestPropertyEditorModel } from './property-editor.model.js';
+import type { ManifestPropertyEditorUi, ManifestPropertyEditorSchema } from './property-editor.model.js';
 import type { ManifestRepository } from './repository.model.js';
 import type { ManifestSection } from './section.model.js';
 import type { ManifestSectionSidebarApp, ManifestSectionSidebarAppMenuKind } from './section-sidebar-app.model.js';
@@ -74,7 +74,7 @@ export type ManifestTypes =
 	| ManifestModal
 	| ManifestPackageView
 	| ManifestPropertyAction
-	| ManifestPropertyEditorModel
+	| ManifestPropertyEditorSchema
 	| ManifestPropertyEditorUi
 	| ManifestRepository
 	| ManifestSection

--- a/src/packages/core/extension-registry/models/property-editor.model.ts
+++ b/src/packages/core/extension-registry/models/property-editor.model.ts
@@ -9,7 +9,7 @@ export interface ManifestPropertyEditorUi extends ManifestElement<UmbPropertyEdi
 
 export interface MetaPropertyEditorUi {
 	label: string;
-	propertyEditorAlias: string;
+	propertyEditorSchemaAlias: string;
 	icon: string;
 	group: string;
 	settings?: PropertyEditorSettings;
@@ -17,12 +17,12 @@ export interface MetaPropertyEditorUi {
 }
 
 // Model
-export interface ManifestPropertyEditorModel extends ManifestBase {
-	type: 'propertyEditorModel';
-	meta: MetaPropertyEditorModel;
+export interface ManifestPropertyEditorSchema extends ManifestBase {
+	type: 'propertyEditorSchema';
+	meta: MetaPropertyEditorSchema;
 }
 
-export interface MetaPropertyEditorModel {
+export interface MetaPropertyEditorSchema {
 	defaultPropertyEditorUiAlias: string;
 	settings?: PropertyEditorSettings;
 }

--- a/src/packages/core/property-editors/manifests.ts
+++ b/src/packages/core/property-editors/manifests.ts
@@ -1,4 +1,4 @@
-import { manifests as propertyEditorModelManifests } from './models/manifests.js';
+import { manifests as propertyEditorSchemaManifests } from './models/manifests.js';
 import { manifests as propertyEditorUIManifests } from './uis/manifests.js';
 
-export const manifests = [...propertyEditorModelManifests, ...propertyEditorUIManifests];
+export const manifests = [...propertyEditorSchemaManifests, ...propertyEditorUIManifests];

--- a/src/packages/core/property-editors/models/Umbraco.BlockGrid.ts
+++ b/src/packages/core/property-editors/models/Umbraco.BlockGrid.ts
@@ -1,7 +1,7 @@
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: ManifestPropertyEditorModel = {
-	type: 'propertyEditorModel',
+export const manifest: ManifestPropertyEditorSchema = {
+	type: 'propertyEditorSchema',
 	name: 'Block Grid',
 	alias: 'Umbraco.BlockGrid',
 	meta: {

--- a/src/packages/core/property-editors/models/Umbraco.BlockList.ts
+++ b/src/packages/core/property-editors/models/Umbraco.BlockList.ts
@@ -1,7 +1,7 @@
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: ManifestPropertyEditorModel = {
-	type: 'propertyEditorModel',
+export const manifest: ManifestPropertyEditorSchema = {
+	type: 'propertyEditorSchema',
 	name: 'Block List',
 	alias: 'Umbraco.BlockList',
 	meta: {

--- a/src/packages/core/property-editors/models/Umbraco.CheckboxList.ts
+++ b/src/packages/core/property-editors/models/Umbraco.CheckboxList.ts
@@ -1,7 +1,7 @@
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: ManifestPropertyEditorModel = {
-	type: 'propertyEditorModel',
+export const manifest: ManifestPropertyEditorSchema = {
+	type: 'propertyEditorSchema',
 	name: 'Checkbox List',
 	alias: 'Umbraco.CheckboxList',
 	meta: {

--- a/src/packages/core/property-editors/models/Umbraco.ColorPicker.EyeDropper.ts
+++ b/src/packages/core/property-editors/models/Umbraco.ColorPicker.EyeDropper.ts
@@ -1,7 +1,7 @@
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: ManifestPropertyEditorModel = {
-	type: 'propertyEditorModel',
+export const manifest: ManifestPropertyEditorSchema = {
+	type: 'propertyEditorSchema',
 	name: 'Eye Dropper Color Picker',
 	alias: 'Umbraco.ColorPicker.EyeDropper',
 	meta: {

--- a/src/packages/core/property-editors/models/Umbraco.ColorPicker.ts
+++ b/src/packages/core/property-editors/models/Umbraco.ColorPicker.ts
@@ -1,7 +1,7 @@
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: ManifestPropertyEditorModel = {
-	type: 'propertyEditorModel',
+export const manifest: ManifestPropertyEditorSchema = {
+	type: 'propertyEditorSchema',
 	name: 'Color Picker',
 	alias: 'Umbraco.ColorPicker',
 	meta: {

--- a/src/packages/core/property-editors/models/Umbraco.DateTime.ts
+++ b/src/packages/core/property-editors/models/Umbraco.DateTime.ts
@@ -1,8 +1,8 @@
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
 // TODO: We won't include momentjs anymore so we need to find a way to handle date formats
-export const manifest: ManifestPropertyEditorModel = {
-	type: 'propertyEditorModel',
+export const manifest: ManifestPropertyEditorSchema = {
+	type: 'propertyEditorSchema',
 	name: 'Date/Time',
 	alias: 'Umbraco.DateTime',
 	meta: {

--- a/src/packages/core/property-editors/models/Umbraco.Decimal.ts
+++ b/src/packages/core/property-editors/models/Umbraco.Decimal.ts
@@ -1,7 +1,7 @@
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: ManifestPropertyEditorModel = {
-	type: 'propertyEditorModel',
+export const manifest: ManifestPropertyEditorSchema = {
+	type: 'propertyEditorSchema',
 	name: 'Decimal',
 	alias: 'Umbraco.Decimal',
 	meta: {

--- a/src/packages/core/property-editors/models/Umbraco.Dropdown.Flexible.ts
+++ b/src/packages/core/property-editors/models/Umbraco.Dropdown.Flexible.ts
@@ -1,8 +1,8 @@
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
 // TODO: We won't include momentjs anymore so we need to find a way to handle date formats
-export const manifest: ManifestPropertyEditorModel = {
-	type: 'propertyEditorModel',
+export const manifest: ManifestPropertyEditorSchema = {
+	type: 'propertyEditorSchema',
 	name: 'Dropdown',
 	alias: 'Umbraco.DropDown.Flexible',
 	meta: {

--- a/src/packages/core/property-editors/models/Umbraco.EmailAddress.ts
+++ b/src/packages/core/property-editors/models/Umbraco.EmailAddress.ts
@@ -1,7 +1,7 @@
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: ManifestPropertyEditorModel = {
-	type: 'propertyEditorModel',
+export const manifest: ManifestPropertyEditorSchema = {
+	type: 'propertyEditorSchema',
 	name: 'Email Address',
 	alias: 'Umbraco.EmailAddress',
 	meta: {

--- a/src/packages/core/property-editors/models/Umbraco.IconPicker.ts
+++ b/src/packages/core/property-editors/models/Umbraco.IconPicker.ts
@@ -1,7 +1,7 @@
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: ManifestPropertyEditorModel = {
-	type: 'propertyEditorModel',
+export const manifest: ManifestPropertyEditorSchema = {
+	type: 'propertyEditorSchema',
 	name: 'Icon Picker',
 	alias: 'Umbraco.IconPicker',
 	meta: {

--- a/src/packages/core/property-editors/models/Umbraco.ImageCropper.ts
+++ b/src/packages/core/property-editors/models/Umbraco.ImageCropper.ts
@@ -1,7 +1,7 @@
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: ManifestPropertyEditorModel = {
-	type: 'propertyEditorModel',
+export const manifest: ManifestPropertyEditorSchema = {
+	type: 'propertyEditorSchema',
 	name: 'Email Address',
 	alias: 'Umbraco.ImageCropper',
 	meta: {

--- a/src/packages/core/property-editors/models/Umbraco.Integer.ts
+++ b/src/packages/core/property-editors/models/Umbraco.Integer.ts
@@ -1,7 +1,7 @@
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: ManifestPropertyEditorModel = {
-	type: 'propertyEditorModel',
+export const manifest: ManifestPropertyEditorSchema = {
+	type: 'propertyEditorSchema',
 	name: 'Decimal',
 	alias: 'Umbraco.Integer',
 	meta: {

--- a/src/packages/core/property-editors/models/Umbraco.JSON.ts
+++ b/src/packages/core/property-editors/models/Umbraco.JSON.ts
@@ -1,7 +1,7 @@
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: ManifestPropertyEditorModel = {
-	type: 'propertyEditorModel',
+export const manifest: ManifestPropertyEditorSchema = {
+	type: 'propertyEditorSchema',
 	name: 'JSON model',
 	alias: 'Umbraco.JSON',
 	meta: {

--- a/src/packages/core/property-editors/models/Umbraco.Label.ts
+++ b/src/packages/core/property-editors/models/Umbraco.Label.ts
@@ -1,7 +1,7 @@
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: ManifestPropertyEditorModel = {
-	type: 'propertyEditorModel',
+export const manifest: ManifestPropertyEditorSchema = {
+	type: 'propertyEditorSchema',
 	name: 'Label',
 	alias: 'Umbraco.Label',
 	meta: {

--- a/src/packages/core/property-editors/models/Umbraco.ListView.ts
+++ b/src/packages/core/property-editors/models/Umbraco.ListView.ts
@@ -1,7 +1,7 @@
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: ManifestPropertyEditorModel = {
-	type: 'propertyEditorModel',
+export const manifest: ManifestPropertyEditorSchema = {
+	type: 'propertyEditorSchema',
 	name: 'List View',
 	alias: 'Umbraco.ListView',
 	meta: {

--- a/src/packages/core/property-editors/models/Umbraco.MarkdownEditor.ts
+++ b/src/packages/core/property-editors/models/Umbraco.MarkdownEditor.ts
@@ -1,7 +1,7 @@
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: ManifestPropertyEditorModel = {
-	type: 'propertyEditorModel',
+export const manifest: ManifestPropertyEditorSchema = {
+	type: 'propertyEditorSchema',
 	name: 'Markdown Editor',
 	alias: 'Umbraco.MarkdownEditor',
 	meta: {

--- a/src/packages/core/property-editors/models/Umbraco.MediaPicker3.ts
+++ b/src/packages/core/property-editors/models/Umbraco.MediaPicker3.ts
@@ -1,7 +1,7 @@
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: ManifestPropertyEditorModel = {
-	type: 'propertyEditorModel',
+export const manifest: ManifestPropertyEditorSchema = {
+	type: 'propertyEditorSchema',
 	name: 'Media Picker 3',
 	alias: 'Umbraco.MediaPicker3',
 	meta: {

--- a/src/packages/core/property-editors/models/Umbraco.MemberGroupPicker.ts
+++ b/src/packages/core/property-editors/models/Umbraco.MemberGroupPicker.ts
@@ -1,7 +1,7 @@
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: ManifestPropertyEditorModel = {
-	type: 'propertyEditorModel',
+export const manifest: ManifestPropertyEditorSchema = {
+	type: 'propertyEditorSchema',
 	name: 'Member Group Picker',
 	alias: 'Umbraco.MemberGroupPicker',
 	meta: {

--- a/src/packages/core/property-editors/models/Umbraco.MemberPicker.ts
+++ b/src/packages/core/property-editors/models/Umbraco.MemberPicker.ts
@@ -1,7 +1,7 @@
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: ManifestPropertyEditorModel = {
-	type: 'propertyEditorModel',
+export const manifest: ManifestPropertyEditorSchema = {
+	type: 'propertyEditorSchema',
 	name: 'Member Picker',
 	alias: 'Umbraco.MemberPicker',
 	meta: {

--- a/src/packages/core/property-editors/models/Umbraco.MultiNodeTreePicker.ts
+++ b/src/packages/core/property-editors/models/Umbraco.MultiNodeTreePicker.ts
@@ -1,7 +1,7 @@
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: ManifestPropertyEditorModel = {
-	type: 'propertyEditorModel',
+export const manifest: ManifestPropertyEditorSchema = {
+	type: 'propertyEditorSchema',
 	name: 'Multi Node Tree Picker',
 	alias: 'Umbraco.MultiNodeTreePicker',
 	meta: {

--- a/src/packages/core/property-editors/models/Umbraco.MultiUrlPicker.ts
+++ b/src/packages/core/property-editors/models/Umbraco.MultiUrlPicker.ts
@@ -1,7 +1,7 @@
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: ManifestPropertyEditorModel = {
-	type: 'propertyEditorModel',
+export const manifest: ManifestPropertyEditorSchema = {
+	type: 'propertyEditorSchema',
 	name: 'Multi URL Picker',
 	alias: 'Umbraco.MultiUrlPicker',
 	meta: {

--- a/src/packages/core/property-editors/models/Umbraco.MultipleTextString.ts
+++ b/src/packages/core/property-editors/models/Umbraco.MultipleTextString.ts
@@ -1,7 +1,7 @@
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: ManifestPropertyEditorModel = {
-	type: 'propertyEditorModel',
+export const manifest: ManifestPropertyEditorSchema = {
+	type: 'propertyEditorSchema',
 	name: 'Multiple Text String',
 	alias: 'Umbraco.MultipleTextString',
 	meta: {

--- a/src/packages/core/property-editors/models/Umbraco.RadioButtonList.ts
+++ b/src/packages/core/property-editors/models/Umbraco.RadioButtonList.ts
@@ -1,7 +1,7 @@
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: ManifestPropertyEditorModel = {
-	type: 'propertyEditorModel',
+export const manifest: ManifestPropertyEditorSchema = {
+	type: 'propertyEditorSchema',
 	name: 'Radio Button List',
 	alias: 'Umbraco.RadioButtonList',
 	meta: {

--- a/src/packages/core/property-editors/models/Umbraco.Slider.ts
+++ b/src/packages/core/property-editors/models/Umbraco.Slider.ts
@@ -1,7 +1,7 @@
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: ManifestPropertyEditorModel = {
-	type: 'propertyEditorModel',
+export const manifest: ManifestPropertyEditorSchema = {
+	type: 'propertyEditorSchema',
 	name: 'Slider',
 	alias: 'Umbraco.Slider',
 	meta: {

--- a/src/packages/core/property-editors/models/Umbraco.Tags.ts
+++ b/src/packages/core/property-editors/models/Umbraco.Tags.ts
@@ -1,7 +1,7 @@
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: ManifestPropertyEditorModel = {
-	type: 'propertyEditorModel',
+export const manifest: ManifestPropertyEditorSchema = {
+	type: 'propertyEditorSchema',
 	name: 'Tags',
 	alias: 'Umbraco.Tags',
 	meta: {

--- a/src/packages/core/property-editors/models/Umbraco.TextArea.ts
+++ b/src/packages/core/property-editors/models/Umbraco.TextArea.ts
@@ -1,7 +1,7 @@
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: ManifestPropertyEditorModel = {
-	type: 'propertyEditorModel',
+export const manifest: ManifestPropertyEditorSchema = {
+	type: 'propertyEditorSchema',
 	name: 'Textarea',
 	alias: 'Umbraco.TextArea',
 	meta: {

--- a/src/packages/core/property-editors/models/Umbraco.TextBox.ts
+++ b/src/packages/core/property-editors/models/Umbraco.TextBox.ts
@@ -1,7 +1,7 @@
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: ManifestPropertyEditorModel = {
-	type: 'propertyEditorModel',
+export const manifest: ManifestPropertyEditorSchema = {
+	type: 'propertyEditorSchema',
 	name: 'Text Box',
 	alias: 'Umbraco.TextBox',
 	meta: {

--- a/src/packages/core/property-editors/models/Umbraco.TinyMCE.ts
+++ b/src/packages/core/property-editors/models/Umbraco.TinyMCE.ts
@@ -1,7 +1,7 @@
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: ManifestPropertyEditorModel = {
-	type: 'propertyEditorModel',
+export const manifest: ManifestPropertyEditorSchema = {
+	type: 'propertyEditorSchema',
 	name: 'Tiny MCE',
 	alias: 'Umbraco.TinyMCE',
 	meta: {

--- a/src/packages/core/property-editors/models/Umbraco.TrueFalse.ts
+++ b/src/packages/core/property-editors/models/Umbraco.TrueFalse.ts
@@ -1,8 +1,8 @@
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
 // TODO: We won't include momentjs anymore so we need to find a way to handle date formats
-export const manifest: ManifestPropertyEditorModel = {
-	type: 'propertyEditorModel',
+export const manifest: ManifestPropertyEditorSchema = {
+	type: 'propertyEditorSchema',
 	name: 'Date/Time',
 	alias: 'Umbraco.TrueFalse',
 	meta: {

--- a/src/packages/core/property-editors/models/Umbraco.UploadField.ts
+++ b/src/packages/core/property-editors/models/Umbraco.UploadField.ts
@@ -1,8 +1,8 @@
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
 // TODO: We won't include momentjs anymore so we need to find a way to handle date formats
-export const manifest: ManifestPropertyEditorModel = {
-	type: 'propertyEditorModel',
+export const manifest: ManifestPropertyEditorSchema = {
+	type: 'propertyEditorSchema',
 	name: 'File upload',
 	alias: 'Umbraco.UploadField',
 	meta: {

--- a/src/packages/core/property-editors/models/Umbraco.UserPicker.ts
+++ b/src/packages/core/property-editors/models/Umbraco.UserPicker.ts
@@ -1,7 +1,7 @@
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: ManifestPropertyEditorModel = {
-	type: 'propertyEditorModel',
+export const manifest: ManifestPropertyEditorSchema = {
+	type: 'propertyEditorSchema',
 	name: 'User Picker',
 	alias: 'Umbraco.UserPicker',
 	meta: {

--- a/src/packages/core/property-editors/models/manifests.ts
+++ b/src/packages/core/property-editors/models/manifests.ts
@@ -30,9 +30,9 @@ import { manifest as trueFalse } from './Umbraco.TrueFalse.js';
 import { manifest as uploadField } from './Umbraco.UploadField.js';
 import { manifest as userPicker } from './Umbraco.UserPicker.js';
 
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestPropertyEditorModel> = [
+export const manifests: Array<ManifestPropertyEditorSchema> = [
 	blockGrid,
 	blockList,
 	checkboxList,

--- a/src/packages/core/property-editors/uis/block-grid/config/block-configuration/manifests.ts
+++ b/src/packages/core/property-editors/uis/block-grid/config/block-configuration/manifests.ts
@@ -7,7 +7,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-block-grid-block-configuration.element.js'),
 	meta: {
 		label: 'Block Grid Block Configuration',
-		propertyEditorAlias: 'Umbraco.BlockGrid.BlockConfiguration',
+		propertyEditorSchemaAlias: 'Umbraco.BlockGrid.BlockConfiguration',
 		icon: 'umb:autofill',
 		group: 'blocks',
 	},

--- a/src/packages/core/property-editors/uis/block-grid/config/group-configuration/manifests.ts
+++ b/src/packages/core/property-editors/uis/block-grid/config/group-configuration/manifests.ts
@@ -7,7 +7,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-block-grid-group-configuration.element.js'),
 	meta: {
 		label: 'Block Grid Group Configuration',
-		propertyEditorAlias: 'Umbraco.BlockGrid.GroupConfiguration',
+		propertyEditorSchemaAlias: 'Umbraco.BlockGrid.GroupConfiguration',
 		icon: 'umb:autofill',
 		group: 'blocks',
 	},

--- a/src/packages/core/property-editors/uis/block-grid/config/stylesheet-picker/manifests.ts
+++ b/src/packages/core/property-editors/uis/block-grid/config/stylesheet-picker/manifests.ts
@@ -7,7 +7,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-block-grid-stylesheet-picker.element.js'),
 	meta: {
 		label: 'Block Grid Stylesheet Picker',
-		propertyEditorAlias: '',
+		propertyEditorSchemaAlias: '',
 		icon: 'umb:autofill',
 		group: 'blocks',
 	},

--- a/src/packages/core/property-editors/uis/block-grid/manifests.ts
+++ b/src/packages/core/property-editors/uis/block-grid/manifests.ts
@@ -10,7 +10,7 @@ const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-block-grid.element.js'),
 	meta: {
 		label: 'Block Grid',
-		propertyEditorAlias: 'Umbraco.BlockGrid',
+		propertyEditorSchemaAlias: 'Umbraco.BlockGrid',
 		icon: 'umb:icon-layout',
 		group: 'richContent',
 		settings: {

--- a/src/packages/core/property-editors/uis/block-list/config/block-configuration/manifests.ts
+++ b/src/packages/core/property-editors/uis/block-list/config/block-configuration/manifests.ts
@@ -7,7 +7,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-block-list-block-configuration.element.js'),
 	meta: {
 		label: 'Block List Block Configuration',
-		propertyEditorAlias: '',
+		propertyEditorSchemaAlias: '',
 		icon: 'umb:autofill',
 		group: 'common',
 	},

--- a/src/packages/core/property-editors/uis/block-list/manifests.ts
+++ b/src/packages/core/property-editors/uis/block-list/manifests.ts
@@ -8,7 +8,7 @@ const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-block-list.element.js'),
 	meta: {
 		label: 'Block List',
-		propertyEditorAlias: 'Umbraco.BlockList',
+		propertyEditorSchemaAlias: 'Umbraco.BlockList',
 		icon: 'umb:thumbnail-list',
 		group: 'lists',
 		settings: {

--- a/src/packages/core/property-editors/uis/checkbox-list/manifests.ts
+++ b/src/packages/core/property-editors/uis/checkbox-list/manifests.ts
@@ -7,7 +7,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-checkbox-list.element.js'),
 	meta: {
 		label: 'Checkbox List',
-		propertyEditorAlias: 'Umbraco.CheckboxList',
+		propertyEditorSchemaAlias: 'Umbraco.CheckboxList',
 		icon: 'umb:bulleted-list',
 		group: 'lists',
 		settings: {

--- a/src/packages/core/property-editors/uis/collection-view/config/bulk-action-permissions/manifests.ts
+++ b/src/packages/core/property-editors/uis/collection-view/config/bulk-action-permissions/manifests.ts
@@ -7,7 +7,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-collection-view-bulk-action-permissions.element.js'),
 	meta: {
 		label: 'Collection View Bulk Action Permissions',
-		propertyEditorAlias: '',
+		propertyEditorSchemaAlias: '',
 		icon: 'umb:autofill',
 		group: 'lists',
 	},

--- a/src/packages/core/property-editors/uis/collection-view/config/column-configuration/manifests.ts
+++ b/src/packages/core/property-editors/uis/collection-view/config/column-configuration/manifests.ts
@@ -7,7 +7,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-collection-view-column-configuration.element.js'),
 	meta: {
 		label: 'Collection View Column Configuration',
-		propertyEditorAlias: '',
+		propertyEditorSchemaAlias: '',
 		icon: 'umb:autofill',
 		group: 'lists',
 	},

--- a/src/packages/core/property-editors/uis/collection-view/config/layout-configuration/manifests.ts
+++ b/src/packages/core/property-editors/uis/collection-view/config/layout-configuration/manifests.ts
@@ -7,7 +7,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-collection-view-layout-configuration.element.js'),
 	meta: {
 		label: 'Collection View Layout Configuration',
-		propertyEditorAlias: '',
+		propertyEditorSchemaAlias: '',
 		icon: 'umb:autofill',
 		group: 'lists',
 	},

--- a/src/packages/core/property-editors/uis/collection-view/config/order-by/manifests.ts
+++ b/src/packages/core/property-editors/uis/collection-view/config/order-by/manifests.ts
@@ -7,7 +7,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-collection-view-order-by.element.js'),
 	meta: {
 		label: 'Collection View Order By',
-		propertyEditorAlias: '',
+		propertyEditorSchemaAlias: '',
 		icon: 'umb:autofill',
 		group: 'lists',
 	},

--- a/src/packages/core/property-editors/uis/collection-view/manifests.ts
+++ b/src/packages/core/property-editors/uis/collection-view/manifests.ts
@@ -11,7 +11,7 @@ const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-collection-view.element.js'),
 	meta: {
 		label: 'Collection View',
-		propertyEditorAlias: 'Umbraco.ListView',
+		propertyEditorSchemaAlias: 'Umbraco.ListView',
 		icon: 'umb:bulleted-list',
 		group: 'lists',
 		settings: {

--- a/src/packages/core/property-editors/uis/color-picker/manifests.ts
+++ b/src/packages/core/property-editors/uis/color-picker/manifests.ts
@@ -7,7 +7,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-color-picker.element.js'),
 	meta: {
 		label: 'Color Picker',
-		propertyEditorAlias: 'Umbraco.ColorPicker',
+		propertyEditorSchemaAlias: 'Umbraco.ColorPicker',
 		icon: 'umb:colorpicker',
 		group: 'pickers',
 	},

--- a/src/packages/core/property-editors/uis/date-picker/manifests.ts
+++ b/src/packages/core/property-editors/uis/date-picker/manifests.ts
@@ -7,7 +7,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-date-picker.element.js'),
 	meta: {
 		label: 'Date Picker',
-		propertyEditorAlias: 'Umbraco.DateTime',
+		propertyEditorSchemaAlias: 'Umbraco.DateTime',
 		icon: 'umb:time',
 		group: 'pickers',
 		settings: {

--- a/src/packages/core/property-editors/uis/dropdown/manifests.ts
+++ b/src/packages/core/property-editors/uis/dropdown/manifests.ts
@@ -7,7 +7,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-dropdown.element.js'),
 	meta: {
 		label: 'Dropdown',
-		propertyEditorAlias: 'Umbraco.Dropdown',
+		propertyEditorSchemaAlias: 'Umbraco.Dropdown',
 		icon: 'umb:time',
 		group: 'pickers',
 		settings: {

--- a/src/packages/core/property-editors/uis/eye-dropper/manifests.ts
+++ b/src/packages/core/property-editors/uis/eye-dropper/manifests.ts
@@ -9,7 +9,7 @@ export const manifest: ManifestPropertyEditorUi = {
 		label: 'Eye Dropper Color Picker',
 		icon: 'umb:colorpicker',
 		group: 'pickers',
-		propertyEditorAlias: 'Umbraco.ColorPicker.EyeDropper',
+		propertyEditorSchemaAlias: 'Umbraco.ColorPicker.EyeDropper',
 		settings: {
 			properties: [
 				{

--- a/src/packages/core/property-editors/uis/icon-picker/manifests.ts
+++ b/src/packages/core/property-editors/uis/icon-picker/manifests.ts
@@ -7,7 +7,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-icon-picker.element.js'),
 	meta: {
 		label: 'Icon Picker',
-		propertyEditorAlias: 'Umbraco.JSON',
+		propertyEditorSchemaAlias: 'Umbraco.JSON',
 		icon: 'umb:autofill',
 		group: 'common',
 	},

--- a/src/packages/core/property-editors/uis/image-cropper/manifests.ts
+++ b/src/packages/core/property-editors/uis/image-cropper/manifests.ts
@@ -9,6 +9,6 @@ export const manifest: ManifestPropertyEditorUi = {
 		label: 'Image Cropper',
 		icon: 'umb:colorpicker',
 		group: 'pickers',
-		propertyEditorAlias: 'Umbraco.ImageCropper',
+		propertyEditorSchemaAlias: 'Umbraco.ImageCropper',
 	},
 };

--- a/src/packages/core/property-editors/uis/image-crops-configuration/manifests.ts
+++ b/src/packages/core/property-editors/uis/image-crops-configuration/manifests.ts
@@ -9,6 +9,6 @@ export const manifest: ManifestPropertyEditorUi = {
 		label: 'Image Crops Configuration',
 		icon: 'umb:autofill',
 		group: 'common',
-		propertyEditorAlias: '',
+		propertyEditorSchemaAlias: '',
 	},
 };

--- a/src/packages/core/property-editors/uis/label/manifests.ts
+++ b/src/packages/core/property-editors/uis/label/manifests.ts
@@ -9,6 +9,6 @@ export const manifest: ManifestPropertyEditorUi = {
 		label: 'Label',
 		icon: 'umb:readonly',
 		group: 'pickers',
-		propertyEditorAlias: 'Umbraco.Label',
+		propertyEditorSchemaAlias: 'Umbraco.Label',
 	},
 };

--- a/src/packages/core/property-editors/uis/manifests.ts
+++ b/src/packages/core/property-editors/uis/manifests.ts
@@ -74,7 +74,7 @@ export const manifests: Array<ManifestPropertyEditorUi> = [
 			label: 'Number',
 			icon: 'umb:autofill',
 			group: 'common',
-			propertyEditorAlias: 'Umbraco.Integer',
+			propertyEditorSchemaAlias: 'Umbraco.Integer',
 		},
 	},
 ];

--- a/src/packages/core/property-editors/uis/markdown-editor/manifests.ts
+++ b/src/packages/core/property-editors/uis/markdown-editor/manifests.ts
@@ -7,7 +7,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-markdown-editor.element.js'),
 	meta: {
 		label: 'Markdown Editor',
-		propertyEditorAlias: 'Umbraco.MarkdownEditor',
+		propertyEditorSchemaAlias: 'Umbraco.MarkdownEditor',
 		icon: 'umb:code',
 		group: 'pickers',
 		settings: {

--- a/src/packages/core/property-editors/uis/media-picker/manifests.ts
+++ b/src/packages/core/property-editors/uis/media-picker/manifests.ts
@@ -7,7 +7,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-media-picker.element.js'),
 	meta: {
 		label: 'Media Picker',
-		propertyEditorAlias: 'Umbraco.MediaPicker3',
+		propertyEditorSchemaAlias: 'Umbraco.MediaPicker3',
 		icon: 'umb:picture',
 		group: 'pickers',
 	},

--- a/src/packages/core/property-editors/uis/member-group-picker/manifests.ts
+++ b/src/packages/core/property-editors/uis/member-group-picker/manifests.ts
@@ -7,7 +7,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-member-group-picker.element.js'),
 	meta: {
 		label: 'Member Group Picker',
-		propertyEditorAlias: 'Umbraco.MemberGroupPicker',
+		propertyEditorSchemaAlias: 'Umbraco.MemberGroupPicker',
 		icon: 'umb:users-alt',
 		group: 'people',
 	},

--- a/src/packages/core/property-editors/uis/member-picker/manifests.ts
+++ b/src/packages/core/property-editors/uis/member-picker/manifests.ts
@@ -7,7 +7,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-member-picker.element.js'),
 	meta: {
 		label: 'Member Picker',
-		propertyEditorAlias: 'Umbraco.MemberPicker',
+		propertyEditorSchemaAlias: 'Umbraco.MemberPicker',
 		icon: 'umb:user',
 		group: 'people',
 	},

--- a/src/packages/core/property-editors/uis/multi-url-picker/manifests.ts
+++ b/src/packages/core/property-editors/uis/multi-url-picker/manifests.ts
@@ -7,7 +7,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-multi-url-picker.element.js'),
 	meta: {
 		label: 'Multi URL Picker',
-		propertyEditorAlias: 'Umbraco.MultiUrlPicker',
+		propertyEditorSchemaAlias: 'Umbraco.MultiUrlPicker',
 		icon: 'umb:link',
 		group: 'pickers',
 		settings: {

--- a/src/packages/core/property-editors/uis/multiple-text-string/manifests.ts
+++ b/src/packages/core/property-editors/uis/multiple-text-string/manifests.ts
@@ -7,7 +7,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-multiple-text-string.element.js'),
 	meta: {
 		label: 'Multiple Text String',
-		propertyEditorAlias: 'Umbraco.MultipleTextString',
+		propertyEditorSchemaAlias: 'Umbraco.MultipleTextString',
 		icon: 'umb:ordered-list',
 		group: '',
 		supportsReadOnly: true,

--- a/src/packages/core/property-editors/uis/number-range/manifests.ts
+++ b/src/packages/core/property-editors/uis/number-range/manifests.ts
@@ -7,7 +7,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-number-range.element.js'),
 	meta: {
 		label: 'Number Range',
-		propertyEditorAlias: '',
+		propertyEditorSchemaAlias: '',
 		icon: 'umb:autofill',
 		group: 'common',
 	},

--- a/src/packages/core/property-editors/uis/number/manifests.ts
+++ b/src/packages/core/property-editors/uis/number/manifests.ts
@@ -15,7 +15,7 @@ export const manifests: Array<ManifestPropertyEditorUi> = [
 		loader: () => import('./property-editor-ui-number.element.js'),
 		meta: {
 			label: 'Integer',
-			propertyEditorAlias: 'Umbraco.Integer',
+			propertyEditorSchemaAlias: 'Umbraco.Integer',
 			icon: 'umb:autofill',
 			group: 'common',
 			settings: {
@@ -36,7 +36,7 @@ export const manifests: Array<ManifestPropertyEditorUi> = [
 		loader: () => import('./property-editor-ui-number.element.js'),
 		meta: {
 			label: 'Decimal',
-			propertyEditorAlias: 'Umbraco.Decimal',
+			propertyEditorSchemaAlias: 'Umbraco.Decimal',
 			icon: 'umb:autofill',
 			group: 'common',
 			settings: {

--- a/src/packages/core/property-editors/uis/order-direction/manifests.ts
+++ b/src/packages/core/property-editors/uis/order-direction/manifests.ts
@@ -7,7 +7,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-order-direction.element.js'),
 	meta: {
 		label: 'Order Direction',
-		propertyEditorAlias: '',
+		propertyEditorSchemaAlias: '',
 		icon: 'umb:autofill',
 		group: 'common',
 	},

--- a/src/packages/core/property-editors/uis/overlay-size/manifests.ts
+++ b/src/packages/core/property-editors/uis/overlay-size/manifests.ts
@@ -7,7 +7,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-overlay-size.element.js'),
 	meta: {
 		label: 'Overlay Size',
-		propertyEditorAlias: '',
+		propertyEditorSchemaAlias: '',
 		icon: 'umb:document',
 		group: '',
 	},

--- a/src/packages/core/property-editors/uis/radio-button-list/manifests.ts
+++ b/src/packages/core/property-editors/uis/radio-button-list/manifests.ts
@@ -7,7 +7,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-radio-button-list.element.js'),
 	meta: {
 		label: 'Radio Button List',
-		propertyEditorAlias: 'Umbraco.RadioButtonList',
+		propertyEditorSchemaAlias: 'Umbraco.RadioButtonList',
 		icon: 'umb:target',
 		group: 'lists',
 		settings: {

--- a/src/packages/core/property-editors/uis/slider/manifests.ts
+++ b/src/packages/core/property-editors/uis/slider/manifests.ts
@@ -7,7 +7,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-slider.element.js'),
 	meta: {
 		label: 'Slider',
-		propertyEditorAlias: 'Umbraco.Slider',
+		propertyEditorSchemaAlias: 'Umbraco.Slider',
 		icon: 'umb:navigation-horizontal',
 		group: 'common',
 		settings: {

--- a/src/packages/core/property-editors/uis/text-box/manifests.ts
+++ b/src/packages/core/property-editors/uis/text-box/manifests.ts
@@ -16,7 +16,7 @@ export const manifests: Array<ManifestPropertyEditorUi> = [
 		loader: () => import('./property-editor-ui-text-box.element.js'),
 		meta: {
 			label: 'Text Box',
-			propertyEditorAlias: 'Umbraco.TextBox',
+			propertyEditorSchemaAlias: 'Umbraco.TextBox',
 			icon: 'umb:autofill',
 			group: 'common',
 			settings: {
@@ -37,7 +37,7 @@ export const manifests: Array<ManifestPropertyEditorUi> = [
 		loader: () => import('./property-editor-ui-text-box.element.js'),
 		meta: {
 			label: 'Email',
-			propertyEditorAlias: 'Umbraco.EmailAddress',
+			propertyEditorSchemaAlias: 'Umbraco.EmailAddress',
 			icon: 'umb:message',
 			group: 'common',
 			settings: {

--- a/src/packages/core/property-editors/uis/textarea/manifests.ts
+++ b/src/packages/core/property-editors/uis/textarea/manifests.ts
@@ -7,7 +7,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-textarea.element.js'),
 	meta: {
 		label: 'Text Area',
-		propertyEditorAlias: 'Umbraco.TextArea',
+		propertyEditorSchemaAlias: 'Umbraco.TextArea',
 		icon: 'umb:edit',
 		group: 'common',
 		settings: {

--- a/src/packages/core/property-editors/uis/tiny-mce/config/configuration/manifests.ts
+++ b/src/packages/core/property-editors/uis/tiny-mce/config/configuration/manifests.ts
@@ -7,7 +7,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-tiny-mce-configuration.element.js'),
 	meta: {
 		label: 'Rich Text Editor Configuration',
-		propertyEditorAlias: 'Umbraco.TinyMCE.Configuration',
+		propertyEditorSchemaAlias: 'Umbraco.TinyMCE.Configuration',
 		icon: 'umb:autofill',
 		group: 'common',
 	},

--- a/src/packages/core/property-editors/uis/tiny-mce/manifests.ts
+++ b/src/packages/core/property-editors/uis/tiny-mce/manifests.ts
@@ -8,7 +8,7 @@ const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-tiny-mce.element.js'),
 	meta: {
 		label: 'Rich Text Editor',
-		propertyEditorAlias: 'Umbraco.TinyMCE',
+		propertyEditorSchemaAlias: 'Umbraco.TinyMCE',
 		icon: 'umb:browser-window',
 		group: 'richText',
 		settings: {

--- a/src/packages/core/property-editors/uis/toggle/manifests.ts
+++ b/src/packages/core/property-editors/uis/toggle/manifests.ts
@@ -7,7 +7,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-toggle.element.js'),
 	meta: {
 		label: 'Toggle',
-		propertyEditorAlias: 'Umbraco.TrueFalse',
+		propertyEditorSchemaAlias: 'Umbraco.TrueFalse',
 		icon: 'umb:checkbox',
 		group: 'common',
 		settings: {

--- a/src/packages/core/property-editors/uis/tree-picker/config/start-node/manifests.ts
+++ b/src/packages/core/property-editors/uis/tree-picker/config/start-node/manifests.ts
@@ -9,6 +9,6 @@ export const manifest: ManifestPropertyEditorUi = {
 		label: 'Tree Picker Start Node',
 		icon: 'umb:page-add',
 		group: 'pickers',
-		propertyEditorAlias: '',
+		propertyEditorSchemaAlias: '',
 	},
 };

--- a/src/packages/core/property-editors/uis/tree-picker/manifests.ts
+++ b/src/packages/core/property-editors/uis/tree-picker/manifests.ts
@@ -10,7 +10,7 @@ const manifest: ManifestPropertyEditorUi = {
 		label: 'Tree Picker',
 		icon: 'umb:page-add',
 		group: 'pickers',
-		propertyEditorAlias: 'Umbraco.MultiNodeTreePicker',
+		propertyEditorSchemaAlias: 'Umbraco.MultiNodeTreePicker',
 		settings: {
 			properties: [
 				{

--- a/src/packages/core/property-editors/uis/upload-field/manifests.ts
+++ b/src/packages/core/property-editors/uis/upload-field/manifests.ts
@@ -7,7 +7,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-upload-field.element.js'),
 	meta: {
 		label: 'Upload Field',
-		propertyEditorAlias: 'Umbraco.UploadField',
+		propertyEditorSchemaAlias: 'Umbraco.UploadField',
 		icon: 'umb:download-alt',
 		group: 'common',
 	},

--- a/src/packages/core/property-editors/uis/user-picker/manifests.ts
+++ b/src/packages/core/property-editors/uis/user-picker/manifests.ts
@@ -7,7 +7,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-user-picker.element.js'),
 	meta: {
 		label: 'User Picker',
-		propertyEditorAlias: 'Umbraco.UserPicker',
+		propertyEditorSchemaAlias: 'Umbraco.UserPicker',
 		icon: 'umb:user',
 		group: 'people',
 	},

--- a/src/packages/core/property-editors/uis/value-type/manifests.ts
+++ b/src/packages/core/property-editors/uis/value-type/manifests.ts
@@ -9,6 +9,6 @@ export const manifest: ManifestPropertyEditorUi = {
 		label: 'Value Type',
 		icon: 'umb:autofill',
 		group: 'common',
-		propertyEditorAlias: 'Umbraco.JSON',
+		propertyEditorSchemaAlias: 'Umbraco.JSON',
 	},
 };

--- a/src/packages/documents/documents/property-editors/Umbraco.ContentPicker.ts
+++ b/src/packages/documents/documents/property-editors/Umbraco.ContentPicker.ts
@@ -1,7 +1,7 @@
-import type { ManifestPropertyEditorModel } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: ManifestPropertyEditorModel = {
-	type: 'propertyEditorModel',
+export const manifest: ManifestPropertyEditorSchema = {
+	type: 'propertyEditorSchema',
 	name: 'Content Picker',
 	alias: 'Umbraco.ContentPicker',
 	meta: {

--- a/src/packages/documents/documents/property-editors/document-picker/manifests.ts
+++ b/src/packages/documents/documents/property-editors/document-picker/manifests.ts
@@ -7,7 +7,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-document-picker.element.js'),
 	meta: {
 		label: 'Document Picker',
-		propertyEditorAlias: 'Umbraco.ContentPicker',
+		propertyEditorSchemaAlias: 'Umbraco.ContentPicker',
 		icon: 'umb:document',
 		group: 'common',
 		settings: {

--- a/src/packages/settings/data-types/components/ref-data-type/ref-data-type.element.ts
+++ b/src/packages/settings/data-types/components/ref-data-type/ref-data-type.element.ts
@@ -29,7 +29,7 @@ export class UmbRefDataTypeElement extends UmbElementMixin(UUIRefNodeElement) {
 					if (dataType) {
 						this.name = dataType.name ?? '';
 						this.propertyEditorUiAlias = dataType.propertyEditorUiAlias ?? '';
-						this.propertyEditorModelAlias = dataType.propertyEditorAlias ?? '';
+						this.propertyEditorSchemaAlias = dataType.propertyEditorAlias ?? '';
 					}
 				},
 				'dataType'
@@ -51,7 +51,7 @@ export class UmbRefDataTypeElement extends UmbElementMixin(UUIRefNodeElement) {
 	 * Property Editor Model Alias
 	 */
 	@state()
-	propertyEditorModelAlias = '';
+	propertyEditorSchemaAlias = '';
 
 	protected renderDetail() {
 		const details: string[] = [];
@@ -63,8 +63,8 @@ export class UmbRefDataTypeElement extends UmbElementMixin(UUIRefNodeElement) {
 		}
 		/*
 		// TODO: Revisit if its fine to leave this out:
-		if (this.propertyEditorModelAlias !== '') {
-			details.push(this.propertyEditorModelAlias);
+		if (this.propertyEditorSchemaAlias !== '') {
+			details.push(this.propertyEditorSchemaAlias);
 		} else {
 			details.push('Property Editor Model Missing');
 		}

--- a/src/packages/settings/data-types/components/ref-data-type/ref-data-type.stories.ts
+++ b/src/packages/settings/data-types/components/ref-data-type/ref-data-type.stories.ts
@@ -15,7 +15,7 @@ export const Overview: Story = {
 	args: {
 		name: 'Custom Data Type',
 		propertyEditorUiAlias: 'Umb.DataTypeInput.CustomUI',
-		propertyEditorModelAlias: 'Umbraco.JSON',
+		propertyEditorSchemaAlias: 'Umbraco.JSON',
 	},
 };
 
@@ -23,7 +23,7 @@ export const WithDetail: Story = {
 	args: {
 		name: 'Custom Data Type',
 		propertyEditorUiAlias: 'Umb.DataType.CustomUI',
-		propertyEditorModelAlias: 'UmbracoInput.JSON',
+		propertyEditorSchemaAlias: 'UmbracoInput.JSON',
 		detail: 'With some custom details',
 	},
 };
@@ -32,14 +32,14 @@ export const WithSlots: Story = {
 	args: {
 		name: 'Custom Data Type',
 		propertyEditorUiAlias: 'Umb.DataTypeInput.CustomUI',
-		propertyEditorModelAlias: 'Umbraco.JSON',
+		propertyEditorSchemaAlias: 'Umbraco.JSON',
 		detail: 'With some custom details',
 	},
 	render: (args) => html`
 		<umb-ref-data-type
 			.name=${args.name}
 			.propertyEditorUiAlias=${args.propertyEditorUiAlias}
-			.propertyEditorModelAlias=${args.propertyEditorModelAlias}
+			.propertyEditorSchemaAlias=${args.propertyEditorSchemaAlias}
 			.detail=${args.detail}>
 			<div slot="tag"><uui-tag color="positive">10</uui-tag></div>
 			<div slot="actions">

--- a/src/packages/settings/data-types/workspace/data-type-workspace.context.ts
+++ b/src/packages/settings/data-types/workspace/data-type-workspace.context.ts
@@ -55,7 +55,7 @@ export class UmbDataTypeWorkspaceContext
 		this.#data.update({ name });
 	}
 
-	setPropertyEditorAlias(alias?: string) {
+	setPropertyEditorSchemaAlias(alias?: string) {
 		this.#data.update({ propertyEditorAlias: alias });
 	}
 	setPropertyEditorUiAlias(alias?: string) {

--- a/src/packages/settings/data-types/workspace/views/details/data-type-details-workspace-view.element.ts
+++ b/src/packages/settings/data-types/workspace/views/details/data-type-details-workspace-view.element.ts
@@ -32,7 +32,7 @@ export class UmbDataTypeDetailsWorkspaceViewEditElement
 	private _propertyEditorUiAlias?: string;
 
 	@state()
-	private _propertyEditorAlias?: string;
+	private _propertyEditorSchemaAlias?: string;
 
 	@state()
 	private _data: Array<any> = [];
@@ -69,13 +69,13 @@ export class UmbDataTypeDetailsWorkspaceViewEditElement
 				if (this._dataType.propertyEditorAlias) {
 					// Get the property editor UI alias from the property editor alias:
 					this.observe(
-						umbExtensionsRegistry.getByTypeAndAlias('propertyEditorModel', this._dataType.propertyEditorAlias),
-						(propertyEditorModel) => {
-							// TODO: show error. We have stored a PropertyEditorModelAlias and can't find the PropertyEditorModel in the registry.
-							if (!propertyEditorModel) return;
-							this._setPropertyEditorUiAlias(propertyEditorModel.meta.defaultPropertyEditorUiAlias ?? undefined);
+						umbExtensionsRegistry.getByTypeAndAlias('propertyEditorSchema', this._dataType.propertyEditorAlias),
+						(propertyEditorSchema) => {
+							// TODO: show error. We have stored a propertyEditorSchemaAlias and can't find the PropertyEditorSchema in the registry.
+							if (!propertyEditorSchema) return;
+							this._setPropertyEditorUiAlias(propertyEditorSchema.meta.defaultPropertyEditorUiAlias ?? undefined);
 						},
-						'_observePropertyEditorModelForDefaultUI'
+						'_observepropertyEditorSchemaForDefaultUI'
 					);
 				} else {
 					this._setPropertyEditorUiAlias(undefined);
@@ -105,8 +105,8 @@ export class UmbDataTypeDetailsWorkspaceViewEditElement
 			return;
 		}
 
-		// remove the '_observePropertyEditorModelForDefaultUI' controller, as we do not want to observe for default value anymore:
-		this.removeControllerByUnique('_observePropertyEditorModelForDefaultUI');
+		// remove the '_observepropertyEditorSchemaForDefaultUI' controller, as we do not want to observe for default value anymore:
+		this.removeControllerByUnique('_observepropertyEditorSchemaForDefaultUI');
 
 		this.observe(
 			umbExtensionsRegistry.getByTypeAndAlias('propertyEditorUi', propertyEditorUiAlias),
@@ -117,9 +117,9 @@ export class UmbDataTypeDetailsWorkspaceViewEditElement
 				this._propertyEditorUiName = propertyEditorUI?.meta.label ?? propertyEditorUI?.name ?? '';
 				this._propertyEditorUiAlias = propertyEditorUI?.alias ?? '';
 				this._propertyEditorUiIcon = propertyEditorUI?.meta.icon ?? '';
-				this._propertyEditorAlias = propertyEditorUI?.meta.propertyEditorAlias ?? '';
+				this._propertyEditorSchemaAlias = propertyEditorUI?.meta.propertyEditorSchemaAlias ?? '';
 
-				this._workspaceContext?.setPropertyEditorAlias(this._propertyEditorAlias);
+				this._workspaceContext?.setPropertyEditorSchemaAlias(this._propertyEditorSchemaAlias);
 			},
 			'_observePropertyEditorUI'
 		);
@@ -158,7 +158,7 @@ export class UmbDataTypeDetailsWorkspaceViewEditElement
 								slot="editor"
 								name=${this._propertyEditorUiName}
 								alias=${this._propertyEditorUiAlias}
-								property-editor-model-alias=${this._propertyEditorAlias}
+								property-editor-model-alias=${this._propertyEditorSchemaAlias}
 								border>
 								<uui-icon name="${this._propertyEditorUiIcon}" slot="icon"></uui-icon>
 								<uui-action-bar slot="actions">
@@ -180,7 +180,7 @@ export class UmbDataTypeDetailsWorkspaceViewEditElement
 
 	private _renderConfig() {
 		return html`
-			${this._propertyEditorAlias && this._propertyEditorUiAlias
+			${this._propertyEditorSchemaAlias && this._propertyEditorUiAlias
 				? html`
 						<uui-box headline="Settings">
 							<umb-property-editor-config

--- a/src/packages/tags/property-editors/tags/config/storage-type/manifests.ts
+++ b/src/packages/tags/property-editors/tags/config/storage-type/manifests.ts
@@ -7,7 +7,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-tags-storage-type.element.js'),
 	meta: {
 		label: 'Tags Storage Type',
-		propertyEditorAlias: '',
+		propertyEditorSchemaAlias: '',
 		icon: 'umb:autofill',
 		group: 'common',
 	},

--- a/src/packages/tags/property-editors/tags/manifests.ts
+++ b/src/packages/tags/property-editors/tags/manifests.ts
@@ -8,7 +8,7 @@ const manifest: ManifestPropertyEditorUi = {
 	loader: () => import('./property-editor-ui-tags.element.js'),
 	meta: {
 		label: 'Tags',
-		propertyEditorAlias: 'Umbraco.Tags',
+		propertyEditorSchemaAlias: 'Umbraco.Tags',
 		icon: 'umb:tags',
 		group: 'common',
 	},

--- a/storybook/stories/extending/property-editors.mdx
+++ b/storybook/stories/extending/property-editors.mdx
@@ -26,7 +26,7 @@ import { Meta } from '@storybook/addon-docs';
 
 ```json
 {
-	"type": "propertyEditorModel",
+	"type": "propertyEditorSchema",
 	"name": "Text Box",
 	"alias": "Umbraco.TextBox",
 };
@@ -43,7 +43,7 @@ import { Meta } from '@storybook/addon-docs';
 	"js": "./my-text-box.element.js",
 	"meta": {
 		"label": "My Text Box",
-		"propertyEditorModel": "Umbraco.TextBox",
+		"propertyEditorSchema": "Umbraco.TextBox",
 		"icon": "umb:autofill",
 		"group": "common"
 	}


### PR DESCRIPTION
Rename propertyEditor and/or propertyEditorModel to `propertyEditorSchema.

Backend models will follow along later.