### PR TITLE
Remove tokens in INSTALL state

### DIFF
--- a/src/shared/auth/auth.context.ts
+++ b/src/shared/auth/auth.context.ts
@@ -26,6 +26,10 @@ export class UmbAuthContext implements IUmbAuth {
 		});
 	}
 
+	setInitialState(): Promise<void> {
+		return this.#authFlow.setInitialState();
+	}
+
 	async fetchCurrentUser(): Promise<UmbLoggedInUser | undefined> {
 		const { data } = await tryExecuteAndNotify(this.#host, UserResource.getUserCurrent());
 

--- a/src/shared/auth/auth.interface.ts
+++ b/src/shared/auth/auth.interface.ts
@@ -3,6 +3,11 @@ import type { Observable } from '@umbraco-cms/backoffice/external/rxjs';
 
 export interface IUmbAuth {
 	/**
+	 * Initialise the auth flow.
+	 */
+	setInitialState(): Promise<void>;
+
+	/**
 	 * Get the current user's access token.
 	 *
 	 * @example


### PR DESCRIPTION
## Description

Due to needs from the backend, we should not store any tokens on the installer, since they will be invalid anyway.

## Changes

* extract auth initialization to another method and only invoke it if we are not in INSTALL state
* clear any cached tokens if we are in INSTALL state