### PR TITLE
Bugfix: Fix Missing server configuration in installer

### DIFF
--- a/src/apps/app/app.element.ts
+++ b/src/apps/app/app.element.ts
@@ -114,6 +114,10 @@ export class UmbAppElement extends UmbLitElement {
 
 		// Try to initialise the auth flow and get the runtime status
 		try {
+			if (this.bypassAuth === false) {
+				await this.#authFlow.fetchServiceConfiguration();
+			}
+
 			// Get the current runtime level
 			await this.#setInitStatus();
 

--- a/src/shared/auth/auth-flow.ts
+++ b/src/shared/auth/auth-flow.ts
@@ -102,7 +102,7 @@ export class UmbAuthFlow {
 		openIdConnectUrl: string,
 		redirectUri: string,
 		clientId = 'umbraco-back-office',
-		scope = 'offline_access'
+		scope = 'offline_access',
 	) {
 		this.#openIdConnectUrl = openIdConnectUrl;
 		this.#redirectUri = redirectUri;
@@ -115,7 +115,7 @@ export class UmbAuthFlow {
 		this.#authorizationHandler = new RedirectRequestHandler(
 			this.#storageBackend,
 			new UmbNoHashQueryStringUtils(),
-			window.location
+			window.location,
 		);
 
 		// set notifier to deliver responses
@@ -156,7 +156,10 @@ export class UmbAuthFlow {
 	 */
 	async setInitialState() {
 		// Ensure there is a connection to the server
-		await this.fetchServiceConfiguration();
+		if (!this.#configuration) {
+			await this.fetchServiceConfiguration();
+		}
+
 		const tokenResponseJson = await this.#storageBackend.getItem(TOKEN_RESPONSE_NAME);
 		if (tokenResponseJson) {
 			const response = new TokenResponse(JSON.parse(tokenResponseJson));
@@ -216,7 +219,7 @@ export class UmbAuthFlow {
 				extras: extras,
 			},
 			undefined,
-			true
+			true,
 		);
 
 		this.#authorizationHandler.performAuthorizationRequest(this.#configuration, request);


### PR DESCRIPTION
When installing the Backoffice we didn't fetch the server configuration. That resulted in a js-error when the installation was done.

https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/src/apps/app/app.element.ts#L122

I have added a call to always fetch the server configuration (unless auth is bypassed).