### PR TITLE
Integer schema name correction

### DIFF
--- a/src/packages/core/property-editor/schemas/Umbraco.Integer.ts
+++ b/src/packages/core/property-editor/schemas/Umbraco.Integer.ts
@@ -2,7 +2,7 @@ import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/exten
 
 export const manifest: ManifestPropertyEditorSchema = {
 	type: 'propertyEditorSchema',
-	name: 'Decimal',
+	name: 'Integer',
 	alias: 'Umbraco.Integer',
 	meta: {
 		defaultPropertyEditorUiAlias: 'Umb.PropertyEditorUi.Integer',


### PR DESCRIPTION
I'd noticed that "Integer" was named "Decimal" whilst browsing.