### PR TITLE
Singular form of tags in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"./language": "./dist-cms/packages/settings/languages/index.js",
 		"./logviewer": "./dist-cms/packages/settings/logviewer/index.js",
 		"./relation-type": "./dist-cms/packages/settings/relation-types/index.js",
-		"./tags": "./dist-cms/packages/tags/index.js",
+		"./tag": "./dist-cms/packages/tags/index.js",
 		"./partial-view": "./dist-cms/packages/templating/partial-views/index.js",
 		"./stylesheet": "./dist-cms/packages/templating/stylesheets/index.js",
 		"./template": "./dist-cms/packages/templating/templates/index.js",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

While working on webhooks workspace I noticed a mix of singular/plural forms of exports in package.json
I have updated `tags` to `tag`, but there are a few more:

- `events` -> `event`
- `models`-> `model`
- `resources` -> `resource`
- `utils` -> `util`
- `components` -> `component`
- `themes` -> `theme`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

To be consistent in naming conventions.

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
