### PR TITLE
profiling reflecting correct status

### DIFF
--- a/src/packages/settings/dashboards/performance-profiling/dashboard-performance-profiling.element.ts
+++ b/src/packages/settings/dashboards/performance-profiling/dashboard-performance-profiling.element.ts
@@ -38,7 +38,11 @@ export class UmbDashboardPerformanceProfilingElement extends UmbLitElement {
 			ProfilingResource.putProfilingStatus({ requestBody: { enabled: !this._profilingStatus } }),
 		);
 
-		error ? this.#setToggle(this._profilingStatus) : this.#setToggle(!this._profilingStatus);
+		if (error) {
+			this.#setToggle(this._profilingStatus);
+		} else {
+			this.#setToggle(!this._profilingStatus);
+		}
 	}
 
 	private renderProfilingStatus() {


### PR DESCRIPTION
The profiling toggle will now not toggle in case of API error, to reflect the current status.
Also added localizations.