### PR TITLE
Bugfix/inputs prevent requests without ids

### DIFF
--- a/src/packages/core/data-type/components/data-type-input/data-type-input.element.ts
+++ b/src/packages/core/data-type/components/data-type-input/data-type-input.element.ts
@@ -61,6 +61,9 @@ export class UmbDataTypeInputElement extends FormControlMixin(UmbLitElement) {
 
 	@property()
 	public set value(idsString: string) {
+		const isEmpty = idsString.trim().length === 0;
+		if (isEmpty) return;
+
 		// Its with full purpose we don't call super.value, as thats being handled by the observation of the context selection.
 		this.selectedIds = idsString.split(/[ ,]+/);
 	}

--- a/src/packages/core/data-type/components/data-type-input/data-type-input.element.ts
+++ b/src/packages/core/data-type/components/data-type-input/data-type-input.element.ts
@@ -62,7 +62,7 @@ export class UmbDataTypeInputElement extends FormControlMixin(UmbLitElement) {
 	@property()
 	public set value(idsString: string) {
 		// Its with full purpose we don't call super.value, as thats being handled by the observation of the context selection.
-		this.selectedIds = idsString.split(/[ ,]+/);
+		this.selectedIds = idsString !== '' ? idsString.split(/[ ,]+/) : [];
 	}
 
 	@property()

--- a/src/packages/core/data-type/components/data-type-input/data-type-input.element.ts
+++ b/src/packages/core/data-type/components/data-type-input/data-type-input.element.ts
@@ -61,9 +61,6 @@ export class UmbDataTypeInputElement extends FormControlMixin(UmbLitElement) {
 
 	@property()
 	public set value(idsString: string) {
-		const isEmpty = idsString.trim().length === 0;
-		if (isEmpty) return;
-
 		// Its with full purpose we don't call super.value, as thats being handled by the observation of the context selection.
 		this.selectedIds = idsString.split(/[ ,]+/);
 	}

--- a/src/packages/documents/document-types/components/document-type-input/document-type-input.element.ts
+++ b/src/packages/documents/document-types/components/document-type-input/document-type-input.element.ts
@@ -61,9 +61,6 @@ export class UmbDocumentTypeInputElement extends FormControlMixin(UmbLitElement)
 
 	@property()
 	public set value(idsString: string) {
-		const isEmpty = idsString.trim().length === 0;
-		if (isEmpty) return;
-
 		// Its with full purpose we don't call super.value, as thats being handled by the observation of the context selection.
 		this.selectedIds = idsString.split(/[ ,]+/);
 	}

--- a/src/packages/documents/document-types/components/document-type-input/document-type-input.element.ts
+++ b/src/packages/documents/document-types/components/document-type-input/document-type-input.element.ts
@@ -61,6 +61,9 @@ export class UmbDocumentTypeInputElement extends FormControlMixin(UmbLitElement)
 
 	@property()
 	public set value(idsString: string) {
+		const isEmpty = idsString.trim().length === 0;
+		if (isEmpty) return;
+
 		// Its with full purpose we don't call super.value, as thats being handled by the observation of the context selection.
 		this.selectedIds = idsString.split(/[ ,]+/);
 	}

--- a/src/packages/documents/document-types/components/document-type-input/document-type-input.element.ts
+++ b/src/packages/documents/document-types/components/document-type-input/document-type-input.element.ts
@@ -62,7 +62,7 @@ export class UmbDocumentTypeInputElement extends FormControlMixin(UmbLitElement)
 	@property()
 	public set value(idsString: string) {
 		// Its with full purpose we don't call super.value, as thats being handled by the observation of the context selection.
-		this.selectedIds = idsString.split(/[ ,]+/);
+		this.selectedIds = idsString !== '' ? idsString.split(/[ ,]+/) : [];
 	}
 
 	@property()

--- a/src/packages/documents/documents/components/input-document-granular-permission/input-document-granular-permission.element.ts
+++ b/src/packages/documents/documents/components/input-document-granular-permission/input-document-granular-permission.element.ts
@@ -27,7 +27,7 @@ export class UmbInputDocumentGranularPermissionElement extends FormControlMixin(
 	@property()
 	public set value(idsString: string) {
 		if (idsString !== this._value) {
-			this.selectedIds = idsString.split(/[ ,]+/);
+			this.selectedIds = idsString !== '' ? idsString.split(/[ ,]+/) : [];
 		}
 	}
 

--- a/src/packages/documents/documents/components/input-document/input-document.element.ts
+++ b/src/packages/documents/documents/components/input-document/input-document.element.ts
@@ -61,9 +61,6 @@ export class UmbInputDocumentElement extends FormControlMixin(UmbLitElement) {
 
 	@property()
 	public set value(idsString: string) {
-		const isEmpty = idsString.trim().length === 0;
-		if (isEmpty) return;
-
 		// Its with full purpose we don't call super.value, as thats being handled by the observation of the context selection.
 		this.selectedIds = idsString.split(/[ ,]+/);
 	}

--- a/src/packages/documents/documents/components/input-document/input-document.element.ts
+++ b/src/packages/documents/documents/components/input-document/input-document.element.ts
@@ -62,8 +62,7 @@ export class UmbInputDocumentElement extends FormControlMixin(UmbLitElement) {
 	@property()
 	public set value(idsString: string) {
 		const isEmpty = idsString.trim().length === 0;
-
-		if (isEmpty) return; //TODO: Do the same for language input
+		if (isEmpty) return;
 
 		// Its with full purpose we don't call super.value, as thats being handled by the observation of the context selection.
 		this.selectedIds = idsString.split(/[ ,]+/);

--- a/src/packages/documents/documents/components/input-document/input-document.element.ts
+++ b/src/packages/documents/documents/components/input-document/input-document.element.ts
@@ -62,7 +62,7 @@ export class UmbInputDocumentElement extends FormControlMixin(UmbLitElement) {
 	@property()
 	public set value(idsString: string) {
 		// Its with full purpose we don't call super.value, as thats being handled by the observation of the context selection.
-		this.selectedIds = idsString.split(/[ ,]+/);
+		this.selectedIds = idsString !== '' ? idsString.split(/[ ,]+/) : [];
 	}
 
 	@state()

--- a/src/packages/documents/documents/components/input-document/input-document.element.ts
+++ b/src/packages/documents/documents/components/input-document/input-document.element.ts
@@ -61,6 +61,10 @@ export class UmbInputDocumentElement extends FormControlMixin(UmbLitElement) {
 
 	@property()
 	public set value(idsString: string) {
+		const isEmpty = idsString.trim().length === 0;
+
+		if (isEmpty) return; //TODO: Do the same for language input
+
 		// Its with full purpose we don't call super.value, as thats being handled by the observation of the context selection.
 		this.selectedIds = idsString.split(/[ ,]+/);
 	}

--- a/src/packages/media/media-types/components/media-type-input/media-type-input.element.ts
+++ b/src/packages/media/media-types/components/media-type-input/media-type-input.element.ts
@@ -61,6 +61,9 @@ export class UmbMediaTypeInputElement extends FormControlMixin(UmbLitElement) {
 
 	@property()
 	public set value(idsString: string) {
+		const isEmpty = idsString.trim().length === 0;
+		if (isEmpty) return;
+
 		// Its with full purpose we don't call super.value, as thats being handled by the observation of the context selection.
 		this.selectedIds = idsString.split(/[ ,]+/);
 	}

--- a/src/packages/media/media-types/components/media-type-input/media-type-input.element.ts
+++ b/src/packages/media/media-types/components/media-type-input/media-type-input.element.ts
@@ -61,9 +61,6 @@ export class UmbMediaTypeInputElement extends FormControlMixin(UmbLitElement) {
 
 	@property()
 	public set value(idsString: string) {
-		const isEmpty = idsString.trim().length === 0;
-		if (isEmpty) return;
-
 		// Its with full purpose we don't call super.value, as thats being handled by the observation of the context selection.
 		this.selectedIds = idsString.split(/[ ,]+/);
 	}

--- a/src/packages/media/media-types/components/media-type-input/media-type-input.element.ts
+++ b/src/packages/media/media-types/components/media-type-input/media-type-input.element.ts
@@ -62,7 +62,7 @@ export class UmbMediaTypeInputElement extends FormControlMixin(UmbLitElement) {
 	@property()
 	public set value(idsString: string) {
 		// Its with full purpose we don't call super.value, as thats being handled by the observation of the context selection.
-		this.selectedIds = idsString.split(/[ ,]+/);
+		this.selectedIds = idsString !== '' ? idsString.split(/[ ,]+/) : [];
 	}
 
 	@property()

--- a/src/packages/media/media/components/input-media/input-media.element.ts
+++ b/src/packages/media/media/components/input-media/input-media.element.ts
@@ -61,9 +61,6 @@ export class UmbInputMediaElement extends FormControlMixin(UmbLitElement) {
 
 	@property()
 	public set value(idsString: string) {
-		const isEmpty = idsString.trim().length === 0;
-		if (isEmpty) return;
-
 		// Its with full purpose we don't call super.value, as thats being handled by the observation of the context selection.
 		this.selectedIds = idsString.split(/[ ,]+/);
 	}

--- a/src/packages/media/media/components/input-media/input-media.element.ts
+++ b/src/packages/media/media/components/input-media/input-media.element.ts
@@ -61,6 +61,9 @@ export class UmbInputMediaElement extends FormControlMixin(UmbLitElement) {
 
 	@property()
 	public set value(idsString: string) {
+		const isEmpty = idsString.trim().length === 0;
+		if (isEmpty) return;
+
 		// Its with full purpose we don't call super.value, as thats being handled by the observation of the context selection.
 		this.selectedIds = idsString.split(/[ ,]+/);
 	}

--- a/src/packages/media/media/components/input-media/input-media.element.ts
+++ b/src/packages/media/media/components/input-media/input-media.element.ts
@@ -62,7 +62,7 @@ export class UmbInputMediaElement extends FormControlMixin(UmbLitElement) {
 	@property()
 	public set value(idsString: string) {
 		// Its with full purpose we don't call super.value, as thats being handled by the observation of the context selection.
-		this.selectedIds = idsString.split(/[ ,]+/);
+		this.selectedIds = idsString !== '' ? idsString.split(/[ ,]+/) : [];
 	}
 
 	@state()

--- a/src/packages/settings/languages/components/input-language-picker/input-language-picker.element.ts
+++ b/src/packages/settings/languages/components/input-language-picker/input-language-picker.element.ts
@@ -64,6 +64,9 @@ export class UmbInputLanguagePickerElement extends FormControlMixin(UmbLitElemen
 
 	@property()
 	public set value(isoCodesString: string) {
+		const isEmpty = isoCodesString.trim().length === 0;
+		if (isEmpty) return;
+
 		// Its with full purpose we don't call super.value, as thats being handled by the observation of the context selection.
 		this.selectedIsoCodes = isoCodesString.split(/[ ,]+/);
 	}

--- a/src/packages/settings/languages/components/input-language-picker/input-language-picker.element.ts
+++ b/src/packages/settings/languages/components/input-language-picker/input-language-picker.element.ts
@@ -65,7 +65,7 @@ export class UmbInputLanguagePickerElement extends FormControlMixin(UmbLitElemen
 	@property()
 	public set value(isoCodesString: string) {
 		// Its with full purpose we don't call super.value, as thats being handled by the observation of the context selection.
-		this.selectedIsoCodes = isoCodesString.split(/[ ,]+/);
+		this.selectedIsoCodes = isoCodesString !== '' ? isoCodesString.split(/[ ,]+/) : [];
 	}
 
 	@state()

--- a/src/packages/settings/languages/components/input-language-picker/input-language-picker.element.ts
+++ b/src/packages/settings/languages/components/input-language-picker/input-language-picker.element.ts
@@ -64,9 +64,6 @@ export class UmbInputLanguagePickerElement extends FormControlMixin(UmbLitElemen
 
 	@property()
 	public set value(isoCodesString: string) {
-		const isEmpty = isoCodesString.trim().length === 0;
-		if (isEmpty) return;
-
 		// Its with full purpose we don't call super.value, as thats being handled by the observation of the context selection.
 		this.selectedIsoCodes = isoCodesString.split(/[ ,]+/);
 	}

--- a/src/packages/user/user-group/components/input-user-group/user-group-input.element.ts
+++ b/src/packages/user/user-group/components/input-user-group/user-group-input.element.ts
@@ -61,9 +61,6 @@ export class UmbUserGroupInputElement extends FormControlMixin(UmbLitElement) {
 
 	@property()
 	public set value(idsString: string) {
-		const isEmpty = idsString.trim().length === 0;
-		if (isEmpty) return;
-
 		// Its with full purpose we don't call super.value, as thats being handled by the observation of the context selection.
 		this.selectedIds = idsString.split(/[ ,]+/);
 	}

--- a/src/packages/user/user-group/components/input-user-group/user-group-input.element.ts
+++ b/src/packages/user/user-group/components/input-user-group/user-group-input.element.ts
@@ -61,6 +61,9 @@ export class UmbUserGroupInputElement extends FormControlMixin(UmbLitElement) {
 
 	@property()
 	public set value(idsString: string) {
+		const isEmpty = idsString.trim().length === 0;
+		if (isEmpty) return;
+
 		// Its with full purpose we don't call super.value, as thats being handled by the observation of the context selection.
 		this.selectedIds = idsString.split(/[ ,]+/);
 	}

--- a/src/packages/user/user-group/components/input-user-group/user-group-input.element.ts
+++ b/src/packages/user/user-group/components/input-user-group/user-group-input.element.ts
@@ -62,7 +62,7 @@ export class UmbUserGroupInputElement extends FormControlMixin(UmbLitElement) {
 	@property()
 	public set value(idsString: string) {
 		// Its with full purpose we don't call super.value, as thats being handled by the observation of the context selection.
-		this.selectedIds = idsString.split(/[ ,]+/);
+		this.selectedIds = idsString !== '' ? idsString.split(/[ ,]+/) : [];
 	}
 
 	@state()

--- a/src/packages/user/user/components/user-input/user-input.element.ts
+++ b/src/packages/user/user/components/user-input/user-input.element.ts
@@ -62,7 +62,7 @@ export class UmbUserInputElement extends FormControlMixin(UmbLitElement) {
 	@property()
 	public set value(idsString: string) {
 		// Its with full purpose we don't call super.value, as thats being handled by the observation of the context selection.
-		this.selectedIds = idsString.split(/[ ,]+/);
+		this.selectedIds = idsString !== '' ? idsString.split(/[ ,]+/) : [];
 	}
 
 	@state()

--- a/src/packages/user/user/components/user-input/user-input.element.ts
+++ b/src/packages/user/user/components/user-input/user-input.element.ts
@@ -61,9 +61,6 @@ export class UmbUserInputElement extends FormControlMixin(UmbLitElement) {
 
 	@property()
 	public set value(idsString: string) {
-		const isEmpty = idsString.trim().length === 0;
-		if (isEmpty) return;
-
 		// Its with full purpose we don't call super.value, as thats being handled by the observation of the context selection.
 		this.selectedIds = idsString.split(/[ ,]+/);
 	}

--- a/src/packages/user/user/components/user-input/user-input.element.ts
+++ b/src/packages/user/user/components/user-input/user-input.element.ts
@@ -61,6 +61,9 @@ export class UmbUserInputElement extends FormControlMixin(UmbLitElement) {
 
 	@property()
 	public set value(idsString: string) {
+		const isEmpty = idsString.trim().length === 0;
+		if (isEmpty) return;
+
 		// Its with full purpose we don't call super.value, as thats being handled by the observation of the context selection.
 		this.selectedIds = idsString.split(/[ ,]+/);
 	}


### PR DESCRIPTION
Prevents empty strings in `selectedIds` arrays of following inputs:
- data type
- document type
- document
- media type
- media
- language
- user group
- user

Empty string were causing issues on types where the id referred to a GUID on the backend, such as the document.

## Description

<!--- Describe the changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
