### PR TITLE
TinyMCE initial value (patch for PR #1105)

### DIFF
--- a/src/packages/core/property-editor/uis/tiny-mce/property-editor-ui-tiny-mce.element.ts
+++ b/src/packages/core/property-editor/uis/tiny-mce/property-editor-ui-tiny-mce.element.ts
@@ -17,7 +17,7 @@ export class UmbPropertyEditorUITinyMceElement extends UmbLitElement implements 
 	#configuration?: UmbPropertyEditorConfigCollection;
 
 	@property({ type: Object })
-	value: RichTextEditorValue = {
+	value?: RichTextEditorValue = {
 		blocks: {},
 		markup: '',
 	};
@@ -39,7 +39,7 @@ export class UmbPropertyEditorUITinyMceElement extends UmbLitElement implements 
 		return html`<umb-input-tiny-mce
 			@change=${this.#onChange}
 			.configuration=${this.#configuration}
-			.value=${this.value.markup}></umb-input-tiny-mce>`;
+			.value=${this.value?.markup ?? ''}></umb-input-tiny-mce>`;
 	}
 
 	static styles = [UmbTextStyles];

--- a/src/packages/core/property-editor/uis/tiny-mce/property-editor-ui-tiny-mce.stories.ts
+++ b/src/packages/core/property-editor/uis/tiny-mce/property-editor-ui-tiny-mce.stories.ts
@@ -80,7 +80,9 @@ const meta: Meta<UmbPropertyEditorUITinyMceElement> = {
 	id: 'umb-property-editor-ui-tiny-mce',
 	args: {
 		config: undefined,
-		value: `
+		value: {
+			blocks: {},
+			markup: `
 			<h2>TinyMCE</h2>
 			<p>I am a default value for the TinyMCE text editor story.</p>
 			<p>
@@ -92,6 +94,7 @@ const meta: Meta<UmbPropertyEditorUITinyMceElement> = {
 				<a href="https://docs.umbraco.com" target="_blank" rel="noopener noreferrer">Umbraco documentation</a>
 			</p>
 		`,
+		},
 	},
 };
 


### PR DESCRIPTION
When creating a new document with an RTE, (against the Management API), the initial value is `undefined` and threw an error. So I have set the `value` to be nullable.

I've also updated the `value` data structure in the story.