### PR TITLE
Bugfix: Render User Group Ref icon

### DIFF
--- a/src/packages/documents/documents/entity-actions/permissions/permissions-modal.element.ts
+++ b/src/packages/documents/documents/entity-actions/permissions/permissions-modal.element.ts
@@ -1,7 +1,7 @@
 import { UmbDocumentPermissionRepository } from '../../user-permissions/index.js';
 import { UmbDocumentRepository } from '../../repository/index.js';
 import { UmbUserGroupRepository } from '@umbraco-cms/backoffice/user-group';
-import { html, customElement, property, state, ifDefined } from '@umbraco-cms/backoffice/external/lit';
+import { html, customElement, property, state, ifDefined, nothing } from '@umbraco-cms/backoffice/external/lit';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import {
 	UMB_ENTITY_USER_PERMISSION_MODAL,
@@ -137,7 +137,7 @@ export class UmbPermissionsModalElement extends UmbLitElement {
 									.userPermissionAliases=${userGroup.permissions}
 									@open=${() => this.#openUserPermissionsModal(userGroup.id)}
 									border>
-									<uui-icon slot="icon" .icon=${userGroup.icon}></uui-icon>
+									${userGroup.icon ? html`<uui-icon slot="icon" name=${userGroup.icon}></uui-icon>` : nothing}
 								</umb-user-group-ref>`,
 						)}
 					</uui-ref-list>

--- a/src/packages/user/user-group/components/input-user-group/user-group-input.element.ts
+++ b/src/packages/user/user-group/components/input-user-group/user-group-input.element.ts
@@ -85,8 +85,16 @@ export class UmbUserGroupInputElement extends FormControlMixin(UmbLitElement) {
 			() => !!this.max && this.#pickerContext.getSelection().length > this.max,
 		);
 
-		this.observe(this.#pickerContext.selection, (selection) => (super.value = selection.join(',')), 'umbUserGroupInputSelectionObserver');
-		this.observe(this.#pickerContext.selectedItems, (selectedItems) => (this._items = selectedItems), 'umbUserGroupInputItemsObserver');
+		this.observe(
+			this.#pickerContext.selection,
+			(selection) => (super.value = selection.join(',')),
+			'umbUserGroupInputSelectionObserver',
+		);
+		this.observe(
+			this.#pickerContext.selectedItems,
+			(selectedItems) => (this._items = selectedItems),
+			'umbUserGroupInputItemsObserver',
+		);
 	}
 
 	protected getFormElement() {
@@ -106,7 +114,7 @@ export class UmbUserGroupInputElement extends FormControlMixin(UmbLitElement) {
 		if (!item.id) return;
 		return html`
 			<umb-user-group-ref name="${ifDefined(item.name)}">
-				${item.icon ? html`<uui-icon slot="icon" icon=${item.icon}></uui-icon>` : nothing}
+				${item.icon ? html`<uui-icon slot="icon" name=${item.icon}></uui-icon>` : nothing}
 
 				<uui-action-bar slot="actions">
 					<uui-button @click=${() => this.#pickerContext.requestRemoveItem(item.id!)} label="Remove ${item.name}"


### PR DESCRIPTION
We were using the wrong attribute name to pass the icon name into an `uui-icon` element. This PR updates the code to use the correct attribute.

How to test
* Make sure that a user group ref renders an icon. (Test the user group picker on a user)