### PR TITLE
Make notifications always be on top of the page

### DIFF
--- a/src/packages/core/components/backoffice-notification-container/backoffice-notification-container.element.ts
+++ b/src/packages/core/components/backoffice-notification-container/backoffice-notification-container.element.ts
@@ -56,7 +56,6 @@ export class UmbBackofficeNotificationContainerElement extends UmbLitElement {
 		UmbTextStyles,
 		css`
 			#notifications {
-				overflow: auto;
 				top: 0;
 				left: 0;
 				right: 0;

--- a/src/packages/core/components/backoffice-notification-container/backoffice-notification-container.element.ts
+++ b/src/packages/core/components/backoffice-notification-container/backoffice-notification-container.element.ts
@@ -33,7 +33,13 @@ export class UmbBackofficeNotificationContainerElement extends UmbLitElement {
 			this._notifications = notifications;
 
 			// Close and instantly open the popover again to make sure it stays on top of all other content on the page
+			// TODO: This ignorer is just needed for JSON SCHEMA TO WORK, As its not updated with latest TS jet.
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore
 			this._notificationsElement?.hidePopover();
+			// TODO: This ignorer is just needed for JSON SCHEMA TO WORK, As its not updated with latest TS jet.
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore
 			this._notificationsElement?.showPopover();
 		});
 	}

--- a/src/packages/core/components/backoffice-notification-container/backoffice-notification-container.element.ts
+++ b/src/packages/core/components/backoffice-notification-container/backoffice-notification-container.element.ts
@@ -1,5 +1,5 @@
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
-import { css, CSSResultGroup, html, customElement, state, repeat } from '@umbraco-cms/backoffice/external/lit';
+import { css, CSSResultGroup, html, customElement, state, repeat, query } from '@umbraco-cms/backoffice/external/lit';
 import {
 	UmbNotificationHandler,
 	UmbNotificationContext,
@@ -9,6 +9,9 @@ import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 
 @customElement('umb-backoffice-notification-container')
 export class UmbBackofficeNotificationContainerElement extends UmbLitElement {
+	@query('#notifications')
+	private _notificationsElement?: HTMLElement;
+
 	@state()
 	private _notifications?: UmbNotificationHandler[];
 
@@ -28,12 +31,16 @@ export class UmbBackofficeNotificationContainerElement extends UmbLitElement {
 
 		this.observe(this._notificationContext.notifications, (notifications) => {
 			this._notifications = notifications;
+
+			// Close and instantly open the popover again to make sure it stays on top of all other content on the page
+			this._notificationsElement?.hidePopover();
+			this._notificationsElement?.showPopover();
 		});
 	}
 
 	render() {
 		return html`
-			<uui-toast-notification-container bottom-up id="notifications">
+			<uui-toast-notification-container bottom-up id="notifications" popover="manual">
 				${this._notifications
 					? repeat(
 							this._notifications,
@@ -49,13 +56,20 @@ export class UmbBackofficeNotificationContainerElement extends UmbLitElement {
 		UmbTextStyles,
 		css`
 			#notifications {
-				position: absolute;
+				overflow: auto;
 				top: 0;
 				left: 0;
 				right: 0;
-				bottom: 70px;
+				bottom: 45px;
 				height: auto;
 				padding: var(--uui-size-layout-1);
+
+				position: fixed;
+				width: 100vw;
+				background: 0;
+				outline: 0;
+				border: 0;
+				margin: 0;
 			}
 		`,
 	];


### PR DESCRIPTION
This PR makes notifications alway be on top of the page by using the popover API.
Before, notifications would be hidden behind modals, sidebars, dialogs and so on.

Explanation:
This solution is a little hacky, as the only way for content be at the very top of the #top-layer is to be the most recently added element. So  we close and instantly open the popover (notification container) when a new notification is added. The closing and opening happens in the same frame/tick, so it is not visible.

## Description

<!--- Describe the changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
