### PR TITLE
Bugfix/table without icon width

### DIFF
--- a/src/packages/core/components/table/table.element.ts
+++ b/src/packages/core/components/table/table.element.ts
@@ -155,7 +155,11 @@ export class UmbTableElement extends LitElement {
 
 	render() {
 		return html`<uui-table class="uui-text">
-			<uui-table-column style="width: 60px;"></uui-table-column>
+			<uui-table-column
+				.style=${when(
+					!(this.config.allowSelection === false && this.config.hideIcon === true),
+					() => 'width: 60px',
+				)}></uui-table-column>
 			<uui-table-head>
 				${this._renderHeaderCheckboxCell()} ${this.columns.map((column) => this._renderHeaderCell(column))}
 			</uui-table-head>

--- a/src/packages/core/components/table/table.stories.ts
+++ b/src/packages/core/components/table/table.stories.ts
@@ -101,3 +101,14 @@ export const WithHiddenIcons: Story = {
 		},
 	},
 };
+
+export const WithHiddenIconsAndDisallowedSelections: Story = {
+	args: {
+		items: items,
+		columns: columns,
+		config: {
+			allowSelection: false,
+			hideIcon: true,
+		},
+	},
+};


### PR DESCRIPTION
One-liner that fixes an issue where the first column in the table would be locked to 60px if the icon is hidden.

Also adds a story to show the usecase

Before
<img width="839" alt="image" src="https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/26099018/f751a002-9149-44a0-a900-8c5f6049e2d1">

After
<img width="842" alt="image" src="https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/26099018/12c331b6-edde-445f-81b7-9724e0b970b7">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
