### PR TITLE
Property Editor: Number - set numeric value

### DIFF
--- a/src/packages/core/property-editor/uis/number/property-editor-ui-number.element.ts
+++ b/src/packages/core/property-editor/uis/number/property-editor-ui-number.element.ts
@@ -6,8 +6,8 @@ import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/
 
 @customElement('umb-property-editor-ui-number')
 export class UmbPropertyEditorUINumberElement extends UmbLitElement implements UmbPropertyEditorUiElement {
-	@property()
-	value = '';
+	@property({ type: Number })
+	value: undefined | number = undefined;
 
 	@state()
 	private _max?: number;
@@ -26,7 +26,7 @@ export class UmbPropertyEditorUINumberElement extends UmbLitElement implements U
 	}
 
 	private onInput(e: InputEvent) {
-		this.value = (e.target as HTMLInputElement).value;
+		this.value = Number((e.target as HTMLInputElement).value);
 		this.dispatchEvent(new CustomEvent('property-value-change'));
 	}
 


### PR DESCRIPTION
This was setting the value as a `string`, which would cause issues when used in certain scenarios, e.g. MNTP min/max configuration, the value would assumed to be numeric, but it'd be a string, so conditions like `max === 1` would be false, as it'd be `"1"` instead.

Ensuring the value is a `number` before the "property-value-change" event is sent appears to resolve this issue.
