### PR TITLE
Chore: Temp remove non working document workspace actions

### DIFF
--- a/src/packages/documents/documents/workspace/manifests.ts
+++ b/src/packages/documents/documents/workspace/manifests.ts
@@ -78,6 +78,7 @@ const workspaceViewCollections: Array<ManifestWorkspaceViewCollection> = [
 ];
 
 const workspaceActions: Array<ManifestWorkspaceAction> = [
+	/*
 	{
 		type: 'workspaceAction',
 		alias: 'Umb.WorkspaceAction.Document.SaveAndPublish',
@@ -96,6 +97,7 @@ const workspaceActions: Array<ManifestWorkspaceAction> = [
 			},
 		],
 	},
+	*/
 	{
 		type: 'workspaceAction',
 		alias: 'Umb.WorkspaceAction.Document.Save',
@@ -103,7 +105,8 @@ const workspaceActions: Array<ManifestWorkspaceAction> = [
 		weight: 80,
 		meta: {
 			label: 'Save',
-			look: 'secondary',
+			look: 'primary',
+			color: 'positive',
 			api: UmbSaveWorkspaceAction,
 		},
 		conditions: [
@@ -113,6 +116,7 @@ const workspaceActions: Array<ManifestWorkspaceAction> = [
 			},
 		],
 	},
+	/*
 	{
 		type: 'workspaceAction',
 		alias: 'Umb.WorkspaceAction.Document.SaveAndPreview',
@@ -145,6 +149,7 @@ const workspaceActions: Array<ManifestWorkspaceAction> = [
 			},
 		],
 	},
+	*/
 ];
 
 export const manifests = [workspace, ...workspaceEditorViews, ...workspaceViewCollections, ...workspaceActions];


### PR DESCRIPTION
A clean-up PR that removes the nonworking document workspace buttons for the preview release.

The PR also makes the save button green. Only because it is the only button now. We will change back later.