### PR TITLE
Selection manager: fixes initial value

### DIFF
--- a/src/shared/utils/selection-manager/selection.manager.ts
+++ b/src/shared/utils/selection-manager/selection.manager.ts
@@ -57,7 +57,7 @@ export class UmbSelectionManager extends UmbBaseController {
 	public setSelection(value: Array<string | null>) {
 		if (this.getSelectable() === false) return;
 		if (value === undefined) throw new Error('Value cannot be undefined');
-		const newSelection = this.getMultiple() ? value : value.length > 0 ? [value[0]] : value;
+		const newSelection = this.getMultiple() ? value : value.slice(0, 1);
 		this.#selection.next(newSelection);
 	}
 

--- a/src/shared/utils/selection-manager/selection.manager.ts
+++ b/src/shared/utils/selection-manager/selection.manager.ts
@@ -57,7 +57,7 @@ export class UmbSelectionManager extends UmbBaseController {
 	public setSelection(value: Array<string | null>) {
 		if (this.getSelectable() === false) return;
 		if (value === undefined) throw new Error('Value cannot be undefined');
-		const newSelection = this.getMultiple() ? value : [value[0]];
+		const newSelection = this.getMultiple() ? value : value.length > 0 ? [value[0]] : value;
 		this.#selection.next(newSelection);
 	}
 
@@ -78,7 +78,7 @@ export class UmbSelectionManager extends UmbBaseController {
 	public setMultiple(value: boolean) {
 		this.#multiple.next(value);
 
-		/* If multiple is set to false, and the current selection is more than one, 
+		/* If multiple is set to false, and the current selection is more than one,
 		then we need to set the selection to the first item. */
 		if (value === false && this.getSelection().length > 1) {
 			this.setSelection([this.getSelection()[0]]);


### PR DESCRIPTION
Whilst working on the Tree Picker editor, I discovered an issue where the selected values always had an `undefined` as the first item in the array. I've pinpointed it down to how the Selection Manager is setting the initial selection/value.

When the modal initially opens, the `#multiple` is `false`, (regardless of how the `multiple` property/attribute is configured), so the initial value, e.g. `value[0]` gets set to `[undefined]`. Then when the `#multiple` is observed as `true`, _(there must be an underlying bug with the modal context code somewhere),_ then the `#selection` array would already have an initial value of `[undefined]` so any selected items would be appended that array.

This patch will check if the initial `value` (in `setSelection()`) has any items, if so, it'll use the first value, otherwise it'll be an empty array.