### PR TITLE
Bugfix: Save validation error - wrong update model passed to server

### DIFF
--- a/src/packages/documents/documents/repository/sources/document.server.data.ts
+++ b/src/packages/documents/documents/repository/sources/document.server.data.ts
@@ -100,7 +100,21 @@ export class UmbDocumentServerDataSource
 	 */
 	async update(id: string, document: UpdateDocumentRequestModel) {
 		if (!id) throw new Error('Id is missing');
-		return tryExecuteAndNotify(this.#host, DocumentResource.putDocumentById({ id, requestBody: document }));
+
+		/* TODO: look into why typescript doesn't complain about getting another model than UpdateDocumentRequestModel
+		Maybe we should simplify the sources, and always send the biggest model.
+		Then it is up to the data source to format the data correctly before passing it to wherever */
+		const requestBody: UpdateDocumentRequestModel = {
+			templateId: document.templateId,
+			values: document.values,
+			variants: document.variants?.map((variant) => ({
+				culture: variant.culture,
+				segment: variant.segment,
+				name: variant.name,
+			})),
+		};
+
+		return tryExecuteAndNotify(this.#host, DocumentResource.putDocumentById({ id, requestBody }));
 	}
 
 	/**


### PR DESCRIPTION
For some reason, we sent the wrong model to the server which resulted in a validation error.

We should look into why TypeScript didn't complain about the wrong model being passed to the method. 

How to test:
* Test that it is possible to save a document.