### PR TITLE
Bugfix/variant selector width

### DIFF
--- a/src/packages/core/components/variant-selector/variant-selector.element.ts
+++ b/src/packages/core/components/variant-selector/variant-selector.element.ts
@@ -1,6 +1,15 @@
 import { UmbVariantId } from '../../variant/variant-id.class.js';
-import { UUIInputElement, UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
-import { css, html, nothing, customElement, property, state, ifDefined } from '@umbraco-cms/backoffice/external/lit';
+import { UUIInputElement, UUIInputEvent, UUIPopoverContainerElement } from '@umbraco-cms/backoffice/external/uui';
+import {
+	css,
+	html,
+	nothing,
+	customElement,
+	property,
+	state,
+	ifDefined,
+	query,
+} from '@umbraco-cms/backoffice/external/lit';
 import {
 	UmbWorkspaceSplitViewContext,
 	UMB_WORKSPACE_SPLIT_VIEW_CONTEXT,
@@ -13,6 +22,9 @@ import { DocumentVariantResponseModel, ContentStateModel } from '@umbraco-cms/ba
 
 @customElement('umb-variant-selector')
 export class UmbVariantSelectorElement extends UmbLitElement {
+	@query('#variant-selector-popover')
+	private _popoverElement?: UUIPopoverContainerElement;
+
 	@state()
 	_variants: Array<DocumentVariantResponseModel> = [];
 
@@ -155,8 +167,19 @@ export class UmbVariantSelectorElement extends UmbLitElement {
 		return state !== ContentStateModel.PUBLISHED && !this._isVariantActive(culture!);
 	}
 
-	#onPopoverToggle(event: any) {
+	// TODO: This ignorer is just needed for JSON SCHEMA TO WORK, As its not updated with latest TS jet.
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore
+	#onPopoverToggle(event: ToggleEvent) {
 		this._variantSelectorOpen = event.newState === 'open';
+
+		if (!this._popoverElement) return;
+
+		const isOpen = event.newState === 'open';
+		if (!isOpen) return;
+
+		const host = this.getBoundingClientRect();
+		this._popoverElement.style.width = `${host.width}px`;
 	}
 
 	render() {
@@ -188,7 +211,10 @@ export class UmbVariantSelectorElement extends UmbLitElement {
 			${
 				this._variants && this._variants.length > 0
 					? html`
-							<uui-popover-container id="variant-selector-popover" @toggle=${this.#onPopoverToggle}>
+							<uui-popover-container
+								id="variant-selector-popover"
+								@beforetoggle=${this.#onPopoverToggle}
+								placement="bottom-end">
 								<div id="variant-selector-dropdown">
 									<uui-scroll-container>
 										<ul>
@@ -239,6 +265,10 @@ export class UmbVariantSelectorElement extends UmbLitElement {
 
 			#variant-selector-toggle {
 				white-space: nowrap;
+			}
+
+			#variant-selector-popover {
+				translate: 1px; /* Fixes tiny alignment issue caused by border */
 			}
 
 			#variant-selector-dropdown {

--- a/src/packages/settings/languages/app-language-select/app-language-select.element.ts
+++ b/src/packages/settings/languages/app-language-select/app-language-select.element.ts
@@ -90,7 +90,7 @@ export class UmbAppLanguageSelectElement extends UmbLitElement {
 	}
 
 	#renderContent() {
-		return html` <uui-popover-container id="dropdown-popover" @toggle=${this.#onPopoverToggle}>
+		return html` <uui-popover-container id="dropdown-popover" @beforetoggle=${this.#onPopoverToggle}>
 			<umb-popover-layout>
 				${repeat(
 					this._languages,


### PR DESCRIPTION
Updates the variant selector styling so it looks the same as before the popover update - Same width as the parent.

Also updates `app-language-select` to listen for the correct event (`beforetoggle`)

## Description

<!--- Describe the changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
