### PR TITLE
Bugfix: Url picker missing document picker

### DIFF
--- a/src/packages/core/modal/common/link-picker/link-picker-modal.element.ts
+++ b/src/packages/core/modal/common/link-picker/link-picker-modal.element.ts
@@ -9,6 +9,7 @@ import {
 	UmbModalBaseElement,
 } from '@umbraco-cms/backoffice/modal';
 import { buildUdi, getKeyFromUdi } from '@umbraco-cms/backoffice/utils';
+import { UMB_DOCUMENT_TREE_ALIAS } from '@umbraco-cms/backoffice/document';
 
 @customElement('umb-link-picker-modal')
 export class UmbLinkPickerModalElement extends UmbModalBaseElement<UmbLinkPickerModalData, UmbLinkPickerModalValue> {
@@ -190,7 +191,7 @@ export class UmbLinkPickerModalElement extends UmbModalBaseElement<UmbLinkPicker
 				<umb-tree
 					?hide-tree-root=${true}
 					?multiple=${false}
-					alias="Umb.Tree.Documents"
+					alias=${UMB_DOCUMENT_TREE_ALIAS}
 					@selection-change=${(event: CustomEvent) => this._handleSelectionChange(event, 'document')}
 					.selection=${[this._selectedKey ?? '']}
 					selectable></umb-tree>

--- a/src/packages/documents/documents/index.ts
+++ b/src/packages/documents/documents/index.ts
@@ -8,3 +8,5 @@ import './components/index.js';
 
 export const DOCUMENT_ROOT_ENTITY_TYPE = 'document-root';
 export const DOCUMENT_ENTITY_TYPE = 'document';
+
+export { UMB_DOCUMENT_TREE_ALIAS } from './tree/index.js';

--- a/src/packages/documents/documents/tree/index.ts
+++ b/src/packages/documents/documents/tree/index.ts
@@ -1,0 +1,1 @@
+export { UMB_DOCUMENT_TREE_ALIAS } from './manifests.js';


### PR DESCRIPTION
After a change in the document tree alias, the document picker inside the URL picker was missing. I have updated the code so it now uses an exported const from the document module.

It feels a bit off to import something from the document from within the core package, but it just shows that we need to have all property editors moved into individual (or combined for now) packages.