### PR TITLE
Feature/simple publishing

### DIFF
--- a/src/external/backend-api/src/index.ts
+++ b/src/external/backend-api/src/index.ts
@@ -213,6 +213,8 @@ export type { PropertyTypeValidationModel } from './models/PropertyTypeValidatio
 export type { PublicAccessBaseModel } from './models/PublicAccessBaseModel';
 export type { PublicAccessRequestModel } from './models/PublicAccessRequestModel';
 export type { PublicAccessResponseModel } from './models/PublicAccessResponseModel';
+export type { PublishDocumentRequestModel } from './models/PublishDocumentRequestModel';
+export type { PublishDocumentWithDescendantsRequestModel } from './models/PublishDocumentWithDescendantsRequestModel';
 export { PublishedStateModel } from './models/PublishedStateModel';
 export type { RecycleBinItemResponseModel } from './models/RecycleBinItemResponseModel';
 export { RedirectStatusModel } from './models/RedirectStatusModel';
@@ -223,6 +225,7 @@ export type { RelationResponseModel } from './models/RelationResponseModel';
 export type { RelationTypeBaseModel } from './models/RelationTypeBaseModel';
 export type { RelationTypeItemResponseModel } from './models/RelationTypeItemResponseModel';
 export type { RelationTypeResponseModel } from './models/RelationTypeResponseModel';
+export type { ResendInviteUserRequestModel } from './models/ResendInviteUserRequestModel';
 export type { ResetPasswordRequestModel } from './models/ResetPasswordRequestModel';
 export type { ResetPasswordTokenRequestModel } from './models/ResetPasswordTokenRequestModel';
 export type { RichTextRuleModel } from './models/RichTextRuleModel';
@@ -273,6 +276,7 @@ export type { TextFileViewModelBaseModel } from './models/TextFileViewModelBaseM
 export type { TourStatusModel } from './models/TourStatusModel';
 export type { TreeItemPresentationModel } from './models/TreeItemPresentationModel';
 export type { UnlockUsersRequestModel } from './models/UnlockUsersRequestModel';
+export type { UnpublishDocumentRequestModel } from './models/UnpublishDocumentRequestModel';
 export type { UpdateContentForDocumentRequestModel } from './models/UpdateContentForDocumentRequestModel';
 export type { UpdateContentForMediaRequestModel } from './models/UpdateContentForMediaRequestModel';
 export type { UpdateContentTypeForDocumentTypeRequestModel } from './models/UpdateContentTypeForDocumentTypeRequestModel';

--- a/src/external/backend-api/src/models/CreateDictionaryItemRequestModel.ts
+++ b/src/external/backend-api/src/models/CreateDictionaryItemRequestModel.ts
@@ -6,6 +6,7 @@
 import type { DictionaryItemModelBaseModel } from './DictionaryItemModelBaseModel';
 
 export type CreateDictionaryItemRequestModel = (DictionaryItemModelBaseModel & {
+    id?: string | null;
     parentId?: string | null;
 });
 

--- a/src/external/backend-api/src/models/DataTypeItemResponseModel.ts
+++ b/src/external/backend-api/src/models/DataTypeItemResponseModel.ts
@@ -6,6 +6,6 @@
 import type { ItemResponseModelBaseModel } from './ItemResponseModelBaseModel';
 
 export type DataTypeItemResponseModel = (ItemResponseModelBaseModel & {
-    icon?: string | null;
+    editorUiAlias?: string | null;
 });
 

--- a/src/external/backend-api/src/models/DataTypeTreeItemResponseModel.ts
+++ b/src/external/backend-api/src/models/DataTypeTreeItemResponseModel.ts
@@ -6,6 +6,6 @@
 import type { FolderTreeItemResponseModel } from './FolderTreeItemResponseModel';
 
 export type DataTypeTreeItemResponseModel = (FolderTreeItemResponseModel & {
-    icon?: string | null;
+    editorUiAlias?: string | null;
 });
 

--- a/src/external/backend-api/src/models/PublishDocumentRequestModel.ts
+++ b/src/external/backend-api/src/models/PublishDocumentRequestModel.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type PublishDocumentRequestModel = {
+    cultures?: Array<string>;
+};
+

--- a/src/external/backend-api/src/models/PublishDocumentWithDescendantsRequestModel.ts
+++ b/src/external/backend-api/src/models/PublishDocumentWithDescendantsRequestModel.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { PublishDocumentRequestModel } from './PublishDocumentRequestModel';
+
+export type PublishDocumentWithDescendantsRequestModel = (PublishDocumentRequestModel & {
+    includeUnpublishedDescendants?: boolean;
+});
+

--- a/src/external/backend-api/src/models/ResendInviteUserRequestModel.ts
+++ b/src/external/backend-api/src/models/ResendInviteUserRequestModel.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type ResendInviteUserRequestModel = {
+    userId?: string;
+    message?: string | null;
+};
+

--- a/src/external/backend-api/src/models/UnpublishDocumentRequestModel.ts
+++ b/src/external/backend-api/src/models/UnpublishDocumentRequestModel.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type UnpublishDocumentRequestModel = {
+    culture?: string | null;
+};
+

--- a/src/external/backend-api/src/services/DocumentResource.ts
+++ b/src/external/backend-api/src/services/DocumentResource.ts
@@ -13,7 +13,10 @@ import type { PagedDocumentTreeItemResponseModel } from '../models/PagedDocument
 import type { PagedDocumentTypeResponseModel } from '../models/PagedDocumentTypeResponseModel';
 import type { PagedRecycleBinItemResponseModel } from '../models/PagedRecycleBinItemResponseModel';
 import type { PublicAccessRequestModel } from '../models/PublicAccessRequestModel';
+import type { PublishDocumentRequestModel } from '../models/PublishDocumentRequestModel';
+import type { PublishDocumentWithDescendantsRequestModel } from '../models/PublishDocumentWithDescendantsRequestModel';
 import type { SortingRequestModel } from '../models/SortingRequestModel';
+import type { UnpublishDocumentRequestModel } from '../models/UnpublishDocumentRequestModel';
 import type { UpdateDocumentNotificationsRequestModel } from '../models/UpdateDocumentNotificationsRequestModel';
 import type { UpdateDocumentRequestModel } from '../models/UpdateDocumentRequestModel';
 import type { UpdateDomainsRequestModel } from '../models/UpdateDomainsRequestModel';
@@ -347,6 +350,255 @@ export class DocumentResource {
     }
 
     /**
+     * @returns string Created
+     * @throws ApiError
+     */
+    public static postDocumentByIdPublicAccess1({
+        id,
+        requestBody,
+    }: {
+        id: string,
+        requestBody?: PublicAccessRequestModel,
+    }): CancelablePromise<string> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/umbraco/management/api/v2/document/{id}/public-access',
+            path: {
+                'id': id,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            responseHeader: 'Location',
+            errors: {
+                404: `Not Found`,
+            },
+        });
+    }
+
+    /**
+     * @returns any Success
+     * @throws ApiError
+     */
+    public static deleteDocumentByIdPublicAccess1({
+        id,
+    }: {
+        id: string,
+    }): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/umbraco/management/api/v2/document/{id}/public-access',
+            path: {
+                'id': id,
+            },
+            errors: {
+                404: `Not Found`,
+            },
+        });
+    }
+
+    /**
+     * @returns void
+     * @throws ApiError
+     */
+    public static getDocumentByIdPublicAccess1({
+        id,
+    }: {
+        id: string,
+    }): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/umbraco/management/api/v2/document/{id}/public-access',
+            path: {
+                'id': id,
+            },
+            errors: {
+                404: `Not Found`,
+            },
+        });
+    }
+
+    /**
+     * @returns any Success
+     * @throws ApiError
+     */
+    public static putDocumentByIdPublicAccess1({
+        id,
+        requestBody,
+    }: {
+        id: string,
+        requestBody?: PublicAccessRequestModel,
+    }): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'PUT',
+            url: '/umbraco/management/api/v2/document/{id}/public-access',
+            path: {
+                'id': id,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                404: `Not Found`,
+            },
+        });
+    }
+
+    /**
+     * @returns any Success
+     * @throws ApiError
+     */
+    public static putDocumentByIdPublish({
+        id,
+        requestBody,
+    }: {
+        id: string,
+        requestBody?: (PublishDocumentRequestModel | PublishDocumentWithDescendantsRequestModel),
+    }): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'PUT',
+            url: '/umbraco/management/api/v1/document/{id}/publish',
+            path: {
+                'id': id,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                400: `Bad Request`,
+                404: `Not Found`,
+            },
+        });
+    }
+
+    /**
+     * @returns any Success
+     * @throws ApiError
+     */
+    public static putDocumentByIdPublish1({
+        id,
+        requestBody,
+    }: {
+        id: string,
+        requestBody?: (PublishDocumentRequestModel | PublishDocumentWithDescendantsRequestModel),
+    }): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'PUT',
+            url: '/umbraco/management/api/v2/document/{id}/publish',
+            path: {
+                'id': id,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                400: `Bad Request`,
+                404: `Not Found`,
+            },
+        });
+    }
+
+    /**
+     * @returns any Success
+     * @throws ApiError
+     */
+    public static putDocumentByIdPublishWithDescendants({
+        id,
+        requestBody,
+    }: {
+        id: string,
+        requestBody?: PublishDocumentWithDescendantsRequestModel,
+    }): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'PUT',
+            url: '/umbraco/management/api/v1/document/{id}/publish-with-descendants',
+            path: {
+                'id': id,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                400: `Bad Request`,
+                404: `Not Found`,
+            },
+        });
+    }
+
+    /**
+     * @returns any Success
+     * @throws ApiError
+     */
+    public static putDocumentByIdPublishWithDescendants1({
+        id,
+        requestBody,
+    }: {
+        id: string,
+        requestBody?: PublishDocumentWithDescendantsRequestModel,
+    }): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'PUT',
+            url: '/umbraco/management/api/v2/document/{id}/publish-with-descendants',
+            path: {
+                'id': id,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                400: `Bad Request`,
+                404: `Not Found`,
+            },
+        });
+    }
+
+    /**
+     * @returns any Success
+     * @throws ApiError
+     */
+    public static putDocumentByIdUnpublish({
+        id,
+        requestBody,
+    }: {
+        id: string,
+        requestBody?: UnpublishDocumentRequestModel,
+    }): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'PUT',
+            url: '/umbraco/management/api/v1/document/{id}/unpublish',
+            path: {
+                'id': id,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                400: `Bad Request`,
+                404: `Not Found`,
+            },
+        });
+    }
+
+    /**
+     * @returns any Success
+     * @throws ApiError
+     */
+    public static putDocumentByIdUnpublish1({
+        id,
+        requestBody,
+    }: {
+        id: string,
+        requestBody?: UnpublishDocumentRequestModel,
+    }): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'PUT',
+            url: '/umbraco/management/api/v2/document/{id}/unpublish',
+            path: {
+                'id': id,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                400: `Bad Request`,
+                404: `Not Found`,
+            },
+        });
+    }
+
+    /**
      * @returns PagedDocumentTypeResponseModel Success
      * @throws ApiError
      */
@@ -362,6 +614,33 @@ export class DocumentResource {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/umbraco/management/api/v1/document/allowed-document-types',
+            query: {
+                'parentId': parentId,
+                'skip': skip,
+                'take': take,
+            },
+            errors: {
+                404: `Not Found`,
+            },
+        });
+    }
+
+    /**
+     * @returns PagedDocumentTypeResponseModel Success
+     * @throws ApiError
+     */
+    public static getDocumentAllowedDocumentTypes1({
+        parentId,
+        skip,
+        take = 100,
+    }: {
+        parentId?: string,
+        skip?: number,
+        take?: number,
+    }): CancelablePromise<PagedDocumentTypeResponseModel> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/umbraco/management/api/v2/document/allowed-document-types',
             query: {
                 'parentId': parentId,
                 'skip': skip,

--- a/src/external/backend-api/src/services/UserResource.ts
+++ b/src/external/backend-api/src/services/UserResource.ts
@@ -14,6 +14,7 @@ import type { EnableUserRequestModel } from '../models/EnableUserRequestModel';
 import type { InviteUserRequestModel } from '../models/InviteUserRequestModel';
 import type { LinkedLoginsRequestModel } from '../models/LinkedLoginsRequestModel';
 import type { PagedUserResponseModel } from '../models/PagedUserResponseModel';
+import type { ResendInviteUserRequestModel } from '../models/ResendInviteUserRequestModel';
 import type { SetAvatarRequestModel } from '../models/SetAvatarRequestModel';
 import type { UnlockUsersRequestModel } from '../models/UnlockUsersRequestModel';
 import type { UpdateUserGroupsOnUserRequestModel } from '../models/UpdateUserGroupsOnUserRequestModel';
@@ -326,6 +327,24 @@ export class UserResource {
      * @returns any Success
      * @throws ApiError
      */
+    public static getUserCurrentPermissionsDocument1({
+        id,
+    }: {
+        id?: Array<string>,
+    }): CancelablePromise<Array<UserPermissionsResponseModel>> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/umbraco/management/api/v2/user/current/permissions/document',
+            query: {
+                'id': id,
+            },
+        });
+    }
+
+    /**
+     * @returns any Success
+     * @throws ApiError
+     */
     public static getUserCurrentPermissionsMedia({
         id,
     }: {
@@ -334,6 +353,24 @@ export class UserResource {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/umbraco/management/api/v1/user/current/permissions/media',
+            query: {
+                'id': id,
+            },
+        });
+    }
+
+    /**
+     * @returns any Success
+     * @throws ApiError
+     */
+    public static getUserCurrentPermissionsMedia1({
+        id,
+    }: {
+        id?: Array<string>,
+    }): CancelablePromise<Array<UserPermissionsResponseModel>> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/umbraco/management/api/v2/user/current/permissions/media',
             query: {
                 'id': id,
             },
@@ -450,6 +487,26 @@ export class UserResource {
             mediaType: 'application/json',
             errors: {
                 404: `Not Found`,
+            },
+        });
+    }
+
+    /**
+     * @returns any Success
+     * @throws ApiError
+     */
+    public static postUserInviteResend({
+        requestBody,
+    }: {
+        requestBody?: ResendInviteUserRequestModel,
+    }): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/umbraco/management/api/v1/user/invite/resend',
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                400: `Bad Request`,
             },
         });
     }

--- a/src/mocks/data/document.data.ts
+++ b/src/mocks/data/document.data.ts
@@ -10,6 +10,7 @@ import {
 	PagedDocumentTreeItemResponseModel,
 	PagedDocumentTypeResponseModel,
 	PagedRecycleBinItemResponseModel,
+	PublishDocumentRequestModel,
 } from '@umbraco-cms/backoffice/backend-api';
 import { UMB_DOCUMENT_ENTITY_TYPE } from '@umbraco-cms/backoffice/document';
 
@@ -691,6 +692,55 @@ class UmbDocumentData extends UmbEntityData<DocumentResponseModel> {
 			}
 		});
 		return result;
+	}
+
+	publish(id: string, data: PublishDocumentRequestModel) {
+
+		// Update detail data:
+		const foundIndex = this.data.findIndex((item) => item.id === id);
+		if (foundIndex !== -1) {
+			// update
+			this.data[foundIndex].variants?.forEach((variant) => {
+				if (data.cultures?.includes(variant.culture ?? '')) {
+					variant.state = ContentStateModel.PUBLISHED;
+				}
+			});
+		}
+
+		// TODO: Tree data is not aware about variants and status of variants: so this is not good enough:
+		this.treeData = this.treeData.map((x) => {
+			if (x.id && x.id === id) {
+				return { ...x, isPublished: true };
+			} else {
+				return x;
+			}
+		});
+		return true;
+	}
+
+	unpublish(id: string, data: PublishDocumentRequestModel) {
+
+		// Update detail data:
+		const foundIndex = this.data.findIndex((item) => item.id === id);
+		if (foundIndex !== -1) {
+			// update
+			this.data[foundIndex].variants?.forEach((variant) => {
+				if (data.cultures?.includes(variant.culture ?? '')) {
+					variant.state = ContentStateModel.DRAFT;
+				}
+			});
+		}
+
+		// TODO: Tree data is not aware about variants and status of variants: so this is not good enough:
+		this.treeData = this.treeData.map((x) => {
+			if (x.id && x.id === id) {
+				return { ...x, isPublished: false };
+			} else {
+				return x;
+			}
+		});
+
+		return true;
 	}
 
 	trash(ids: string[]): DocumentResponseModel[] {

--- a/src/mocks/handlers/document/document.handlers.ts
+++ b/src/mocks/handlers/document/document.handlers.ts
@@ -15,6 +15,24 @@ export const handlers = [
 		return res(ctx.status(200));
 	}),
 
+	rest.put(umbracoPath('/document/:id/publish'), async (req, res, ctx) => {
+		const id = req.params.id as string;
+		if (!id) return;
+		const data = await req.json();
+		if (!data) return;
+		umbDocumentData.publish(id, data);
+		return res(ctx.status(200));
+	}),
+
+	rest.put(umbracoPath('/document/:id/unpublish'), async (req, res, ctx) => {
+		const id = req.params.id as string;
+		if (!id) return;
+		const data = await req.json();
+		if (!data) return;
+		umbDocumentData.unpublish(id, data);
+		return res(ctx.status(200));
+	}),
+
 	rest.get(umbracoPath('/document/:id/allowed-document-types'), (req, res, ctx) => {
 		const id = req.params.id as string;
 		if (!id) return;

--- a/src/packages/core/workspace/workspace-context/publishable-workspace-context.interface.ts
+++ b/src/packages/core/workspace/workspace-context/publishable-workspace-context.interface.ts
@@ -3,6 +3,7 @@ import type { UmbSaveableWorkspaceContextInterface } from './saveable-workspace-
 export interface UmbPublishableWorkspaceContextInterface<EntityType = unknown>
 	extends UmbSaveableWorkspaceContextInterface<EntityType> {
 	//getData(): EntityType | undefined;
+	saveAndPublish(): Promise<void>;
 	publish(): Promise<void>;
 	unpublish(): Promise<void>;
 }

--- a/src/packages/core/workspace/workspace-context/publishable-workspace-context.interface.ts
+++ b/src/packages/core/workspace/workspace-context/publishable-workspace-context.interface.ts
@@ -4,4 +4,5 @@ export interface UmbPublishableWorkspaceContextInterface<EntityType = unknown>
 	extends UmbSaveableWorkspaceContextInterface<EntityType> {
 	//getData(): EntityType | undefined;
 	publish(): Promise<void>;
+	unpublish(): Promise<void>;
 }

--- a/src/packages/documents/documents/entity-actions/publish.action.ts
+++ b/src/packages/documents/documents/entity-actions/publish.action.ts
@@ -8,7 +8,8 @@ export class UmbPublishDocumentEntityAction extends UmbEntityActionBase<UmbDocum
 	}
 
 	async execute() {
-		console.log(`execute for: ${this.unique}`);
-		await this.repository?.publish();
+		console.log(`publish: ${this.unique}`);
+		// TODO: implement dialog or something to handle variants.
+		//await this.repository?.publish();
 	}
 }

--- a/src/packages/documents/documents/entity-actions/unpublish.action.ts
+++ b/src/packages/documents/documents/entity-actions/unpublish.action.ts
@@ -8,7 +8,8 @@ export class UmbUnpublishDocumentEntityAction extends UmbEntityActionBase<UmbDoc
 	}
 
 	async execute() {
-		console.log(`execute for: ${this.unique}`);
-		await this.repository?.unpublish();
+		console.log(`unpublish: ${this.unique}`);
+		// TODO: implement dialog or something to handle variants.
+		//await this.repository?.unpublish();
 	}
 }

--- a/src/packages/documents/documents/repository/document.repository.ts
+++ b/src/packages/documents/documents/repository/document.repository.ts
@@ -12,6 +12,7 @@ import {
 } from '@umbraco-cms/backoffice/backend-api';
 import { UmbNotificationContext, UMB_NOTIFICATION_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/notification';
 import { UmbApi } from '@umbraco-cms/backoffice/extension-api';
+import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 
 export class UmbDocumentRepository
 	extends UmbBaseController
@@ -217,11 +218,38 @@ export class UmbDocumentRepository
 		return { error };
 	}
 
-	// Listing all currently known methods we need to implement:
-	// these currently only covers posting data
-	// TODO: find a good way to split these
-	async saveAndPublish() {
-		alert('save and publish');
+	async saveAndPublish(id: string, variantIds: Array<UmbVariantId>) {
+		if (!id) throw new Error('id is missing');
+		if (!variantIds) throw new Error('variant IDs are missing');
+		await this.#init;
+
+		const { error } = await this.#detailDataSource.saveAndPublish(id, variantIds);
+
+		if (!error) {
+			// TODO: Update other stores based on above effect.
+
+			const notification = { data: { message: `Document published` } };
+			this.#notificationContext?.peek('positive', notification);
+		}
+
+		return { error };
+	}
+
+	async unpublish(id: string, variantIds: Array<UmbVariantId>) {
+		if (!id) throw new Error('id is missing');
+		if (!variantIds) throw new Error('variant IDs are missing');
+		await this.#init;
+
+		const { error } = await this.#detailDataSource.unpublish(id, variantIds);
+
+		if (!error) {
+			// TODO: Update other stores based on above effect.
+
+			const notification = { data: { message: `Document unpublished` } };
+			this.#notificationContext?.peek('positive', notification);
+		}
+
+		return { error };
 	}
 
 	async saveAndPreview() {
@@ -258,14 +286,6 @@ export class UmbDocumentRepository
 
 	async setPublicAccess() {
 		alert('set public access');
-	}
-
-	async publish() {
-		alert('publish');
-	}
-
-	async unpublish() {
-		alert('unpublish');
 	}
 
 	async rollback() {

--- a/src/packages/documents/documents/repository/document.repository.ts
+++ b/src/packages/documents/documents/repository/document.repository.ts
@@ -218,7 +218,26 @@ export class UmbDocumentRepository
 		return { error };
 	}
 
-	async saveAndPublish(id: string, variantIds: Array<UmbVariantId>) {
+	async saveAndPublish(id: string, item: UpdateDocumentRequestModel, variantIds: Array<UmbVariantId>) {
+		if (!id) throw new Error('id is missing');
+		if (!variantIds) throw new Error('variant IDs are missing');
+		//await this.#init;
+
+		await this.save(id, item);
+
+		const { error } = await this.#detailDataSource.saveAndPublish(id, variantIds);
+
+		if (!error) {
+			// TODO: Update other stores based on above effect.
+
+			const notification = { data: { message: `Document saved and published` } };
+			this.#notificationContext?.peek('positive', notification);
+		}
+
+		return { error };
+	}
+
+	async publish(id: string, variantIds: Array<UmbVariantId>) {
 		if (!id) throw new Error('id is missing');
 		if (!variantIds) throw new Error('variant IDs are missing');
 		await this.#init;

--- a/src/packages/documents/documents/repository/sources/document.server.data.ts
+++ b/src/packages/documents/documents/repository/sources/document.server.data.ts
@@ -6,9 +6,12 @@ import {
 	ContentStateModel,
 	CreateDocumentRequestModel,
 	UpdateDocumentRequestModel,
+	PublishDocumentRequestModel,
+	UnpublishDocumentRequestModel,
 } from '@umbraco-cms/backoffice/backend-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { tryExecuteAndNotify } from '@umbraco-cms/backoffice/resources';
+import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 
 /**
  * A data source for the Document that fetches data from the server
@@ -112,6 +115,43 @@ export class UmbDocumentServerDataSource
 		};
 
 		return tryExecuteAndNotify(this.#host, DocumentResource.putDocumentById({ id, requestBody }));
+	}
+
+
+	/**
+	 * Publish one or more variants of a Document
+	 * @param {string} id
+	 * @param {Array<UmbVariantId>} variantIds
+	 * @return {*}
+	 * @memberof UmbDocumentServerDataSource
+	 */
+	async saveAndPublish(id: string, variantIds: Array<UmbVariantId>) {
+		if (!id) throw new Error('Id is missing');
+
+		// TODO: THIS DOES NOT TAKE SEGMENTS INTO ACCOUNT!!!!!!
+		const requestBody: PublishDocumentRequestModel = {
+			cultures: variantIds.map((variant) => variant.toCultureString()),
+		};
+
+		return tryExecuteAndNotify(this.#host, DocumentResource.putDocumentByIdPublish({ id, requestBody }));
+	}
+
+	/**
+	 * Unpublish one or more variants of a Document
+	 * @param {string} id
+	 * @param {Array<UmbVariantId>} variantIds
+	 * @return {*}
+	 * @memberof UmbDocumentServerDataSource
+	 */
+	async unpublish(id: string, variantIds: Array<UmbVariantId>) {
+		if (!id) throw new Error('Id is missing');
+
+		// TODO: THIS DOES NOT TAKE SEGMENTS INTO ACCOUNT!!!!!!
+		const requestBody: UnpublishDocumentRequestModel = {
+			culture: variantIds.map((variant) => variant.toCultureString())[0],
+		};
+
+		return tryExecuteAndNotify(this.#host, DocumentResource.putDocumentByIdUnpublish({ id, requestBody }));
 	}
 
 	/**

--- a/src/packages/documents/documents/workspace/actions/save-and-publish.action.ts
+++ b/src/packages/documents/documents/workspace/actions/save-and-publish.action.ts
@@ -9,10 +9,11 @@ export class UmbDocumentSaveAndPublishWorkspaceAction extends UmbWorkspaceAction
 
 	async execute() {
 		if (!this.workspaceContext) return;
+		// TODO: Revisit, its unclear to me why we check the data of the context, should not matter IMO.
 		// TODO: it doesn't get the updated value
-		const document = this.workspaceContext.getData();
+		//const document = this.workspaceContext.getData();
 		// TODO: handle errors
-		if (!document) return;
-		this.workspaceContext.repository.saveAndPublish();
+		//if (!document) return;
+		this.workspaceContext.publish();
 	}
 }

--- a/src/packages/documents/documents/workspace/document-workspace.context.ts
+++ b/src/packages/documents/documents/workspace/document-workspace.context.ts
@@ -217,7 +217,19 @@ export class UmbDocumentWorkspaceContext
 			const variantIds = currentData.variants?.map((x) => UmbVariantId.Create(x));
 			const id = this.getEntityId();
 			if(variantIds && id) {
-				await this.repository.saveAndPublish(id, variantIds);
+				await this.repository.publish(id, variantIds);
+			}
+		}
+	}
+
+	public async saveAndPublish() {
+		// TODO: This might be right to publish all, but we need a method that just saves and publishes a declared range of variants.
+		const currentData = this.#currentData.value;
+		if(currentData) {
+			const variantIds = currentData.variants?.map((x) => UmbVariantId.Create(x));
+			const id = currentData.id;
+			if(variantIds && id) {
+				await this.repository.saveAndPublish(id, currentData, variantIds);
 			}
 		}
 	}

--- a/src/packages/documents/documents/workspace/manifests.ts
+++ b/src/packages/documents/documents/workspace/manifests.ts
@@ -80,7 +80,6 @@ const workspaceViewCollections: Array<ManifestWorkspaceViewCollection> = [
 ];
 
 const workspaceActions: Array<ManifestWorkspaceAction> = [
-	/*
 	{
 		type: 'workspaceAction',
 		alias: 'Umb.WorkspaceAction.Document.SaveAndPublish',
@@ -99,7 +98,6 @@ const workspaceActions: Array<ManifestWorkspaceAction> = [
 			},
 		],
 	},
-	*/
 	{
 		type: 'workspaceAction',
 		alias: 'Umb.WorkspaceAction.Document.Save',
@@ -108,7 +106,7 @@ const workspaceActions: Array<ManifestWorkspaceAction> = [
 		api: UmbSaveWorkspaceAction,
 		meta: {
 			label: 'Save',
-			look: 'primary',
+			look: 'secondary',
 			color: 'positive',
 		},
 		conditions: [


### PR DESCRIPTION
Implement the simple version of publishing.
This publishes all available variants, no publish dialog, also no unpublish button, as we are still missing the button drop-up UI.
Also, notice publish API does not support segments, and I think this needs to be changed to a different model like:

```
{
    variants: [
        {
            culture: string | null
            segment: string | null
        }
    ]
}
```

This would be futureproof, and allow for even more props pr. variant and as well using null for invariant or not-segmented seems more correct to me.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
