### PR TITLE
Tree Element: Adds selection configuration property

### DIFF
--- a/src/packages/core/modal/common/tree-picker/tree-picker-modal.element.ts
+++ b/src/packages/core/modal/common/tree-picker/tree-picker-modal.element.ts
@@ -1,9 +1,8 @@
-import { type UmbTreeElement } from '../../../tree/tree.element.js';
 import { html, customElement, state, ifDefined } from '@umbraco-cms/backoffice/external/lit';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { UmbTreePickerModalData, UmbPickerModalValue, UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 import { UmbSelectionChangeEvent } from '@umbraco-cms/backoffice/event';
-import { UmbTreeItemModelBase } from '@umbraco-cms/backoffice/tree';
+import { UmbTreeElement, UmbTreeItemModelBase, type UmbTreeSelectionConfiguration } from '@umbraco-cms/backoffice/tree';
 
 @customElement('umb-tree-picker-modal')
 export class UmbTreePickerModalElement<TreeItemType extends UmbTreeItemModelBase> extends UmbModalBaseElement<
@@ -11,10 +10,11 @@ export class UmbTreePickerModalElement<TreeItemType extends UmbTreeItemModelBase
 	UmbPickerModalValue
 > {
 	@state()
-	_selection: Array<string | null> = [];
-
-	@state()
-	_multiple = false;
+	_selectionConfiguration: UmbTreeSelectionConfiguration = {
+		multiple: false,
+		selectable: true,
+		selection: [],
+	};
 
 	connectedCallback() {
 		super.connectedCallback();
@@ -22,17 +22,17 @@ export class UmbTreePickerModalElement<TreeItemType extends UmbTreeItemModelBase
 		// TODO: We should make a nicer way to observe the value..
 		if (this.modalContext) {
 			this.observe(this.modalContext.value, (value) => {
-				this._selection = value?.selection ?? [];
+				this._selectionConfiguration.selection = value?.selection ?? [];
 			});
 		}
 
-		this._multiple = this.data?.multiple ?? false;
+		this._selectionConfiguration.multiple = this.data?.multiple ?? false;
 	}
 
 	#onSelectionChange(e: CustomEvent) {
 		e.stopPropagation();
 		const element = e.target as UmbTreeElement;
-		this.value = { selection: element.selection };
+		this.value = { selection: element.getSelection() };
 		this.dispatchEvent(new UmbSelectionChangeEvent());
 	}
 
@@ -44,11 +44,9 @@ export class UmbTreePickerModalElement<TreeItemType extends UmbTreeItemModelBase
 						?hide-tree-root=${this.data?.hideTreeRoot}
 						alias=${ifDefined(this.data?.treeAlias)}
 						@selection-change=${this.#onSelectionChange}
-						.selection=${this._selection}
-						selectable
+						.selectionConfiguration=${this._selectionConfiguration}
 						.filter=${this.data?.filter}
-						.selectableFilter=${this.data?.pickableFilter}
-						?multiple=${this._multiple}></umb-tree>
+						.selectableFilter=${this.data?.pickableFilter}></umb-tree>
 				</uui-box>
 				<div slot="actions">
 					<uui-button label=${this.localize.term('general_close')} @click=${this._rejectModal}></uui-button>

--- a/src/packages/core/tree/tree.element.ts
+++ b/src/packages/core/tree/tree.element.ts
@@ -7,6 +7,12 @@ import { UmbObserverController } from '@umbraco-cms/backoffice/observable-api';
 import './tree-item-default/tree-item.element.js';
 import './tree-item-base/tree-item-base.element.js';
 
+export type UmbTreeSelectionConfiguration = {
+	multiple?: boolean;
+	selectable?: boolean;
+	selection?: Array<string | null>;
+};
+
 @customElement('umb-tree')
 export class UmbTreeElement extends UmbLitElement {
 	@property({ type: String, reflect: true })
@@ -17,29 +23,21 @@ export class UmbTreeElement extends UmbLitElement {
 		this.#treeContext.setTreeAlias(newVal);
 	}
 
-	@property({ type: Boolean, reflect: true })
-	get selectable() {
-		return this.#treeContext.selection.getSelectable();
-	}
-	set selectable(newVal) {
-		this.#treeContext.selection.setSelectable(newVal);
-	}
+	private _selectionConfiguration: UmbTreeSelectionConfiguration = {
+		multiple: false,
+		selectable: true,
+		selection: [],
+	};
 
-	@property({ type: Array })
-	get selection() {
-		return this.#treeContext.selection.getSelection();
+	@property({ type: Object })
+	get selectionConfiguration(): UmbTreeSelectionConfiguration {
+		return this._selectionConfiguration;
 	}
-	set selection(newVal) {
-		if (!Array.isArray(newVal)) return;
-		this.#treeContext?.selection.setSelection(newVal);
-	}
-
-	@property({ type: Boolean, reflect: true })
-	get multiple() {
-		return this.#treeContext.selection.getMultiple();
-	}
-	set multiple(newVal) {
-		this.#treeContext.selection.setMultiple(newVal);
+	set selectionConfiguration(config: UmbTreeSelectionConfiguration) {
+		this._selectionConfiguration = config;
+		this.#treeContext.selection.setMultiple(config.multiple ?? false);
+		this.#treeContext.selection.setSelectable(config.selectable ?? true);
+		this.#treeContext.selection.setSelection(config.selection ?? []);
 	}
 
 	// TODO: what is the best name for this functionality?
@@ -109,6 +107,10 @@ export class UmbTreeElement extends UmbLitElement {
 				this.requestUpdate('_items', oldValue);
 			});
 		}
+	}
+
+	getSelection() {
+		return this.#treeContext.selection.getSelection();
 	}
 
 	render() {

--- a/src/packages/core/tree/tree.element.ts
+++ b/src/packages/core/tree/tree.element.ts
@@ -16,11 +16,11 @@ export type UmbTreeSelectionConfiguration = {
 @customElement('umb-tree')
 export class UmbTreeElement extends UmbLitElement {
 	@property({ type: String, reflect: true })
-	get alias() {
-		return this.#treeContext.getTreeAlias();
-	}
 	set alias(newVal) {
 		this.#treeContext.setTreeAlias(newVal);
+	}
+	get alias() {
+		return this.#treeContext.getTreeAlias();
 	}
 
 	private _selectionConfiguration: UmbTreeSelectionConfiguration = {
@@ -30,22 +30,19 @@ export class UmbTreeElement extends UmbLitElement {
 	};
 
 	@property({ type: Object })
-	get selectionConfiguration(): UmbTreeSelectionConfiguration {
-		return this._selectionConfiguration;
-	}
 	set selectionConfiguration(config: UmbTreeSelectionConfiguration) {
 		this._selectionConfiguration = config;
 		this.#treeContext.selection.setMultiple(config.multiple ?? false);
 		this.#treeContext.selection.setSelectable(config.selectable ?? true);
 		this.#treeContext.selection.setSelection(config.selection ?? []);
 	}
+	get selectionConfiguration(): UmbTreeSelectionConfiguration {
+		return this._selectionConfiguration;
+	}
 
 	// TODO: what is the best name for this functionality?
 	private _hideTreeRoot = false;
 	@property({ type: Boolean, attribute: 'hide-tree-root' })
-	get hideTreeRoot() {
-		return this._hideTreeRoot;
-	}
 	set hideTreeRoot(newVal: boolean) {
 		const oldVal = this._hideTreeRoot;
 		this._hideTreeRoot = newVal;
@@ -55,21 +52,24 @@ export class UmbTreeElement extends UmbLitElement {
 
 		this.requestUpdate('hideTreeRoot', oldVal);
 	}
+	get hideTreeRoot() {
+		return this._hideTreeRoot;
+	}
 
 	@property()
-	get selectableFilter() {
-		return this.#treeContext.selectableFilter;
-	}
 	set selectableFilter(newVal) {
 		this.#treeContext.selectableFilter = newVal;
 	}
+	get selectableFilter() {
+		return this.#treeContext.selectableFilter;
+	}
 
 	@property()
-	get filter() {
-		return this.#treeContext.filter;
-	}
 	set filter(newVal) {
 		this.#treeContext.filter = newVal;
+	}
+	get filter() {
+		return this.#treeContext.filter;
 	}
 
 	@state()

--- a/src/packages/dictionary/dictionary/entity-actions/import/import-dictionary-modal.element.ts
+++ b/src/packages/dictionary/dictionary/entity-actions/import/import-dictionary-modal.element.ts
@@ -8,7 +8,7 @@ import {
 	UmbModalBaseElement,
 } from '@umbraco-cms/backoffice/modal';
 import { UmbId } from '@umbraco-cms/backoffice/id';
-import { UmbEntityTreeItemModel, UmbTreeElement } from '@umbraco-cms/backoffice/tree';
+import { UmbEntityTreeItemModel, UmbTreeElement, type UmbTreeSelectionConfiguration } from '@umbraco-cms/backoffice/tree';
 
 interface DictionaryItemPreview {
 	name: string;
@@ -21,6 +21,13 @@ export class UmbImportDictionaryModalLayout extends UmbModalBaseElement<
 	UmbImportDictionaryModalData,
 	UmbImportDictionaryModalValue
 > {
+	@state()
+	private _selectionConfiguration: UmbTreeSelectionConfiguration = {
+		multiple: false,
+		selectable: true,
+		selection: [],
+	};
+
 	@state()
 	private _parentId?: string;
 
@@ -93,6 +100,7 @@ export class UmbImportDictionaryModalLayout extends UmbModalBaseElement<
 	connectedCallback(): void {
 		super.connectedCallback();
 		this._parentId = this.data?.unique ?? undefined;
+		this._selectionConfiguration.selection = this._parentId ? [this._parentId] : [];
 	}
 
 	#dictionaryPreviewBuilder(htmlString: string) {
@@ -139,7 +147,7 @@ export class UmbImportDictionaryModalLayout extends UmbModalBaseElement<
 	}
 
 	#onParentChange() {
-		this._parentId = this._treeElement?.selection[0] ?? undefined;
+		this._parentId = this._treeElement?.getSelection()[0] ?? undefined;
 	}
 
 	async #onFileInput() {
@@ -189,11 +197,9 @@ export class UmbImportDictionaryModalLayout extends UmbModalBaseElement<
 
 					<umb-tree
 						?hide-tree-root=${true}
-						?multiple=${false}
 						alias=${UMB_DICTIONARY_TREE_ALIAS}
 						@selection-change=${this.#onParentChange}
-						.selection=${[this._parentId ?? '']}
-						selectable></umb-tree>
+						.selectionConfiguration=${this._selectionConfiguration}></umb-tree>
 				</div>
 
 				${this.#renderNavigate()}

--- a/src/packages/templating/modals/partial-view-picker-modal.element.ts
+++ b/src/packages/templating/modals/partial-view-picker-modal.element.ts
@@ -5,7 +5,7 @@ import {
 	UmbPartialViewPickerModalValue,
 	UmbModalBaseElement,
 } from '@umbraco-cms/backoffice/modal';
-import { UmbTreeElement } from '@umbraco-cms/backoffice/tree';
+import { UmbTreeElement, type UmbTreeSelectionConfiguration } from '@umbraco-cms/backoffice/tree';
 
 @customElement('umb-partial-view-picker-modal')
 export default class UmbPartialViewPickerModalElement extends UmbModalBaseElement<
@@ -13,26 +13,26 @@ export default class UmbPartialViewPickerModalElement extends UmbModalBaseElemen
 	UmbPartialViewPickerModalValue
 > {
 	@state()
-	_selection: Array<string | null> = [];
-
-	@state()
-	_multiple = false;
+	_selectionConfiguration: UmbTreeSelectionConfiguration = {
+		multiple: false,
+		selectable: true,
+		selection: [],
+	};
 
 	connectedCallback() {
 		super.connectedCallback();
-		this._selection = this.value?.selection ?? [];
-		this._multiple = this.data?.multiple ?? true;
+		this._selectionConfiguration.selection = this.value?.selection ?? [];
+		this._selectionConfiguration.multiple = this.data?.multiple ?? true;
 	}
 
 	private _handleSelectionChange(e: CustomEvent) {
 		e.stopPropagation();
 		const element = e.target as UmbTreeElement;
-		this._selection = this._multiple ? element.selection : [element.selection[element.selection.length - 1]];
+		this.value = { selection: element.getSelection() };
 		this._submit();
 	}
 
 	private _submit() {
-		this.value = { selection: this._selection };
 		this.modalContext?.submit();
 	}
 
@@ -48,8 +48,7 @@ export default class UmbPartialViewPickerModalElement extends UmbModalBaseElemen
 						<umb-tree
 							alias="Umb.Tree.PartialViews"
 							@selection-change=${this._handleSelectionChange}
-							.selection=${this._selection}
-							selectable></umb-tree>
+							.selectionConfiguration=${this._selectionConfiguration}></umb-tree>
 					</uui-box>
 				</div>
 				<div slot="actions">


### PR DESCRIPTION
> **This supersedes pull-request #1098.**

Introduces a `selectionConfiguration` property (and new type `UmbTreeSelectionConfiguration`) to the `<umb-tree>` element.

As discussed on https://github.com/umbraco/Umbraco.CMS.Backoffice/pull/1098#issuecomment-1883001464, this property is a container for the required configuration of a tree-picker selection.

I have attempted to update the other uses of `<umb-tree>` that I could find within the codebase, namely the Multi-URL Picker editor, Import Dictionary modal and the Partial View Picker.