### PR TITLE
Bugfix: Return entity type from workspace context method

### DIFF
--- a/src/packages/users/user-groups/workspace/user-group-workspace.context.ts
+++ b/src/packages/users/user-groups/workspace/user-group-workspace.context.ts
@@ -55,9 +55,11 @@ export class UmbUserGroupWorkspaceContext
 	getEntityId(): string | undefined {
 		throw new Error('Method not implemented.');
 	}
+	
 	getEntityType(): string {
-		throw new Error('Method not implemented.');
+		return 'user-group';
 	}
+
 	getData(): UserGroupResponseModel | undefined {
 		throw new Error('Method not implemented.');
 	}


### PR DESCRIPTION
Currently, the user group workspace editor can't render a user group because it doesn't return anything from the getEntityType method. The result is that the workspace context never gets consumed.

This PR quick fixes the problem, and returns the 'user-group' entityType from the workspace context. Ideally, we should get the entity type from the User Group Repository, because a workspace could consist of multiple entity types, but I think we need to change this in many places.