### PR TITLE
load msw from local to avoid storybook failures

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -9,7 +9,7 @@
   #root-inner {
     height: 100%;
   }
-	
+
 	body {
 		padding: 0px !important;
 	}
@@ -23,7 +23,7 @@
 		line-height: 1.3em;
 	}
 </style>
-<script src="https://cdn.jsdelivr.net/npm/msw/lib/iife/index.js"></script>
+<script src="umbraco/backoffice/msw/index.js"></script>
 <script>
 	(function () {
 		window.addEventListener('load', () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,6 +29,10 @@ export const plugins: PluginOption[] = [
 				src: 'node_modules/tinymce-i18n/langs6/**/*',
 				dest: 'umbraco/backoffice/tinymce/langs',
 			},
+			{
+				src: 'node_modules/msw/lib/iife/**/*',
+				dest: 'umbraco/backoffice/msw',
+			}
 		],
 	}),
 	viteTSConfigPaths(),


### PR DESCRIPTION
Storybook doesn't really work in the latest ui-api deployment. This should fix it.