### PR TITLE
Improvement: Simplify requirements for the workspace context interface

### DIFF
--- a/src/packages/core/workspace/workspace-action/common/save/save.action.ts
+++ b/src/packages/core/workspace/workspace-action/common/save/save.action.ts
@@ -1,9 +1,9 @@
-import { UmbWorkspaceContextInterface } from '../../../workspace-context/workspace-context.interface.js';
+import { UmbSaveableWorkspaceContextInterface } from '../../../workspace-context/saveable-workspace-context.interface.js';
 import { UmbWorkspaceActionBase } from '../../workspace-action-base.js';
 import type { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
 
 // TODO: add interface for repo/partial repo/save-repo
-export class UmbSaveWorkspaceAction extends UmbWorkspaceActionBase<UmbWorkspaceContextInterface> {
+export class UmbSaveWorkspaceAction extends UmbWorkspaceActionBase<UmbSaveableWorkspaceContextInterface> {
 	constructor(host: UmbControllerHostElement) {
 		super(host);
 

--- a/src/packages/core/workspace/workspace-context/property-structure-workspace-context.interface.ts
+++ b/src/packages/core/workspace/workspace-context/property-structure-workspace-context.interface.ts
@@ -2,9 +2,6 @@ import type { UmbWorkspaceContextInterface } from './workspace-context.interface
 import { Observable } from '@umbraco-cms/backoffice/external/rxjs';
 import type { ValueModelBaseModel } from '@umbraco-cms/backoffice/backend-api';
 
-export interface UmbPropertyStructureWorkspaceContextInterface<EntityType = unknown>
-	extends UmbWorkspaceContextInterface<EntityType> {
-
-		propertyStructureById(id: string): Promise<Observable<ValueModelBaseModel | undefined>>;
-
+export interface UmbPropertyStructureWorkspaceContextInterface extends UmbWorkspaceContextInterface {
+	propertyStructureById(id: string): Promise<Observable<ValueModelBaseModel | undefined>>;
 }

--- a/src/packages/core/workspace/workspace-context/saveable-workspace-context.interface.ts
+++ b/src/packages/core/workspace/workspace-context/saveable-workspace-context.interface.ts
@@ -1,7 +1,11 @@
 import type { UmbWorkspaceContextInterface } from './workspace-context.interface.js';
+import { Observable } from '@umbraco-cms/backoffice/external/rxjs';
 
-export interface UmbSaveableWorkspaceContextInterface<EntityType = unknown>
-	extends UmbWorkspaceContextInterface<EntityType> {
-	//getData(): EntityType | undefined;
+export interface UmbSaveableWorkspaceContextInterface<Type = unknown> extends UmbWorkspaceContextInterface {
+	isNew: Observable<boolean | undefined>;
+	getIsNew(): boolean | undefined;
+	setIsNew(value: boolean): void;
 	save(): Promise<void>;
+	setValidationErrors?(errorMap: any): void; // TODO: temp solution to bubble validation errors to the UI
+	destroy(): void;
 }

--- a/src/packages/core/workspace/workspace-context/variant-workspace-context.token.ts
+++ b/src/packages/core/workspace/workspace-context/variant-workspace-context.token.ts
@@ -3,7 +3,7 @@ import type { UmbVariantableWorkspaceContextInterface } from './workspace-varian
 import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
 import type { UmbEntityBase } from '@umbraco-cms/backoffice/models';
 
-export const UMB_VARIANT_WORKSPACE_CONTEXT_TOKEN = new UmbContextToken<UmbWorkspaceContextInterface<UmbEntityBase>, UmbVariantableWorkspaceContextInterface<UmbEntityBase>>(
-	'UmbWorkspaceContext',
-	(context): context is UmbVariantableWorkspaceContextInterface => 'variants' in context,
-);
+export const UMB_VARIANT_WORKSPACE_CONTEXT_TOKEN = new UmbContextToken<
+	UmbWorkspaceContextInterface,
+	UmbVariantableWorkspaceContextInterface<UmbEntityBase>
+>('UmbWorkspaceContext', (context): context is UmbVariantableWorkspaceContextInterface => 'variants' in context);

--- a/src/packages/core/workspace/workspace-context/workspace-context.interface.ts
+++ b/src/packages/core/workspace/workspace-context/workspace-context.interface.ts
@@ -1,18 +1,6 @@
-import { Observable } from '@umbraco-cms/backoffice/external/rxjs';
-
-export interface UmbWorkspaceContextInterface<DataType = unknown> {
-	destroy(): void;
-	workspaceAlias: string;
-
-	save(): Promise<void>;
-	// TODO: temp solution to bubble validation errors to the UI
-	setValidationErrors?(errorMap: any): void;
-
-	getEntityId(): string | undefined; // Consider if this should go away now that we have getUnique()
+export interface UmbWorkspaceContextInterface {
+	readonly workspaceAlias: string;
 	// TODO: should we consider another name than entity type. File system files are not entities but still have this type.
 	getEntityType(): string;
-
-	isNew: Observable<boolean | undefined>;
-	getIsNew(): boolean | undefined;
-	setIsNew(value: boolean): void;
+	getEntityId(): string | undefined; // Consider if this should go away now that we have getUnique()
 }

--- a/src/packages/core/workspace/workspace-context/workspace-context.token.ts
+++ b/src/packages/core/workspace/workspace-context/workspace-context.token.ts
@@ -1,7 +1,4 @@
 import type { UmbWorkspaceContextInterface } from './workspace-context.interface.js';
 import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
-import type { UmbEntityBase } from '@umbraco-cms/backoffice/models';
 
-export const UMB_WORKSPACE_CONTEXT = new UmbContextToken<UmbWorkspaceContextInterface<UmbEntityBase>>(
-	'UmbWorkspaceContext'
-);
+export const UMB_WORKSPACE_CONTEXT = new UmbContextToken<UmbWorkspaceContextInterface>('UmbWorkspaceContext');

--- a/src/packages/log-viewer/workspace/logviewer.context.ts
+++ b/src/packages/log-viewer/workspace/logviewer.context.ts
@@ -6,7 +6,6 @@ import {
 	UmbDeepState,
 	UmbObjectState,
 	UmbStringState,
-	UmbBooleanState,
 } from '@umbraco-cms/backoffice/observable-api';
 import {
 	DirectionModel,
@@ -22,8 +21,6 @@ import { UmbBaseController, UmbControllerHostElement } from '@umbraco-cms/backof
 import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
 import { query } from '@umbraco-cms/backoffice/router';
 import { UMB_WORKSPACE_CONTEXT, UmbWorkspaceContextInterface } from '@umbraco-cms/backoffice/workspace';
-import { Observable } from '@umbraco-cms/backoffice/external/rxjs';
-import type { UmbEntityBase } from '@umbraco-cms/backoffice/models';
 
 export type PoolingInterval = 0 | 2000 | 5000 | 10000 | 20000 | 30000;
 export interface PoolingCOnfig {
@@ -36,34 +33,20 @@ export interface LogViewerDateRange {
 }
 
 // TODO: Revisit usage of workspace for this case...
-export class UmbLogViewerWorkspaceContext
-	extends UmbBaseController
-	implements UmbWorkspaceContextInterface<UmbEntityBase>
-{
+export class UmbLogViewerWorkspaceContext extends UmbBaseController implements UmbWorkspaceContextInterface {
 	public readonly workspaceAlias: string = 'Umb.Workspace.LogViewer';
 	#repository: UmbLogViewerRepository;
 
-	#isNew = new UmbBooleanState<boolean | undefined>(undefined);
-	isNew: Observable<boolean | undefined> = this.#isNew.asObservable();
-	getIsNew(): boolean | undefined {
-		return false;
-	}
-	setIsNew(value: boolean): void {}
-	getEntityId(): string | undefined {
-		return undefined;
-	}
-	getData(): UmbEntityBase {
-		return {} as any;
-	}
-	repository: any;
-	getEntityType(): string {
+	getEntityType() {
 		return 'log-viewer';
 	}
-	getEntityName(): string {
+
+	getEntityName() {
 		return 'Log Viewer';
 	}
-	save() {
-		return Promise.resolve();
+
+	getEntityId() {
+		return undefined;
 	}
 
 	get today() {
@@ -352,5 +335,5 @@ export class UmbLogViewerWorkspaceContext
 }
 
 export const UMB_APP_LOG_VIEWER_CONTEXT_TOKEN = new UmbContextToken<UmbLogViewerWorkspaceContext>(
-	UmbLogViewerWorkspaceContext.name
+	UmbLogViewerWorkspaceContext.name,
 );


### PR DESCRIPTION
The interface for the workspace context had a lot of requirements that isn't needed. I have cleaned it up a bit, and moved most of them to the SaveableWorkspaceContext instead.