### PR TITLE
add warning dialog to internal cache button

### DIFF
--- a/src/packages/settings/dashboards/published-status/dashboard-published-status.element.ts
+++ b/src/packages/settings/dashboards/published-status/dashboard-published-status.element.ts
@@ -72,7 +72,7 @@ export class UmbDashboardPublishedStatusElement extends UmbLitElement {
 	private async _onReloadCacheHandler() {
 		const modalContext = this._modalContext?.open(UMB_CONFIRM_MODAL, {
 			headline: 'Reload',
-			content: html` Trigger a in-memory and local file cache reload on all servers. `,
+			content: html` Trigger a in-memory and local file cache reload on all servers.`,
 			color: 'danger',
 			confirmLabel: 'Continue',
 		});
@@ -106,6 +106,7 @@ export class UmbDashboardPublishedStatusElement extends UmbLitElement {
 
 	//Collect
 	private async _cacheCollect() {
+		this._buttonStateCollect = 'waiting';
 		const { error } = await tryExecuteAndNotify(this, PublishedCacheResource.postPublishedCacheCollect());
 		if (error) {
 			this._buttonStateCollect = 'failed';
@@ -115,8 +116,15 @@ export class UmbDashboardPublishedStatusElement extends UmbLitElement {
 	}
 
 	private async _onSnapshotCacheHandler() {
-		this._buttonStateCollect = 'waiting';
-		await this._cacheCollect();
+		const modalContex = this._modalContext?.open(UMB_CONFIRM_MODAL, {
+			headline: 'Snapshot',
+			content: html` Trigger a NuCache snapshots collection.`,
+			color: 'danger',
+			confirmLabel: 'Continue',
+		});
+		modalContex?.onSubmit().then(() => {
+			this._cacheCollect();
+		});
 	}
 
 	render() {


### PR DESCRIPTION
fix for #800 - add warning dialog to internal cache button on the settings published status dashboard. 

NOTE: Current CMS functionality does not include a warning dialog for this action so the dialog text is new.

![2023-07-31 20_30_23-Umbraco - Personal - Microsoft​ Edge](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/4968254/e24bb7c0-b34e-40c8-8b5b-7ec90e7b75df)
