### PR TITLE
Vary by culture toggle

### DIFF
--- a/src/packages/core/content-type/content-type-property-structure-helper.class.ts
+++ b/src/packages/core/content-type/content-type-property-structure-helper.class.ts
@@ -29,7 +29,7 @@ export class UmbContentTypePropertyStructureHelper {
 		this.#propertyStructure.sortBy((a, b) => ((a as any).sortOrder ?? 0) - ((b as any).sortOrder ?? 0));
 	}
 
-	public getOwnerDocumentTypes() {
+	get ownerDocumentTypes() {
 		return this.#structure?.documentTypes;
 	}
 

--- a/src/packages/core/modal/token/property-settings-modal.token.ts
+++ b/src/packages/core/modal/token/property-settings-modal.token.ts
@@ -1,7 +1,10 @@
 import { PropertyTypeModelBaseModel } from '@umbraco-cms/backoffice/backend-api';
 import { UmbModalToken } from '@umbraco-cms/backoffice/modal';
 
-export type UmbPropertySettingsModalData = PropertyTypeModelBaseModel;
+export type UmbPropertySettingsModalData = {
+	documentTypeId: string;
+	propertyData: PropertyTypeModelBaseModel
+};
 export type UmbPropertySettingsModalResult = PropertyTypeModelBaseModel;
 
 export const UMB_PROPERTY_SETTINGS_MODAL = new UmbModalToken<

--- a/src/packages/documents/document-types/index.ts
+++ b/src/packages/documents/document-types/index.ts
@@ -1,5 +1,7 @@
 import './components/index.js';
 
+export * from './repository/index.js';
+
 export const DOCUMENT_TYPE_ROOT_ENTITY_TYPE = 'document-type-root';
 export const DOCUMENT_TYPE_ENTITY_TYPE = 'document-type';
 export const DOCUMENT_TYPE_FOLDER_ENTITY_TYPE = 'document-type-folder';

--- a/src/packages/documents/document-types/repository/document-type.store.ts
+++ b/src/packages/documents/document-types/repository/document-type.store.ts
@@ -10,7 +10,7 @@ import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api
  * @extends {UmbStoreBase}
  * @description - Data Store for Document Types
  */
-export class UmbDocumentTypeStore extends UmbStoreBase {
+export class UmbDocumentTypeStore extends UmbStoreBase<DocumentTypeResponseModel> {
 	/**
 	 * Creates an instance of UmbDocumentTypeStore.
 	 * @param {UmbControllerHostElement} host

--- a/src/packages/documents/document-types/repository/index.ts
+++ b/src/packages/documents/document-types/repository/index.ts
@@ -1,0 +1,3 @@
+export * from './document-type.repository.js'
+export * from './document-type.store.js'
+export * from './document-type.tree.store.js'

--- a/src/packages/documents/document-types/workspace/views/design/document-type-workspace-view-edit-properties.element.ts
+++ b/src/packages/documents/document-types/workspace/views/design/document-type-workspace-view-edit-properties.element.ts
@@ -104,7 +104,14 @@ export class UmbDocumentTypeWorkspaceViewEditPropertiesElement extends UmbLitEle
 		new UmbModalRouteRegistrationController(this, UMB_PROPERTY_SETTINGS_MODAL)
 			.addAdditionalPath('new-property')
 			.onSetup(async () => {
-				return (await this._propertyStructureHelper.createPropertyScaffold(this._containerId)) ?? false;
+
+				const documentTypeId = this._ownerDocumentTypes?.find(
+					(types) => types.containers?.find((containers) => containers.id === this.containerId),
+				)?.id;
+				if(documentTypeId === undefined) return false;
+				const propertyData = await this._propertyStructureHelper.createPropertyScaffold(this._containerId);
+				if(propertyData === undefined) return false;
+				return {propertyData, documentTypeId};
 			})
 			.onSubmit((result) => {
 				this.#addProperty(result);
@@ -116,7 +123,7 @@ export class UmbDocumentTypeWorkspaceViewEditPropertiesElement extends UmbLitEle
 
 	connectedCallback(): void {
 		super.connectedCallback();
-		const doctypes = this._propertyStructureHelper.getOwnerDocumentTypes();
+		const doctypes = this._propertyStructureHelper.ownerDocumentTypes;
 		if (!doctypes) return;
 		this.observe(
 			doctypes,

--- a/src/packages/documents/document-types/workspace/views/design/document-type-workspace-view-edit-property.element.ts
+++ b/src/packages/documents/document-types/workspace/views/design/document-type-workspace-view-edit-property.element.ts
@@ -86,7 +86,11 @@ export class UmbDocumentTypeWorkspacePropertyElement extends UmbLitElement {
 		this.#modalRegistration = new UmbModalRouteRegistrationController(this, UMB_PROPERTY_SETTINGS_MODAL)
 			.addUniquePaths(['propertyId'])
 			.onSetup(() => {
-				return this.property ?? false;
+				const documentTypeId = this.ownerDocumentTypeId;
+				if(documentTypeId === undefined) return false;
+				const propertyData = this.property;
+				if(propertyData === undefined) return false;
+				return {propertyData, documentTypeId};
 			})
 			.onSubmit((result) => {
 				this._partialUpdate(result);


### PR DESCRIPTION
Ability to toggle Vary by Culture for a property on a document type.

![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/6791648/e3c63da9-f3ac-411e-8f8c-073d52c37200)

This does depend on the Document Type setting, as it has to be set to Allow for vary by culture. But the way this is written it only works when the document type has been saved. This must be solved later when we have made a proxy for the context consumption event, so it can reach a context from a parent layer/modal, so solve getting the draft version in another way.
