### PR TITLE
Tree Picker: Start Node / Document Picker Root

### DIFF
--- a/.github/localization_overview.md
+++ b/.github/localization_overview.md
@@ -135,6 +135,7 @@ Ensure all property editors are properly localized.
 - [ ] Toggle
 - [ ] Tree Picker
 	- [ ] StartNode
+	- [x] DynamicRoot
 - [ ] Upload Field
 - [ ] User Picker
 - [ ] Value Type

--- a/src/assets/lang/da-dk.ts
+++ b/src/assets/lang/da-dk.ts
@@ -1151,6 +1151,8 @@ export default {
 	},
 	contentPicker: {
 		allowedItemTypes: 'Du kan kun vælge følgende type(r) dokumenter: %0%',
+		defineDynamicRoot: 'Definer Dynamisk Udgangspunkt',
+		defineRootNode: 'Vælg udgangspunkt',
 		pickedTrashedItem: 'Du har valgt et dokument som er slettet eller lagt i papirkurven',
 		pickedTrashedItems: 'Du har valgt dokumenter som er slettede eller lagt i papirkurven',
 	},

--- a/src/assets/lang/en-us.ts
+++ b/src/assets/lang/en-us.ts
@@ -1148,6 +1148,8 @@ export default {
 	},
 	contentPicker: {
 		allowedItemTypes: 'You can only select items of type(s): %0%',
+		defineDynamicRoot: 'Specify a Dynamic Root',
+		defineRootNode: 'Pick root node',
 		pickedTrashedItem: 'You have picked a content item currently deleted or in the recycle bin',
 		pickedTrashedItems: 'You have picked content items currently deleted or in the recycle bin',
 	},

--- a/src/packages/core/components/input-start-node/input-start-node.element.ts
+++ b/src/packages/core/components/input-start-node/input-start-node.element.ts
@@ -1,4 +1,4 @@
-import { UmbInputDocumentSourceElement } from '@umbraco-cms/backoffice/document';
+import { UmbInputDocumentPickerRootElement } from '@umbraco-cms/backoffice/document';
 import { html, customElement, property, css, state } from '@umbraco-cms/backoffice/external/lit';
 import { FormControlMixin, UUISelectEvent } from '@umbraco-cms/backoffice/external/uui';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
@@ -79,7 +79,7 @@ export class UmbInputStartNodeElement extends FormControlMixin(UmbLitElement) {
 		//console.log('onIdChange', event.target);
 		switch (this.type) {
 			case 'content':
-				this.nodeId = (<UmbInputDocumentSourceElement>event.target).nodeId;
+				this.nodeId = (<UmbInputDocumentPickerRootElement>event.target).nodeId;
 				break;
 			case 'media':
 				this.nodeId = (<UmbInputMediaElement>event.target).selectedIds.join('');
@@ -112,9 +112,9 @@ export class UmbInputStartNodeElement extends FormControlMixin(UmbLitElement) {
 	}
 
 	#renderTypeContent() {
-		return html`<umb-input-document-source
+		return html`<umb-input-document-picker-root
 			@change=${this.#onIdChange}
-			.nodeId=${this.nodeId}></umb-input-document-source>`;
+			.nodeId=${this.nodeId}></umb-input-document-picker-root>`;
 	}
 
 	#renderTypeMedia() {

--- a/src/packages/core/components/input-start-node/input-start-node.element.ts
+++ b/src/packages/core/components/input-start-node/input-start-node.element.ts
@@ -1,16 +1,26 @@
-import { UmbInputDocumentElement } from '@umbraco-cms/backoffice/document';
+import { UmbInputDocumentSourceElement } from '@umbraco-cms/backoffice/document';
 import { html, customElement, property, css, state } from '@umbraco-cms/backoffice/external/lit';
 import { FormControlMixin, UUISelectEvent } from '@umbraco-cms/backoffice/external/uui';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 import { UmbInputMediaElement } from '@umbraco-cms/backoffice/media';
-import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
+//import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 
 export type ContentType = 'content' | 'member' | 'media';
+
+export type DynamicRootQueryStepType = {
+	alias: string;
+	anyOfDocTypeKeys: Array<string>;
+};
+
+export type DynamicRootType = {
+	originAlias: string;
+	querySteps?: Array<DynamicRootQueryStepType> | null;
+};
 
 export type StartNode = {
 	type?: ContentType;
 	id?: string | null;
-	query?: string | null;
+	dynamicRoot?: DynamicRootType | null;
 };
 
 @customElement('umb-input-start-node')
@@ -20,14 +30,21 @@ export class UmbInputStartNodeElement extends FormControlMixin(UmbLitElement) {
 	}
 
 	private _type: StartNode['type'] = 'content';
+
 	@property()
 	public set type(value: StartNode['type']) {
+		if (value === undefined) {
+			value = this._type;
+		}
+
 		const oldValue = this._type;
 
 		this._options = this._options.map((option) =>
 			option.value === value ? { ...option, selected: true } : { ...option, selected: false },
 		);
+
 		this._type = value;
+
 		this.requestUpdate('type', oldValue);
 	}
 	public get type(): StartNode['type'] {
@@ -35,30 +52,43 @@ export class UmbInputStartNodeElement extends FormControlMixin(UmbLitElement) {
 	}
 
 	@property({ attribute: 'node-id' })
-	nodeId = '';
+	nodeId?: string | null;
 
-	@property({ attribute: 'dynamic-path' })
-	dynamicPath = '';
+	@property({ attribute: false })
+	dynamicRoot?: DynamicRootType | null;
 
 	@state()
 	_options: Array<Option> = [
 		{ value: 'content', name: 'Content' },
-		{ value: 'member', name: 'Members' },
 		{ value: 'media', name: 'Media' },
+		{ value: 'member', name: 'Members' },
 	];
 
 	#onTypeChange(event: UUISelectEvent) {
+		//console.log('onTypeChange');
+
 		this.type = event.target.value as StartNode['type'];
 
-		// Clear others
 		this.nodeId = '';
-		this.dynamicPath = '';
-		this.dispatchEvent(new UmbChangeEvent());
+
+		// TODO: Appears that the event gets bubbled up. Will need to review. [LK]
+		//this.dispatchEvent(new UmbChangeEvent());
 	}
 
 	#onIdChange(event: CustomEvent) {
-		this.nodeId = (event.target as UmbInputDocumentElement | UmbInputMediaElement).selectedIds.join('');
-		this.dispatchEvent(new CustomEvent('change'));
+		//console.log('onIdChange', event.target);
+		switch (this.type) {
+			case 'content':
+				this.nodeId = (<UmbInputDocumentSourceElement>event.target).nodeId;
+				break;
+			case 'media':
+				this.nodeId = (<UmbInputMediaElement>event.target).selectedIds.join('');
+				break;
+			default:
+				break;
+		}
+
+		this.dispatchEvent(new CustomEvent(event.type));
 	}
 
 	render() {
@@ -82,21 +112,21 @@ export class UmbInputStartNodeElement extends FormControlMixin(UmbLitElement) {
 	}
 
 	#renderTypeContent() {
-		const nodeId = this.nodeId ? [this.nodeId] : [];
-		//TODO: Dynamic paths
-		return html` <umb-input-document @change=${this.#onIdChange} .selectedIds=${nodeId} max="1"></umb-input-document> `;
+		return html`<umb-input-document-source
+			@change=${this.#onIdChange}
+			.nodeId=${this.nodeId}></umb-input-document-source>`;
 	}
 
 	#renderTypeMedia() {
 		const nodeId = this.nodeId ? [this.nodeId] : [];
 		//TODO => MediaTypes
-		return html` <umb-input-media @change=${this.#onIdChange} .selectedIds=${nodeId} max="1"></umb-input-media> `;
+		return html`<umb-input-media @change=${this.#onIdChange} .selectedIds=${nodeId} max="1"></umb-input-media>`;
 	}
 
 	#renderTypeMember() {
 		const nodeId = this.nodeId ? [this.nodeId] : [];
 		//TODO => Members
-		return html` <umb-input-member @change=${this.#onIdChange} .selectedIds=${nodeId} max="1"></umb-input-member> `;
+		return html`<umb-input-member @change=${this.#onIdChange} .selectedIds=${nodeId} max="1"></umb-input-member>`;
 	}
 
 	static styles = [

--- a/src/packages/core/property-editor/uis/tree-picker/config/start-node/property-editor-ui-tree-picker-start-node.element.ts
+++ b/src/packages/core/property-editor/uis/tree-picker/config/start-node/property-editor-ui-tree-picker-start-node.element.ts
@@ -22,15 +22,17 @@ export class UmbPropertyEditorUITreePickerStartNodeElement extends UmbLitElement
 		this.value = {
 			type: target.type,
 			id: target.nodeId,
-			// TODO: Please check this makes sense, Check if we want to support XPath in this version, if not then make sure we handle DynamicRoot correct.
-			query: target.dynamicPath,
+			dynamicRoot: target.dynamicRoot,
 		};
 
 		this.dispatchEvent(new CustomEvent('property-value-change'));
 	}
 
 	render() {
-		return html`<umb-input-start-node @change="${this.#onChange}" .type=${this.value?.type}></umb-input-start-node>`;
+		return html`<umb-input-start-node
+			@change=${this.#onChange}
+			.type=${this.value?.type}
+			.nodeId=${this.value?.id}></umb-input-start-node>`;
 	}
 
 	static styles = [UmbTextStyles];

--- a/src/packages/documents/documents/components/index.ts
+++ b/src/packages/documents/documents/components/index.ts
@@ -1,3 +1,3 @@
 export * from './input-document/input-document.element.js';
 export * from './input-document-granular-permission/input-document-granular-permission.element.js';
-export * from './input-document-source/input-document-source.element.js';
+export * from './input-document-picker-root/input-document-picker-root.element.js';

--- a/src/packages/documents/documents/components/index.ts
+++ b/src/packages/documents/documents/components/index.ts
@@ -1,2 +1,3 @@
 export * from './input-document/input-document.element.js';
 export * from './input-document-granular-permission/input-document-granular-permission.element.js';
+export * from './input-document-source/input-document-source.element.js';

--- a/src/packages/documents/documents/components/input-document-picker-root/input-document-picker-root.element.ts
+++ b/src/packages/documents/documents/components/input-document-picker-root/input-document-picker-root.element.ts
@@ -1,17 +1,17 @@
 import { UmbDocumentPickerContext } from '../input-document/input-document.context.js';
-import { css, html, customElement, property, state, ifDefined, repeat } from '@umbraco-cms/backoffice/external/lit';
-import { FormControlMixin, UUIButtonElement } from '@umbraco-cms/backoffice/external/uui';
+import { html, customElement, property, state, ifDefined, repeat } from '@umbraco-cms/backoffice/external/lit';
+import { FormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 import type { DocumentItemResponseModel } from '@umbraco-cms/backoffice/backend-api';
 
 @customElement('umb-input-document-picker-root')
 export class UmbInputDocumentPickerRootElement extends FormControlMixin(UmbLitElement) {
 	public get nodeId(): string | null | undefined {
-		return this.#pickerContext.getSelection()[0];
+		return this.#documentPickerContext.getSelection()[0];
 	}
 	public set nodeId(id: string | null | undefined) {
 		const selection = id ? [id] : [];
-		this.#pickerContext.setSelection(selection);
+		this.#documentPickerContext.setSelection(selection);
 	}
 
 	@property()
@@ -22,28 +22,26 @@ export class UmbInputDocumentPickerRootElement extends FormControlMixin(UmbLitEl
 	@state()
 	private _items?: Array<DocumentItemResponseModel>;
 
-	#pickerContext = new UmbDocumentPickerContext(this);
+	#documentPickerContext = new UmbDocumentPickerContext(this);
+
+	// TODO: DynamicRoot - once feature implemented, wire up context and picker UI. [LK]
+	#dynamicRootPickerContext = {
+		openPicker: () => {
+			throw new Error('DynamicRoot picker has not been implemented yet.');
+		},
+	};
 
 	constructor() {
 		super();
 
-		this.#pickerContext.max = 1;
+		this.#documentPickerContext.max = 1;
 
-		this.observe(this.#pickerContext.selection, (selection) => (super.value = selection.join(',')));
-		this.observe(this.#pickerContext.selectedItems, (selectedItems) => (this._items = selectedItems));
+		this.observe(this.#documentPickerContext.selection, (selection) => (super.value = selection.join(',')));
+		this.observe(this.#documentPickerContext.selectedItems, (selectedItems) => (this._items = selectedItems));
 	}
 
 	protected getFormElement() {
 		return undefined;
-	}
-
-	// TODO: Wire up the DynamicRoot picker feature. [LK]
-	private _openDynamicRootPicker(e: Event) {
-		console.log('openDynamicRootPicker', e);
-		const btn = e.target as UUIButtonElement;
-		btn.color = 'warning';
-		btn.label = 'TODO!';
-		btn.look = 'primary';
 	}
 
 	render() {
@@ -68,11 +66,11 @@ export class UmbInputDocumentPickerRootElement extends FormControlMixin(UmbLitEl
 		return html` <uui-button-group>
 			<uui-button
 				look="placeholder"
-				@click=${() => this.#pickerContext.openPicker()}
+				@click=${() => this.#documentPickerContext.openPicker()}
 				label=${this.localize.term('contentPicker_defineRootNode')}></uui-button>
 			<uui-button
 				look="placeholder"
-				@click=${this._openDynamicRootPicker}
+				@click=${() => this.#dynamicRootPickerContext.openPicker()}
 				label=${this.localize.term('contentPicker_defineDynamicRoot')}></uui-button>
 		</uui-button-group>`;
 	}
@@ -83,11 +81,11 @@ export class UmbInputDocumentPickerRootElement extends FormControlMixin(UmbLitEl
 			<uui-ref-node name=${ifDefined(item.name)} detail=${ifDefined(item.id)}>
 				<!-- TODO: implement is trashed <uui-tag size="s" slot="tag" color="danger">Trashed</uui-tag> -->
 				<uui-action-bar slot="actions">
-					<uui-button @click=${() => this.#pickerContext.openPicker()} label="Edit document ${item.name}"
+					<uui-button @click=${() => this.#documentPickerContext.openPicker()} label="Edit document ${item.name}"
 						>Edit</uui-button
 					>
 					<uui-button
-						@click=${() => this.#pickerContext.requestRemoveItem(item.id!)}
+						@click=${() => this.#documentPickerContext.requestRemoveItem(item.id!)}
 						label="Remove document ${item.name}"
 						>Remove</uui-button
 					>
@@ -95,8 +93,6 @@ export class UmbInputDocumentPickerRootElement extends FormControlMixin(UmbLitEl
 			</uui-ref-node>
 		`;
 	}
-
-	static styles = [css``];
 }
 
 export default UmbInputDocumentPickerRootElement;

--- a/src/packages/documents/documents/components/input-document-picker-root/input-document-picker-root.element.ts
+++ b/src/packages/documents/documents/components/input-document-picker-root/input-document-picker-root.element.ts
@@ -4,8 +4,8 @@ import { FormControlMixin, UUIButtonElement } from '@umbraco-cms/backoffice/exte
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 import type { DocumentItemResponseModel } from '@umbraco-cms/backoffice/backend-api';
 
-@customElement('umb-input-document-source')
-export class UmbInputDocumentSourceElement extends FormControlMixin(UmbLitElement) {
+@customElement('umb-input-document-picker-root')
+export class UmbInputDocumentPickerRootElement extends FormControlMixin(UmbLitElement) {
 	public get nodeId(): string | null | undefined {
 		return this.#pickerContext.getSelection()[0];
 	}
@@ -99,10 +99,10 @@ export class UmbInputDocumentSourceElement extends FormControlMixin(UmbLitElemen
 	static styles = [css``];
 }
 
-export default UmbInputDocumentSourceElement;
+export default UmbInputDocumentPickerRootElement;
 
 declare global {
 	interface HTMLElementTagNameMap {
-		'umb-input-document-source': UmbInputDocumentSourceElement;
+		'umb-input-document-picker-root': UmbInputDocumentPickerRootElement;
 	}
 }

--- a/src/packages/documents/documents/components/input-document-source/input-document-source.element.ts
+++ b/src/packages/documents/documents/components/input-document-source/input-document-source.element.ts
@@ -1,0 +1,108 @@
+import { UmbDocumentPickerContext } from '../input-document/input-document.context.js';
+import { css, html, customElement, property, state, ifDefined, repeat } from '@umbraco-cms/backoffice/external/lit';
+import { FormControlMixin, UUIButtonElement } from '@umbraco-cms/backoffice/external/uui';
+import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
+import type { DocumentItemResponseModel } from '@umbraco-cms/backoffice/backend-api';
+
+@customElement('umb-input-document-source')
+export class UmbInputDocumentSourceElement extends FormControlMixin(UmbLitElement) {
+	public get nodeId(): string | null | undefined {
+		return this.#pickerContext.getSelection()[0];
+	}
+	public set nodeId(id: string | null | undefined) {
+		const selection = id ? [id] : [];
+		this.#pickerContext.setSelection(selection);
+	}
+
+	@property()
+	public set value(id: string) {
+		this.nodeId = id;
+	}
+
+	@state()
+	private _items?: Array<DocumentItemResponseModel>;
+
+	#pickerContext = new UmbDocumentPickerContext(this);
+
+	constructor() {
+		super();
+
+		this.#pickerContext.max = 1;
+
+		this.observe(this.#pickerContext.selection, (selection) => (super.value = selection.join(',')));
+		this.observe(this.#pickerContext.selectedItems, (selectedItems) => (this._items = selectedItems));
+	}
+
+	protected getFormElement() {
+		return undefined;
+	}
+
+	// TODO: Wire up the DynamicRoot picker feature. [LK]
+	private _openDynamicRootPicker(e: Event) {
+		console.log('openDynamicRootPicker', e);
+		const btn = e.target as UUIButtonElement;
+		btn.color = 'warning';
+		btn.label = 'TODO!';
+		btn.look = 'primary';
+	}
+
+	render() {
+		return html`
+			${this._items
+				? html` <uui-ref-list
+						>${repeat(
+							this._items,
+							(item) => item.id,
+							(item) => this._renderItem(item),
+						)}
+				  </uui-ref-list>`
+				: ''}
+			${this.#renderButtons()}
+		`;
+	}
+
+	#renderButtons() {
+		if (this.nodeId) return;
+
+		//TODO: Dynamic paths
+		return html` <uui-button-group>
+			<uui-button
+				look="placeholder"
+				@click=${() => this.#pickerContext.openPicker()}
+				label=${this.localize.term('contentPicker_defineRootNode')}></uui-button>
+			<uui-button
+				look="placeholder"
+				@click=${this._openDynamicRootPicker}
+				label=${this.localize.term('contentPicker_defineDynamicRoot')}></uui-button>
+		</uui-button-group>`;
+	}
+
+	private _renderItem(item: DocumentItemResponseModel) {
+		if (!item.id) return;
+		return html`
+			<uui-ref-node name=${ifDefined(item.name)} detail=${ifDefined(item.id)}>
+				<!-- TODO: implement is trashed <uui-tag size="s" slot="tag" color="danger">Trashed</uui-tag> -->
+				<uui-action-bar slot="actions">
+					<uui-button @click=${() => this.#pickerContext.openPicker()} label="Edit document ${item.name}"
+						>Edit</uui-button
+					>
+					<uui-button
+						@click=${() => this.#pickerContext.requestRemoveItem(item.id!)}
+						label="Remove document ${item.name}"
+						>Remove</uui-button
+					>
+				</uui-action-bar>
+			</uui-ref-node>
+		`;
+	}
+
+	static styles = [css``];
+}
+
+export default UmbInputDocumentSourceElement;
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-input-document-source': UmbInputDocumentSourceElement;
+	}
+}


### PR DESCRIPTION
Updates the Tree Picker's Start Node configuration to include a placeholder for the Dynamic Root functionality.

Introduces a `<umb-input-document-picker-root>` component for selecting the initial root node for the Multinode Treepicker editor.