### PR TITLE
Feature/isolate auth flow

### DIFF
--- a/src/apps/app/app.element.ts
+++ b/src/apps/app/app.element.ts
@@ -247,7 +247,7 @@ export class UmbAppElement extends UmbLitElement {
 
 	#isAuthorized(): boolean {
 		if (!this.#authContext) return false;
-		return this.bypassAuth ? true : this.#authContext.isLoggedIn.value;
+		return this.bypassAuth ? true : this.#authContext.isAuthorized();
 	}
 
 	#isAuthorizedGuard(): Guard {

--- a/src/apps/app/app.element.ts
+++ b/src/apps/app/app.element.ts
@@ -201,7 +201,11 @@ export class UmbAppElement extends UmbLitElement {
 
 		this.#listenForLanguageChange();
 
-		this.#authContext!.isLoggedIn.next(true);
+		if (this.#authContext?.isAuthorized()) {
+			this.#authContext.isLoggedIn.next(true);
+		} else {
+			this.#authContext?.isLoggedIn.next(false);
+		}
 	}
 
 	#redirect() {

--- a/src/apps/app/app.element.ts
+++ b/src/apps/app/app.element.ts
@@ -88,8 +88,7 @@ export class UmbAppElement extends UmbLitElement {
 		// This way we can ensure that the document language is always loaded first and subsequently registered as the fallback language.
 		umbLocalizationRegistry.isDefaultLoaded.subscribe((isDefaultLoaded) => {
 			if (!this.#authContext) {
-				console.error('[Fatal] AuthContext requested before it was initialised');
-				return;
+				throw new Error('[Fatal] AuthContext requested before it was initialised');
 			}
 
 			if (!isDefaultLoaded) return;
@@ -185,12 +184,11 @@ export class UmbAppElement extends UmbLitElement {
 	}
 
 	async #setAuthStatus() {
-		if (!this.#authContext) {
-			console.error('[Fatal] AuthContext requested before it was initialised');
-			return;
-		}
-
 		if (this.bypassAuth === false) {
+			if (!this.#authContext) {
+				throw new Error('[Fatal] AuthContext requested before it was initialised');
+			}
+
 			// Get service configuration from authentication server
 			await this.#authContext.setInitialState();
 

--- a/src/apps/app/app.element.ts
+++ b/src/apps/app/app.element.ts
@@ -1,7 +1,7 @@
 import type { UmbAppErrorElement } from './app-error.element.js';
 import { UMB_APP, UmbAppContext } from './app.context.js';
 import { umbLocalizationRegistry } from '@umbraco-cms/backoffice/localization';
-import { UMB_AUTH, UmbAuthFlow, UmbAuthContext } from '@umbraco-cms/backoffice/auth';
+import { UMB_AUTH, UmbAuthContext } from '@umbraco-cms/backoffice/auth';
 import { css, html, customElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UUIIconRegistryEssential } from '@umbraco-cms/backoffice/external/uui';
 import { UmbIconRegistry } from '@umbraco-cms/backoffice/icon';
@@ -56,7 +56,7 @@ export class UmbAppElement extends UmbLitElement {
 		},
 	];
 
-	#authFlow?: UmbAuthFlow;
+	#authContext?: UmbAuthContext;
 	#umbIconRegistry = new UmbIconRegistry();
 	#uuiIconRegistry = new UUIIconRegistryEssential();
 	#runtimeLevel = RuntimeLevelModel.UNKNOWN;
@@ -81,15 +81,21 @@ export class UmbAppElement extends UmbLitElement {
 		}
 	}
 
-	#listenForLanguageChange(authContext: UmbAuthContext) {
+	#listenForLanguageChange() {
 		// This will wait for the default language to be loaded before attempting to load the current user language
 		// just in case the user language is not the default language.
 		// We **need** to do this because the default language (typically en-us) holds all the fallback keys for all the other languages.
 		// This way we can ensure that the document language is always loaded first and subsequently registered as the fallback language.
 		umbLocalizationRegistry.isDefaultLoaded.subscribe((isDefaultLoaded) => {
+			if (!this.#authContext) {
+				console.error('[Fatal] AuthContext requested before it was initialised');
+				return;
+			}
+
 			if (!isDefaultLoaded) return;
+
 			this.observe(
-				authContext.languageIsoCode,
+				this.#authContext.languageIsoCode,
 				(currentLanguageIsoCode) => {
 					umbLocalizationRegistry.loadLanguage(currentLanguageIsoCode);
 				},
@@ -104,11 +110,9 @@ export class UmbAppElement extends UmbLitElement {
 		OpenAPI.BASE = this.serverUrl;
 		const redirectUrl = `${window.location.origin}${this.backofficePath}`;
 
-		this.#authFlow = new UmbAuthFlow(this.serverUrl, redirectUrl);
+		this.#authContext = new UmbAuthContext(this, this.serverUrl, redirectUrl);
 
-		const authContext = new UmbAuthContext(this, this.#authFlow);
-
-		this.provideContext(UMB_AUTH, authContext);
+		this.provideContext(UMB_AUTH, this.#authContext);
 
 		this.provideContext(UMB_APP, new UmbAppContext({ backofficePath: this.backofficePath, serverUrl: this.serverUrl }));
 
@@ -120,9 +124,9 @@ export class UmbAppElement extends UmbLitElement {
 			// If the runtime level is "install" we should clear any cached tokens
 			// else we should try and set the auth status
 			if (this.#runtimeLevel === RuntimeLevelModel.INSTALL) {
-				await authContext.signOut();
+				await this.#authContext.signOut();
 			} else {
-				await this.#setAuthStatus(authContext);
+				await this.#setAuthStatus();
 			}
 
 			// Initialise the router
@@ -180,19 +184,24 @@ export class UmbAppElement extends UmbLitElement {
 		this.#runtimeLevel = data?.serverStatus ?? RuntimeLevelModel.UNKNOWN;
 	}
 
-	async #setAuthStatus(authContext: UmbAuthContext) {
+	async #setAuthStatus() {
+		if (!this.#authContext) {
+			console.error('[Fatal] AuthContext requested before it was initialised');
+			return;
+		}
+
 		if (this.bypassAuth === false) {
 			// Get service configuration from authentication server
-			await authContext.setInitialState();
+			await this.#authContext.setInitialState();
 
 			// Instruct all requests to use the auth flow to get and use the access_token for all subsequent requests
-			OpenAPI.TOKEN = () => this.#authFlow!.performWithFreshTokens();
+			OpenAPI.TOKEN = () => this.#authContext!.performWithFreshTokens();
 			OpenAPI.WITH_CREDENTIALS = true;
 		}
 
-		this.#listenForLanguageChange(authContext);
+		this.#listenForLanguageChange();
 
-		authContext.isLoggedIn.next(true);
+		this.#authContext!.isLoggedIn.next(true);
 	}
 
 	#redirect() {
@@ -233,8 +242,8 @@ export class UmbAppElement extends UmbLitElement {
 	}
 
 	#isAuthorized(): boolean {
-		if (!this.#authFlow) return false;
-		return this.bypassAuth ? true : this.#authFlow.loggedIn();
+		if (!this.#authContext) return false;
+		return this.bypassAuth ? true : this.#authContext.isLoggedIn.value;
 	}
 
 	#isAuthorizedGuard(): Guard {
@@ -247,7 +256,7 @@ export class UmbAppElement extends UmbLitElement {
 			window.sessionStorage.setItem('umb:auth:redirect', location.href);
 
 			// Make a request to the auth server to start the auth flow
-			this.#authFlow!.makeAuthorizationRequest();
+			this.#authContext!.login();
 
 			// Return false to prevent the route from being rendered
 			return false;

--- a/src/apps/app/app.element.ts
+++ b/src/apps/app/app.element.ts
@@ -195,7 +195,7 @@ export class UmbAppElement extends UmbLitElement {
 			await this.#authContext.setInitialState();
 
 			// Instruct all requests to use the auth flow to get and use the access_token for all subsequent requests
-			OpenAPI.TOKEN = () => this.#authContext!.performWithFreshTokens();
+			OpenAPI.TOKEN = () => this.#authContext!.getLatestToken();
 			OpenAPI.WITH_CREDENTIALS = true;
 		}
 

--- a/src/external/openid/index.ts
+++ b/src/external/openid/index.ts
@@ -4,6 +4,7 @@ export {
 	FetchRequestor,
 	LocalStorageBackend,
 	RedirectRequestHandler,
+	RevokeTokenRequest,
 } from '@openid/appauth';
 export { AuthorizationRequest } from '@openid/appauth/built/authorization_request';
 export { AuthorizationNotifier } from '@openid/appauth/built/authorization_request_handler';

--- a/src/packages/user/current-user/modals/current-user/current-user-modal.element.ts
+++ b/src/packages/user/current-user/modals/current-user/current-user-modal.element.ts
@@ -44,7 +44,6 @@ export class UmbCurrentUserModalElement extends UmbLitElement {
 
 	private async _logout() {
 		if (!this.#authContext) return;
-		this.#authContext.performWithFreshTokens;
 		await this.#authContext.signOut();
 		let newUrl = this.#appContext ? `${this.#appContext.getBackofficePath()}/login` : '/';
 		newUrl = newUrl.replace(/\/\//g, '/');

--- a/src/shared/auth/auth-flow.ts
+++ b/src/shared/auth/auth-flow.ts
@@ -24,6 +24,7 @@ import {
 	AuthorizationServiceConfiguration,
 	GRANT_TYPE_AUTHORIZATION_CODE,
 	GRANT_TYPE_REFRESH_TOKEN,
+	RevokeTokenRequest,
 	TokenRequest,
 	TokenResponse,
 	LocationLike,
@@ -227,6 +228,17 @@ export class UmbAuthFlow {
 	 */
 	async signOut() {
 		// forget all cached token state
+		if (!this.#accessTokenResponse) {
+			return;
+		}
+
+		const tokenRevokeRequest = new RevokeTokenRequest({
+			token: this.#accessTokenResponse.accessToken,
+			client_id: this.#clientId,
+			token_type_hint: 'access_token',
+		});
+
+		await this.#tokenHandler.performRevokeTokenRequest(this.#configuration, tokenRevokeRequest);
 		this.#accessTokenResponse = undefined;
 		this.#refreshToken = undefined;
 		await this.#storageBackend.removeItem(TOKEN_RESPONSE_NAME);

--- a/src/shared/auth/auth-flow.ts
+++ b/src/shared/auth/auth-flow.ts
@@ -228,22 +228,33 @@ export class UmbAuthFlow {
 	 */
 	async signOut() {
 		// forget all cached token state
-		if (!this.#accessTokenResponse) {
-			return;
+		await this.#storageBackend.removeItem(TOKEN_RESPONSE_NAME);
+
+		if (this.#accessTokenResponse) {
+			// TODO: Enable this when the server supports it
+			// const tokenRevokeRequest = new RevokeTokenRequest({
+			// 	token: this.#accessTokenResponse.accessToken,
+			// 	client_id: this.#clientId,
+			// 	token_type_hint: 'access_token',
+			// });
+
+			// await this.#tokenHandler.performRevokeTokenRequest(this.#configuration, tokenRevokeRequest);
+
+			this.#accessTokenResponse = undefined;
 		}
 
-		// TODO: Enable this when the server supports it
-		// const tokenRevokeRequest = new RevokeTokenRequest({
-		// 	token: this.#accessTokenResponse.accessToken,
-		// 	client_id: this.#clientId,
-		// 	token_type_hint: 'access_token',
-		// });
+		if (this.#refreshToken) {
+			// TODO: Enable this when the server supports it
+			// const tokenRevokeRequest = new RevokeTokenRequest({
+			// 	token: this.#refreshToken,
+			// 	client_id: this.#clientId,
+			// 	token_type_hint: 'refresh_token',
+			// });
 
-		// await this.#tokenHandler.performRevokeTokenRequest(this.#configuration, tokenRevokeRequest);
+			// await this.#tokenHandler.performRevokeTokenRequest(this.#configuration, tokenRevokeRequest);
 
-		this.#accessTokenResponse = undefined;
-		this.#refreshToken = undefined;
-		await this.#storageBackend.removeItem(TOKEN_RESPONSE_NAME);
+			this.#refreshToken = undefined;
+		}
 	}
 
 	/**

--- a/src/shared/auth/auth-flow.ts
+++ b/src/shared/auth/auth-flow.ts
@@ -232,13 +232,15 @@ export class UmbAuthFlow {
 			return;
 		}
 
-		const tokenRevokeRequest = new RevokeTokenRequest({
-			token: this.#accessTokenResponse.accessToken,
-			client_id: this.#clientId,
-			token_type_hint: 'access_token',
-		});
+		// TODO: Enable this when the server supports it
+		// const tokenRevokeRequest = new RevokeTokenRequest({
+		// 	token: this.#accessTokenResponse.accessToken,
+		// 	client_id: this.#clientId,
+		// 	token_type_hint: 'access_token',
+		// });
 
-		await this.#tokenHandler.performRevokeTokenRequest(this.#configuration, tokenRevokeRequest);
+		// await this.#tokenHandler.performRevokeTokenRequest(this.#configuration, tokenRevokeRequest);
+
 		this.#accessTokenResponse = undefined;
 		this.#refreshToken = undefined;
 		await this.#storageBackend.removeItem(TOKEN_RESPONSE_NAME);

--- a/src/shared/auth/auth-flow.ts
+++ b/src/shared/auth/auth-flow.ts
@@ -219,7 +219,7 @@ export class UmbAuthFlow {
 	 *
 	 * @returns true if the user is logged in, false otherwise.
 	 */
-	loggedIn(): boolean {
+	isAuthorized(): boolean {
 		return !!this.#accessTokenResponse && this.#accessTokenResponse.isValid();
 	}
 

--- a/src/shared/auth/auth.context.ts
+++ b/src/shared/auth/auth.context.ts
@@ -5,26 +5,33 @@ import { UserResource } from '@umbraco-cms/backoffice/backend-api';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
 import { UmbObjectState } from '@umbraco-cms/backoffice/observable-api';
 import { tryExecuteAndNotify } from '@umbraco-cms/backoffice/resources';
-import { ReplaySubject } from '@umbraco-cms/backoffice/external/rxjs';
+import { BehaviorSubject } from '@umbraco-cms/backoffice/external/rxjs';
 
 export class UmbAuthContext implements IUmbAuth {
 	#currentUser = new UmbObjectState<UmbLoggedInUser | undefined>(undefined);
 	readonly currentUser = this.#currentUser.asObservable();
-	readonly isLoggedIn = new ReplaySubject<boolean>(1);
+	readonly isLoggedIn = new BehaviorSubject<boolean>(false);
 	readonly languageIsoCode = this.#currentUser.asObservablePart((user) => user?.languageIsoCode ?? 'en-us');
 
 	#host;
 	#authFlow;
 
-	constructor(host: UmbControllerHostElement, authFlow: UmbAuthFlow) {
+	constructor(host: UmbControllerHostElement, serverUrl: string, redirectUrl: string) {
 		this.#host = host;
-		this.#authFlow = authFlow;
+		this.#authFlow = new UmbAuthFlow(serverUrl, redirectUrl);
 
 		this.isLoggedIn.subscribe((isLoggedIn) => {
 			if (isLoggedIn) {
 				this.fetchCurrentUser();
 			}
 		});
+	}
+
+	/**
+	 * Initiates the login flow.
+	 */
+	login(): void {
+		return this.#authFlow.makeAuthorizationRequest();
 	}
 
 	setInitialState(): Promise<void> {

--- a/src/shared/auth/auth.context.ts
+++ b/src/shared/auth/auth.context.ts
@@ -58,6 +58,9 @@ export class UmbAuthContext implements IUmbAuth {
 		return this.#authFlow.performWithFreshTokens();
 	}
 
+	/**
+	 * Signs the user out by removing any tokens from the browser.
+	 */
 	signOut(): Promise<void> {
 		return this.#authFlow.signOut();
 	}

--- a/src/shared/auth/auth.context.ts
+++ b/src/shared/auth/auth.context.ts
@@ -34,6 +34,10 @@ export class UmbAuthContext implements IUmbAuth {
 		return this.#authFlow.makeAuthorizationRequest();
 	}
 
+	isAuthorized() {
+		return this.#authFlow.isAuthorized();
+	}
+
 	setInitialState(): Promise<void> {
 		return this.#authFlow.setInitialState();
 	}

--- a/src/shared/auth/auth.context.ts
+++ b/src/shared/auth/auth.context.ts
@@ -46,7 +46,15 @@ export class UmbAuthContext implements IUmbAuth {
 		return data;
 	}
 
-	performWithFreshTokens(): Promise<string> {
+	/**
+	 * Gets the latest token from the Management API.
+	 * If the token is expired, it will be refreshed.
+	 *
+	 * NB! The user may experience being redirected to the login screen if the token is expired.
+	 *
+	 * @returns The latest token from the Management API
+	 */
+	getLatestToken(): Promise<string> {
 		return this.#authFlow.performWithFreshTokens();
 	}
 

--- a/src/shared/auth/auth.interface.ts
+++ b/src/shared/auth/auth.interface.ts
@@ -13,6 +13,11 @@ export interface IUmbAuth {
 	setInitialState(): Promise<void>;
 
 	/**
+	 * Checks if there is a token and it is still valid.
+	 */
+	isAuthorized(): boolean;
+
+	/**
 	 * Gets the latest token from the Management API.
 	 * If the token is expired, it will be refreshed.
 	 *

--- a/src/shared/auth/auth.interface.ts
+++ b/src/shared/auth/auth.interface.ts
@@ -3,20 +3,30 @@ import type { Observable } from '@umbraco-cms/backoffice/external/rxjs';
 
 export interface IUmbAuth {
 	/**
+	 * Initiates the login flow.
+	 */
+	login(): void;
+
+	/**
 	 * Initialise the auth flow.
 	 */
 	setInitialState(): Promise<void>;
 
 	/**
-	 * Get the current user's access token.
+	 * Gets the latest token from the Management API.
+	 * If the token is expired, it will be refreshed.
+	 *
+	 * NB! The user may experience being redirected to the login screen if the token is expired.
 	 *
 	 * @example
 	 * ```js
-	 *   const token = await auth.getAccessToken();
+	 *   const token = await authContext.getLatestToken();
 	 *   const result = await fetch('https://my-api.com', { headers: { Authorization: `Bearer ${token}` } });
 	 * ```
+	 *
+	 * @returns The latest token from the Management API
 	 */
-	performWithFreshTokens(): Promise<string>;
+	getLatestToken(): Promise<string>;
 
 	/**
 	 * Get the current user model of the current user.
@@ -34,7 +44,7 @@ export interface IUmbAuth {
 	fetchCurrentUser(): Promise<UmbLoggedInUser | undefined>;
 
 	/**
-	 * Sign out the current user.
+	 * Signs the user out by removing any tokens from the browser.
 	 */
 	signOut(): Promise<void>;
 }

--- a/src/shared/auth/index.ts
+++ b/src/shared/auth/index.ts
@@ -1,6 +1,5 @@
-export type { IUmbAuth } from './auth.interface.js';
-export { UmbAuthFlow } from './auth-flow.js';
-export { UmbAuthContext } from './auth.context.js';
+export * from './auth.interface.js';
+export * from './auth.context.js';
 
 export * from './types.js';
 export * from './auth.token.js';


### PR DESCRIPTION
Make it more obvious what you get from the `UMB_AUTH` context and how to use it by explaining that it is related to the Management API only.

The main change is that `performWithFreshTokens` has been renamed to `getLatestToken` and added some documentation to highlight that it is only useful for the management API.

We've also removed an internal auth class from the exports to avoid letting outsiders access that directly. All auth work should be interacted with through UmbAuthContext only, which is available as the token `UMB_AUTH`.