### PR TITLE
Bugfix: Fix user group paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 		"./partial-view": "./dist-cms/packages/templating/partial-views/index.js",
 		"./stylesheet": "./dist-cms/packages/templating/stylesheets/index.js",
 		"./template": "./dist-cms/packages/templating/templates/index.js",
-		"./user-group": "./dist-cms/packages/user/user-groups/index.js",
+		"./user-group": "./dist-cms/packages/user/user-group/index.js",
 		"./current-user": "./dist-cms/packages/user/current-user/index.js",
 		"./user": "./dist-cms/packages/user/user/index.js",
 		"./code-editor": "./dist-cms/packages/templating/code-editor/index.js",

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -101,7 +101,7 @@ export default {
 						'@umbraco-cms/backoffice/stylesheet': './src/packages/templating/stylesheets/index.ts',
 						'@umbraco-cms/backoffice/template': './src/packages/templating/templates/index.ts',
 
-						'@umbraco-cms/backoffice/user-group': './src/packages/user/user-groups/index.ts',
+						'@umbraco-cms/backoffice/user-group': './src/packages/user/user-group/index.ts',
 						'@umbraco-cms/backoffice/current-user': './src/packages/user/current-user/index.ts',
 						'@umbraco-cms/backoffice/user': './src/packages/user/user/index.ts',
 


### PR DESCRIPTION
A couple of paths were forgotten when the user group folder was renamed.

Please review this at the same time for the razor files in the CMS: https://github.com/umbraco/Umbraco-CMS/pull/14952