### PR TITLE
Languages: Use checkmarks in table instead of true/false

### DIFF
--- a/src/packages/settings/languages/workspace/language-root/components/language-root-table-boolean-column-layout.element.ts
+++ b/src/packages/settings/languages/workspace/language-root/components/language-root-table-boolean-column-layout.element.ts
@@ -1,0 +1,21 @@
+import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
+import { css, html, nothing, customElement, property } from '@umbraco-cms/backoffice/external/lit';
+import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
+
+@customElement('umb-language-root-table-boolean-column-layout')
+export class UmbLanguageRootTableBooleanColumnLayoutElement extends UmbLitElement {
+	@property({ attribute: false })
+	value = false;
+
+	render() {
+		return this.value ? html`<uui-icon name="icon-check"></uui-icon>` : nothing;
+	}
+
+	static styles = [UmbTextStyles, css``];
+}
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-language-root-table-boolean-column-layout': UmbLanguageRootTableBooleanColumnLayoutElement;
+	}
+}

--- a/src/packages/settings/languages/workspace/language-root/language-root-workspace.element.ts
+++ b/src/packages/settings/languages/workspace/language-root/language-root-workspace.element.ts
@@ -7,6 +7,7 @@ import { LanguageResponseModel } from '@umbraco-cms/backoffice/backend-api';
 
 import './components/language-root-table-delete-column-layout.element.js';
 import './components/language-root-table-name-column-layout.element.js';
+import './components/language-root-table-boolean-column-layout.element.js';
 
 @customElement('umb-language-root-workspace')
 export class UmbLanguageRootWorkspaceElement extends UmbLitElement {
@@ -29,10 +30,12 @@ export class UmbLanguageRootWorkspaceElement extends UmbLitElement {
 		{
 			name: 'Default',
 			alias: 'defaultLanguage',
+			elementName: 'umb-language-root-table-boolean-column-layout',
 		},
 		{
 			name: 'Mandatory',
 			alias: 'mandatoryLanguage',
+			elementName: 'umb-language-root-table-boolean-column-layout',
 		},
 		{
 			name: 'Fallback',


### PR DESCRIPTION
Changes the language table to use checkmarks for boolean values instead of true/false

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Screenshots (if appropriate)
<img width="977" alt="image" src="https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/26099018/36e48e24-754e-466f-b382-6154957259c0">

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
