### PR TITLE
Template Query Element - do not load in constructor

### DIFF
--- a/src/packages/templating/templates/modals/query-builder/query-builder.element.ts
+++ b/src/packages/templating/templates/modals/query-builder/query-builder.element.ts
@@ -5,7 +5,6 @@ import { UmbModalBaseElement } from '@umbraco-cms/internal/modal';
 import {
 	UMB_DOCUMENT_PICKER_MODAL,
 	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
-	UmbModalManagerContext,
 } from '@umbraco-cms/backoffice/modal';
 import {
 	TemplateQueryExecuteModel,
@@ -63,7 +62,7 @@ export default class UmbChooseInsertTypeModalElement extends UmbModalBaseElement
 	private _defaultSortDirection: SortOrder = SortOrder.Descending;
 
 	#documentRepository: UmbDocumentRepository;
-	#modalManagerContext?: UmbModalManagerContext;
+	#modalManagerContext?: typeof UMB_MODAL_MANAGER_CONTEXT_TOKEN.TYPE;
 	#templateRepository: UmbTemplateRepository;
 
 	constructor() {

--- a/src/packages/templating/templates/modals/query-builder/query-builder.element.ts
+++ b/src/packages/templating/templates/modals/query-builder/query-builder.element.ts
@@ -14,8 +14,8 @@ import {
 } from '@umbraco-cms/backoffice/backend-api';
 import { UmbDocumentRepository } from '@umbraco-cms/backoffice/document';
 import { UmbButtonWithDropdownElement } from '@umbraco-cms/backoffice/components';
+import type { UmbQueryBuilderFilterElement } from './query-builder-filter.element.js';
 import './query-builder-filter.element.js';
-import UmbQueryBuilderFilterElement from './query-builder-filter.element.js';
 
 export interface TemplateQueryBuilderModalData {
 	hidePartialViews?: boolean;
@@ -74,12 +74,15 @@ export default class UmbChooseInsertTypeModalElement extends UmbModalBaseElement
 		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
 			this.#modalManagerContext = instance;
 		});
-		this.#init();
 	}
 
-	#init() {
-		this.#getTemplateQuerySettings();
-		this.#postTemplateQuery();
+	async connectedCallback() {
+		super.connectedCallback();
+
+		await Promise.all([
+			this.#getTemplateQuerySettings(),
+			this.#postTemplateQuery()
+		]);
 	}
 
 	#close() {


### PR DESCRIPTION
load prerequisites for query builder element after its connected to the DOM and await the load before proceeding
