### PR TITLE
Feature/document type groups

### DIFF
--- a/src/packages/core/content-type/content-type-property-structure-helper.class.ts
+++ b/src/packages/core/content-type/content-type-property-structure-helper.class.ts
@@ -29,6 +29,10 @@ export class UmbContentTypePropertyStructureHelper {
 		this.#propertyStructure.sortBy((a, b) => ((a as any).sortOrder ?? 0) - ((b as any).sortOrder ?? 0));
 	}
 
+	public getOwnerDocumentTypes() {
+		return this.#structure?.documentTypes;
+	}
+
 	public setStructureManager(structure: UmbContentTypePropertyStructureManager) {
 		this.#structure = structure;
 		this.#initResolver?.(undefined);
@@ -75,7 +79,7 @@ export class UmbContentTypePropertyStructureHelper {
 				(groupContainers) => {
 					groupContainers.forEach((group) => this._observePropertyStructureOf(group.id));
 				},
-				'_observeGroupContainers'
+				'_observeGroupContainers',
 			);
 		}
 	}
@@ -99,7 +103,7 @@ export class UmbContentTypePropertyStructureHelper {
 				// Fire update to subscribers:
 				this.#propertyStructure.next(_propertyStructure);
 			},
-			'_observePropertyStructureOfGroup' + groupId
+			'_observePropertyStructureOfGroup' + groupId,
 		);
 	}
 

--- a/src/packages/core/content-type/content-type-structure-manager.class.ts
+++ b/src/packages/core/content-type/content-type-structure-manager.class.ts
@@ -33,7 +33,7 @@ export class UmbContentTypePropertyStructureManager<R extends UmbDetailRepositor
 	#documentTypes = new UmbArrayState<T>([], (x) => x.id);
 	readonly documentTypes = this.#documentTypes.asObservable();
 	private readonly _documentTypeContainers = this.#documentTypes.asObservablePart((x) =>
-		x.flatMap((x) => x.containers ?? [])
+		x.flatMap((x) => x.containers ?? []),
 	);
 
 	#containers: UmbArrayState<PropertyTypeContainerModelBaseModel> =
@@ -137,7 +137,7 @@ export class UmbContentTypePropertyStructureManager<R extends UmbDetailRepositor
 					 */
 					this.#documentTypes.appendOne(docType);
 				}
-			})
+			}),
 		);
 	}
 
@@ -173,7 +173,7 @@ export class UmbContentTypePropertyStructureManager<R extends UmbDetailRepositor
 		contentTypeId: string | null,
 		parentId: string | null = null,
 		type: PropertyContainerTypes = 'Group',
-		sortOrder?: number
+		sortOrder?: number,
 	) {
 		await this.#init;
 		contentTypeId = contentTypeId ?? this.#ownerDocumentTypeId!;
@@ -197,7 +197,7 @@ export class UmbContentTypePropertyStructureManager<R extends UmbDetailRepositor
 	makeContainerNameUniqueForOwnerDocument(
 		newName: string,
 		containerType: PropertyContainerTypes = 'Tab',
-		parentId: string | null = null
+		parentId: string | null = null,
 	) {
 		const ownerRootContainers = this.getOwnerContainers(containerType); //getRootContainers() can't differentiates between compositions and locals
 
@@ -215,7 +215,7 @@ export class UmbContentTypePropertyStructureManager<R extends UmbDetailRepositor
 	async updateContainer(
 		documentTypeId: string | null,
 		containerId: string,
-		partialUpdate: Partial<PropertyTypeContainerModelBaseModel>
+		partialUpdate: Partial<PropertyTypeContainerModelBaseModel>,
 	) {
 		await this.#init;
 		documentTypeId = documentTypeId ?? this.#ownerDocumentTypeId!;
@@ -287,7 +287,7 @@ export class UmbContentTypePropertyStructureManager<R extends UmbDetailRepositor
 
 		const frozenProperties = this.#documentTypes.getValue().find((x) => x.id === documentTypeId)?.properties ?? [];
 
-		const properties = filterFrozenArray(frozenProperties, (x) => x.id === propertyId);
+		const properties = filterFrozenArray(frozenProperties, (x) => x.id !== propertyId);
 
 		this.#documentTypes.updateOne(documentTypeId, { properties });
 	}
@@ -295,7 +295,7 @@ export class UmbContentTypePropertyStructureManager<R extends UmbDetailRepositor
 	async updateProperty(
 		documentTypeId: string | null,
 		propertyId: string,
-		partialUpdate: Partial<PropertyTypeModelBaseModel>
+		partialUpdate: Partial<PropertyTypeModelBaseModel>,
 	) {
 		await this.#init;
 		documentTypeId = documentTypeId ?? this.#ownerDocumentTypeId!;
@@ -387,7 +387,7 @@ export class UmbContentTypePropertyStructureManager<R extends UmbDetailRepositor
 
 	containersOfParentKey(
 		parentId: PropertyTypeContainerModelBaseModel['parentId'],
-		containerType: PropertyContainerTypes
+		containerType: PropertyContainerTypes,
 	) {
 		return this.#containers.asObservablePart((data) => {
 			return data.filter((x) => x.parentId === parentId && x.type === containerType);

--- a/src/packages/core/modal/common/property-settings/property-settings-modal.element.ts
+++ b/src/packages/core/modal/common/property-settings/property-settings-modal.element.ts
@@ -153,7 +153,7 @@ export class UmbPropertySettingsModalElement extends UmbModalBaseElement<
 		this._customValidationOptions.forEach((option) => {
 			option.selected = option.value === regEx;
 		});
-		console.log(this._customValidationOptions);
+		//console.log(this._customValidationOptions);
 
 		this._returnData.validation!.regEx = regEx ?? null;
 		this.requestUpdate('_returnData');

--- a/src/packages/documents/document-types/workspace/views/design/document-type-workspace-view-edit-property.element.ts
+++ b/src/packages/documents/document-types/workspace/views/design/document-type-workspace-view-edit-property.element.ts
@@ -5,6 +5,7 @@ import {
 	UMB_CONFIRM_MODAL,
 	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
 	UMB_PROPERTY_SETTINGS_MODAL,
+	UMB_WORKSPACE_MODAL,
 	UmbConfirmModalData,
 	UmbModalRouteRegistrationController,
 } from '@umbraco-cms/backoffice/modal';
@@ -56,6 +57,9 @@ export class UmbDocumentTypeWorkspacePropertyElement extends UmbLitElement {
 	@state()
 	protected _modalRoute?: string;
 
+	@state()
+	protected _editDocumentTypePath?: string;
+
 	@property()
 	public get modalRoute() {
 		return this._modalRoute;
@@ -88,6 +92,15 @@ export class UmbDocumentTypeWorkspacePropertyElement extends UmbLitElement {
 			})
 			.observeRouteBuilder((routeBuilder) => {
 				this._modalRoute = routeBuilder(null);
+			});
+
+		new UmbModalRouteRegistrationController(this, UMB_WORKSPACE_MODAL)
+			.addAdditionalPath('document-type')
+			.onSetup(() => {
+				return { entityType: 'document-type', preset: {} };
+			})
+			.observeRouteBuilder((routeBuilder) => {
+				this._editDocumentTypePath = routeBuilder({});
 			});
 
 		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (context) => {
@@ -217,7 +230,9 @@ export class UmbDocumentTypeWorkspacePropertyElement extends UmbLitElement {
 							<uui-icon name="umb:merge"></uui-icon>
 							<span>
 								${this.localize.term('contentTypeEditor_inheritedFrom')}
-								<a href=${ifDefined(this.dataOwnerDocumentTypeId)}> ${this.dataOwnerDocumentTypeName ?? '??'}</a>
+								<a href=${this._editDocumentTypePath + 'edit/' + this.dataOwnerDocumentTypeId}>
+									${this.dataOwnerDocumentTypeName ?? '??'}
+								</a>
 							</span>
 						</uui-tag>
 					</div>

--- a/src/packages/documents/document-types/workspace/views/design/document-type-workspace-view-edit-property.element.ts
+++ b/src/packages/documents/document-types/workspace/views/design/document-type-workspace-view-edit-property.element.ts
@@ -1,9 +1,16 @@
 import { UUIInputElement, UUIInputEvent, UUITextStyles } from '@umbraco-cms/backoffice/external/uui';
-import { css, html, customElement, property, state, ifDefined } from '@umbraco-cms/backoffice/external/lit';
+import { css, html, customElement, property, state, ifDefined, nothing } from '@umbraco-cms/backoffice/external/lit';
 import { PropertyTypeModelBaseModel } from '@umbraco-cms/backoffice/backend-api';
-import { UMB_PROPERTY_SETTINGS_MODAL, UmbModalRouteRegistrationController } from '@umbraco-cms/backoffice/modal';
+import {
+	UMB_CONFIRM_MODAL,
+	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_PROPERTY_SETTINGS_MODAL,
+	UmbConfirmModalData,
+	UmbModalRouteRegistrationController,
+} from '@umbraco-cms/backoffice/modal';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 import { generateAlias } from '@umbraco-cms/backoffice/utils';
+import { UmbDataTypeRepository } from '@umbraco-cms/backoffice/data-type';
 
 /**
  *  @element document-type-workspace-view-edit-property
@@ -27,6 +34,7 @@ export class UmbDocumentTypeWorkspacePropertyElement extends UmbLitElement {
 		const oldValue = this._property;
 		this._property = value;
 		this.#modalRegistration.setUniquePathValue('propertyId', value?.id?.toString());
+		this.setDataType(this._property?.dataTypeId);
 		this.requestUpdate('property', oldValue);
 	}
 
@@ -40,10 +48,32 @@ export class UmbDocumentTypeWorkspacePropertyElement extends UmbLitElement {
 	@property({ type: Boolean })
 	public inherited?: boolean;
 
+	#dataTypeRepository = new UmbDataTypeRepository(this);
+
 	#modalRegistration;
+	private _modalManagerContext?: typeof UMB_MODAL_MANAGER_CONTEXT_TOKEN.TYPE;
 
 	@state()
 	protected _modalRoute?: string;
+
+	@property()
+	public get modalRoute() {
+		return this._modalRoute;
+	}
+
+	@property({ type: String, attribute: 'data-owner-document-type-id' })
+	public dataOwnerDocumentTypeId?: string;
+
+	@property({ type: String, attribute: 'data-owner-document-type-name' })
+	public dataOwnerDocumentTypeName?: string;
+
+	@state()
+	private _dataTypeName?: string;
+
+	async setDataType(dataTypeId: string | undefined) {
+		if (!dataTypeId) return;
+		this.#dataTypeRepository.requestById(dataTypeId).then((x) => (this._dataTypeName = x?.data?.name));
+	}
 
 	constructor() {
 		super();
@@ -59,6 +89,10 @@ export class UmbDocumentTypeWorkspacePropertyElement extends UmbLitElement {
 			.observeRouteBuilder((routeBuilder) => {
 				this._modalRoute = routeBuilder(null);
 			});
+
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (context) => {
+			this._modalManagerContext = context;
+		});
 	}
 
 	_partialUpdate(partialObject: PropertyTypeModelBaseModel) {
@@ -72,24 +106,40 @@ export class UmbDocumentTypeWorkspacePropertyElement extends UmbLitElement {
 		this.dispatchEvent(new CustomEvent('partial-property-update', { detail: partialObject }));
 	}
 
-	renderInheritedProperty() {
-		return this.property
-			? html`
-					<div id="header">
-						<b>${this.property.name}</b>
-						<i>${this.property.alias}</i>
-						<p>${this.property.description}</p>
-					</div>
-					<div id="editor"></div>
-			  `
-			: '';
-	}
-
 	@state()
 	private _aliasLocked = true;
 
 	#onToggleAliasLock() {
 		this._aliasLocked = !this._aliasLocked;
+	}
+
+	#requestRemove(e: Event) {
+		e.preventDefault();
+		e.stopImmediatePropagation();
+		if (!this.property || !this.property.id) return;
+
+		const Message: UmbConfirmModalData = {
+			headline: `${this.localize.term('actions_delete')} property`,
+			content: html`<umb-localize key="contentTypeEditor_confirmDeletePropertyMessage" .args=${[
+				this.property.name || this.property.id,
+			]}>
+					Are you sure you want to delete the property <strong>${this.property.name || this.property.id}</strong>
+				</umb-localize>
+				</div>`,
+			confirmLabel: this.localize.term('actions_delete'),
+			color: 'danger',
+		};
+
+		const modalHandler = this._modalManagerContext?.open(UMB_CONFIRM_MODAL, Message);
+
+		modalHandler
+			?.onSubmit()
+			.then(() => {
+				this.dispatchEvent(new CustomEvent('property-delete'));
+			})
+			.catch(() => {
+				return;
+			});
 	}
 
 	#onNameChange(event: UUIInputEvent) {
@@ -124,21 +174,7 @@ export class UmbDocumentTypeWorkspacePropertyElement extends UmbLitElement {
 							.value=${this.property.name}
 							@input=${this.#onNameChange}></uui-input>
 						<!-- TODO: should use UUI-LOCK-INPUT, but that does not fire an event when its locked/unlocked -->
-						<uui-input
-							name="alias"
-							id="alias-input"
-							label="alias"
-							placeholder=${this.localize.term('placeholders_alias')}
-							.value=${this.property.alias}
-							?disabled=${this._aliasLocked}
-							@input=${(e: CustomEvent) => {
-								if (e.target) this._singleValueUpdate('alias', (e.target as HTMLInputElement).value);
-							}}>
-							<!-- TODO: validation for bad characters -->
-							<div @click=${this.#onToggleAliasLock} @keydown=${() => ''} id="alias-lock" slot="prepend">
-								<uui-icon name=${this._aliasLocked ? 'umb:lock' : 'umb:unlocked'}></uui-icon>
-							</div>
-						</uui-input>
+						${this.renderPropertyAlias()}
 						<slot name="property-action-menu"></slot>
 						<p>
 							<uui-textarea
@@ -152,11 +188,79 @@ export class UmbDocumentTypeWorkspacePropertyElement extends UmbLitElement {
 								}}></uui-textarea>
 						</p>
 					</div>
-					<uui-button id="editor" label="Edit property settings" href=${ifDefined(this._modalRoute)}>
-						<b></b>
+					<uui-button
+						id="editor"
+						label=${this.localize.term('contentTypeEditor_editorSettings')}
+						href=${ifDefined(this._modalRoute)}>
+						${this.renderPropertyTags()}
+						<uui-action-bar>
+							<uui-button label="${this.localize.term('actions_delete')}" @click="${this.#requestRemove}">
+								<uui-icon name="delete"></uui-icon>
+							</uui-button>
+						</uui-action-bar>
 					</uui-button>
 			  `
 			: '';
+	}
+
+	renderInheritedProperty() {
+		return this.property
+			? html`
+					<div id="header">
+						<b>${this.property.name}</b>
+						<i>${this.property.alias}</i>
+						<p>${this.property.description}</p>
+					</div>
+					<div id="editor">
+						${this.renderPropertyTags()}
+						<uui-tag look="default" class="inherited">
+							<uui-icon name="umb:merge"></uui-icon>
+							<span>
+								${this.localize.term('contentTypeEditor_inheritedFrom')}
+								<a href=${ifDefined(this.dataOwnerDocumentTypeId)}> ${this.dataOwnerDocumentTypeName ?? '??'}</a>
+							</span>
+						</uui-tag>
+					</div>
+			  `
+			: '';
+	}
+
+	renderPropertyAlias() {
+		return this.property
+			? html`<uui-input
+					name="alias"
+					id="alias-input"
+					label="alias"
+					placeholder=${this.localize.term('placeholders_alias')}
+					.value=${this.property.alias}
+					?disabled=${this._aliasLocked}
+					@input=${(e: CustomEvent) => {
+						if (e.target) this._singleValueUpdate('alias', (e.target as HTMLInputElement).value);
+					}}>
+					<!-- TODO: validation for bad characters -->
+					<div @click=${this.#onToggleAliasLock} @keydown=${() => ''} id="alias-lock" slot="prepend">
+						<uui-icon name=${this._aliasLocked ? 'umb:lock' : 'umb:unlocked'}></uui-icon>
+					</div>
+			  </uui-input>`
+			: '';
+	}
+
+	renderPropertyTags() {
+		return this.property
+			? html`<div class="types">
+					${this.property.dataTypeId ? html`<uui-tag look="default">${this._dataTypeName}</uui-tag>` : nothing}
+					${this.property.variesByCulture
+						? html`<uui-tag look="default">
+								<uui-icon name="umb:shuffle"></uui-icon> ${this.localize.term('contentTypeEditor_cultureVariantLabel')}
+						  </uui-tag>`
+						: nothing}
+					${this.property.appearance?.labelOnTop == true
+						? html`<uui-tag look="default">
+								<span>${this.localize.term('contentTypeEditor_displaySettingsLabelOnTop')}</span>
+						  </uui-tag>`
+						: nothing}
+			  </div>`
+			: nothing;
 	}
 
 	render() {
@@ -201,7 +305,8 @@ export class UmbDocumentTypeWorkspacePropertyElement extends UmbLitElement {
 			:host(.--umb-sorter-placeholder) {
 				height: 2px;
 			}
-			:host(.--umb-sorter-placeholder) > div {
+			:host(.--umb-sorter-placeholder) > div,
+			:host(.--umb-sorter-placeholder) > uui-button {
 				display: none;
 			}
 			:host(.--umb-sorter-placeholder)::after {
@@ -225,6 +330,7 @@ export class UmbDocumentTypeWorkspacePropertyElement extends UmbLitElement {
 			}
 
 			#editor {
+				position: relative;
 				background-color: var(--uui-color-background);
 			}
 			#alias-input,
@@ -260,6 +366,40 @@ export class UmbDocumentTypeWorkspacePropertyElement extends UmbLitElement {
 			#description-input {
 				--uui-textarea-border-color: transparent;
 				font-weight: 0.5rem; /* TODO: Cant change font size of UUI textarea yet */
+			}
+
+			.types > div uui-icon,
+			.inherited uui-icon {
+				vertical-align: sub;
+			}
+
+			.inherited {
+				position: absolute;
+				top: var(--uui-size-space-2);
+				right: var(--uui-size-space-2);
+			}
+
+			.types {
+				position: absolute;
+				top: var(--uui-size-space-2);
+				left: var(--uui-size-space-2);
+				display: flex;
+				gap: var(--uui-size-space-2);
+			}
+
+			#editor uui-action-bar {
+				position: absolute;
+				top: var(--uui-size-space-2);
+				right: var(--uui-size-space-2);
+				display: none;
+			}
+			#editor:hover uui-action-bar,
+			#editor:focus uui-action-bar {
+				display: block;
+			}
+
+			a {
+				color: inherit;
 			}
 		`,
 	];


### PR DESCRIPTION
## Document Type Groups

- Properties can now be deleted. The delete button will appear when focusing/hovering the property editing field
- Properties that are inherited cannot be deleted, but will show where are inherited from, and has a link for a fast editing (modal route) the document type they belong to.
- Properties have tags that shows a little bit of info: Their datatype, if they vary by culture, and if label above is set to true.
- Clicking on "Add property" now opens a modal for creating a property, and will only create a new property if this is submitted.

