### PR TITLE
Remove create button from language collection row

### DIFF
--- a/src/packages/settings/languages/entity-actions/manifests.ts
+++ b/src/packages/settings/languages/entity-actions/manifests.ts
@@ -27,7 +27,7 @@ const entityActions: Array<ManifestEntityAction> = [
 			icon: 'icon-add',
 			label: 'Create',
 			repositoryAlias: UMB_LANGUAGE_REPOSITORY_ALIAS,
-			entityTypes: [UMB_LANGUAGE_ENTITY_TYPE, UMB_LANGUAGE_ROOT_ENTITY_TYPE],
+			entityTypes: [UMB_LANGUAGE_ROOT_ENTITY_TYPE],
 		},
 	},
 ];


### PR DESCRIPTION
Removes the create button in the entity action dropdown on the language collection so that there is only remove.
Later we will find a way to only show a dropdown menu if there is more than one action