### PR TITLE
Change icon of Image Cropper property editor

### DIFF
--- a/src/packages/core/property-editor/uis/image-cropper/manifests.ts
+++ b/src/packages/core/property-editor/uis/image-cropper/manifests.ts
@@ -7,7 +7,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	js: () => import('./property-editor-ui-image-cropper.element.js'),
 	meta: {
 		label: 'Image Cropper',
-		icon: 'icon-colorpicker',
+		icon: 'icon-crop',
 		group: 'pickers',
 		propertyEditorSchemaAlias: 'Umbraco.ImageCropper',
 	},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Just a minor update to change icon of Image Cropper property editor to use crop icon instead of color picker icon.

Some else to consider.
- Change icon for dropdown to something else than time icon.
- Maybe toggle icon from Lucide icons as icon for Toggle property editor as it hasn't been a checkbox for a long time.
- Some other icon updates.
- Maybe all configuration editors should be under a "Configuration" group? And does it need configuration in name? Alternatively under a tab/app "Configuration" and a setting in manifest?
- Should there be a User Group Picker as well?


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
