### PR TITLE
Datatype workspace modal token

### DIFF
--- a/src/packages/core/components/property-type-based-property/property-type-based-property.element.ts
+++ b/src/packages/core/components/property-type-based-property/property-type-based-property.element.ts
@@ -39,12 +39,12 @@ export class UmbPropertyTypeBasedPropertyElement extends UmbLitElement {
 				await this._dataTypeDetailRepository.byUnique(dataTypeUnique),
 				(dataType) => {
 					this._dataTypeData = dataType?.values;
-					this._propertyEditorUiAlias = dataType?.propertyEditorUiAlias || undefined;
+					this._propertyEditorUiAlias = dataType?.editorUiAlias || undefined;
 					// If there is no UI, we will look up the Property editor model to find the default UI alias:
-					if (!this._propertyEditorUiAlias && dataType?.propertyEditorAlias) {
-						//use 'dataType.propertyEditorAlias' to look up the extension in the registry:
+					if (!this._propertyEditorUiAlias && dataType?.editorAlias) {
+						//use 'dataType.editorAlias' to look up the extension in the registry:
 						this.observe(
-							umbExtensionsRegistry.getByTypeAndAlias('propertyEditorSchema', dataType.propertyEditorAlias),
+							umbExtensionsRegistry.getByTypeAndAlias('propertyEditorSchema', dataType.editorAlias),
 							(extension) => {
 								if (!extension) return;
 								this._propertyEditorUiAlias = extension?.meta.defaultPropertyEditorUiAlias;

--- a/src/packages/core/data-type/components/data-type-flow-input/data-type-flow-input.element.ts
+++ b/src/packages/core/data-type/components/data-type-flow-input/data-type-flow-input.element.ts
@@ -1,11 +1,8 @@
+import { UMB_DATATYPE_WORKSPACE_MODAL } from '../../index.js';
 import { css, html, customElement, property, state } from '@umbraco-cms/backoffice/external/lit';
 import { FormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
-import {
-	UmbModalRouteRegistrationController,
-	UMB_DATA_TYPE_PICKER_FLOW_MODAL,
-	UMB_WORKSPACE_MODAL,
-} from '@umbraco-cms/backoffice/modal';
+import { UmbModalRouteRegistrationController, UMB_DATA_TYPE_PICKER_FLOW_MODAL } from '@umbraco-cms/backoffice/modal';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 
 // Note: Does only support picking a single data type. But this could be developed later into this same component. To follow other picker input components.
@@ -49,9 +46,7 @@ export class UmbInputDataTypeElement extends FormControlMixin(UmbLitElement) {
 	constructor() {
 		super();
 
-		this.#editDataTypeModal = new UmbModalRouteRegistrationController(this, UMB_WORKSPACE_MODAL).onSetup(() => {
-			return { data: { entityType: 'data-type', preset: {} } };
-		});
+		this.#editDataTypeModal = new UmbModalRouteRegistrationController(this, UMB_DATATYPE_WORKSPACE_MODAL);
 
 		new UmbModalRouteRegistrationController(this, UMB_DATA_TYPE_PICKER_FLOW_MODAL)
 			.onSetup(() => {

--- a/src/packages/core/data-type/components/ref-data-type/ref-data-type.element.ts
+++ b/src/packages/core/data-type/components/ref-data-type/ref-data-type.element.ts
@@ -28,8 +28,8 @@ export class UmbRefDataTypeElement extends UmbElementMixin(UUIRefNodeElement) {
 				(dataType) => {
 					if (dataType) {
 						this.name = dataType.name ?? '';
-						this.propertyEditorUiAlias = dataType.propertyEditorUiAlias ?? '';
-						this.propertyEditorSchemaAlias = dataType.propertyEditorAlias ?? '';
+						this.propertyEditorUiAlias = dataType.editorUiAlias ?? '';
+						this.propertyEditorSchemaAlias = dataType.editorAlias ?? '';
 					}
 				},
 				'dataType',

--- a/src/packages/core/data-type/modals/data-type-picker-flow/data-type-picker-flow-modal.element.ts
+++ b/src/packages/core/data-type/modals/data-type-picker-flow/data-type-picker-flow-modal.element.ts
@@ -4,7 +4,6 @@ import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import type { UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
 import {
 	UMB_DATA_TYPE_PICKER_FLOW_DATA_TYPE_PICKER_MODAL,
-	UMB_WORKSPACE_MODAL,
 	UmbDataTypePickerFlowModalData,
 	UmbDataTypePickerFlowModalValue,
 	UmbModalBaseElement,
@@ -13,6 +12,7 @@ import {
 } from '@umbraco-cms/backoffice/modal';
 import { ManifestPropertyEditorUi, umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbEntityTreeItemModel } from '@umbraco-cms/backoffice/tree';
+import { UMB_DATATYPE_WORKSPACE_MODAL } from '@umbraco-cms/backoffice/data-type';
 
 interface GroupedItems<T> {
 	[key: string]: Array<T>;
@@ -73,7 +73,7 @@ export class UmbDataTypePickerFlowModalElement extends UmbModalBaseElement<
 				this.requestUpdate('_dataTypePickerModalRouteBuilder');
 			});
 
-		this._createDataTypeModal = new UmbModalRouteRegistrationController(this, UMB_WORKSPACE_MODAL)
+		this._createDataTypeModal = new UmbModalRouteRegistrationController(this, UMB_DATATYPE_WORKSPACE_MODAL)
 			.addAdditionalPath(':uiAlias')
 			.onSetup((params) => {
 				return { data: { entityType: 'data-type', preset: { editorUiAlias: params.uiAlias } } };

--- a/src/packages/core/data-type/repository/detail/data-type-detail.server.data-source.ts
+++ b/src/packages/core/data-type/repository/detail/data-type-detail.server.data-source.ts
@@ -39,8 +39,8 @@ export class UmbDataTypeServerDataSource implements UmbDetailDataSource<UmbDataT
 			unique: UmbId.new(),
 			parentUnique,
 			name: '',
-			propertyEditorAlias: undefined,
-			propertyEditorUiAlias: null,
+			editorAlias: undefined,
+			editorUiAlias: null,
 			values: [],
 		};
 
@@ -68,8 +68,8 @@ export class UmbDataTypeServerDataSource implements UmbDetailDataSource<UmbDataT
 			unique: data.id,
 			parentUnique: data.parentId || null,
 			name: data.name,
-			propertyEditorAlias: data.editorAlias,
-			propertyEditorUiAlias: data.editorUiAlias || null,
+			editorAlias: data.editorAlias,
+			editorUiAlias: data.editorUiAlias || null,
 			values: data.values as Array<UmbDataTypePropertyModel>,
 		};
 
@@ -85,15 +85,15 @@ export class UmbDataTypeServerDataSource implements UmbDetailDataSource<UmbDataT
 	async create(dataType: UmbDataTypeDetailModel) {
 		if (!dataType) throw new Error('Data Type is missing');
 		if (!dataType.unique) throw new Error('Data Type unique is missing');
-		if (!dataType.propertyEditorAlias) throw new Error('Property Editor Alias is missing');
+		if (!dataType.editorAlias) throw new Error('Property Editor Alias is missing');
 
 		// TODO: make data mapper to prevent errors
 		const requestBody: CreateDataTypeRequestModel = {
 			id: dataType.unique,
 			parentId: dataType.parentUnique,
 			name: dataType.name,
-			editorAlias: dataType.propertyEditorAlias,
-			editorUiAlias: dataType.propertyEditorUiAlias,
+			editorAlias: dataType.editorAlias,
+			editorUiAlias: dataType.editorUiAlias,
 			values: dataType.values,
 		};
 
@@ -120,13 +120,13 @@ export class UmbDataTypeServerDataSource implements UmbDetailDataSource<UmbDataT
 	 */
 	async update(data: UmbDataTypeDetailModel) {
 		if (!data.unique) throw new Error('Unique is missing');
-		if (!data.propertyEditorAlias) throw new Error('Property Editor Alias is missing');
+		if (!data.editorAlias) throw new Error('Property Editor Alias is missing');
 
 		// TODO: make data mapper to prevent errors
 		const requestBody: DataTypeModelBaseModel = {
 			name: data.name,
-			editorAlias: data.propertyEditorAlias,
-			editorUiAlias: data.propertyEditorUiAlias,
+			editorAlias: data.editorAlias,
+			editorUiAlias: data.editorUiAlias,
 			values: data.values,
 		};
 

--- a/src/packages/core/data-type/repository/detail/data-type-detail.store.ts
+++ b/src/packages/core/data-type/repository/detail/data-type-detail.store.ts
@@ -21,9 +21,7 @@ export class UmbDataTypeDetailStore extends UmbDetailStoreBase<UmbDataTypeDetail
 
 	withPropertyEditorUiAlias(propertyEditorUiAlias: string) {
 		// TODO: Use a model for the data-type tree items: ^^Most likely it should be parsed to the UmbEntityTreeStore as a generic type.
-		return this._data.asObservablePart((items) =>
-			items.filter((item) => item.propertyEditorUiAlias === propertyEditorUiAlias),
-		);
+		return this._data.asObservablePart((items) => items.filter((item) => item.editorUiAlias === propertyEditorUiAlias));
 	}
 }
 

--- a/src/packages/core/data-type/types.ts
+++ b/src/packages/core/data-type/types.ts
@@ -3,8 +3,8 @@ export interface UmbDataTypeDetailModel {
 	unique: string;
 	parentUnique: string | null;
 	name: string;
-	propertyEditorAlias: string | undefined;
-	propertyEditorUiAlias: string | null;
+	editorAlias: string | undefined;
+	editorUiAlias: string | null;
 	values: Array<UmbDataTypePropertyModel>;
 }
 

--- a/src/packages/core/data-type/workspace/data-type-workspace.context.ts
+++ b/src/packages/core/data-type/workspace/data-type-workspace.context.ts
@@ -32,8 +32,8 @@ export class UmbDataTypeWorkspaceContext
 	readonly name = this.#data.asObservablePart((data) => data?.name);
 	readonly unique = this.#data.asObservablePart((data) => data?.unique);
 
-	readonly propertyEditorUiAlias = this.#data.asObservablePart((data) => data?.propertyEditorUiAlias);
-	readonly propertyEditorSchemaAlias = this.#data.asObservablePart((data) => data?.propertyEditorAlias);
+	readonly propertyEditorUiAlias = this.#data.asObservablePart((data) => data?.editorUiAlias);
+	readonly propertyEditorSchemaAlias = this.#data.asObservablePart((data) => data?.editorAlias);
 
 	#properties = new UmbArrayState<PropertyEditorConfigProperty>([], (x) => x.alias);
 	readonly properties = this.#properties.asObservable();
@@ -231,10 +231,10 @@ export class UmbDataTypeWorkspaceContext
 	}
 
 	setPropertyEditorSchemaAlias(alias?: string) {
-		this.#data.update({ propertyEditorAlias: alias });
+		this.#data.update({ editorAlias: alias });
 	}
 	setPropertyEditorUiAlias(alias?: string) {
-		this.#data.update({ propertyEditorUiAlias: alias });
+		this.#data.update({ editorUiAlias: alias });
 	}
 
 	async propertyValueByAlias<ReturnType = unknown>(propertyAlias: string) {

--- a/src/packages/core/data-type/workspace/data-type-workspace.modal-token.ts
+++ b/src/packages/core/data-type/workspace/data-type-workspace.modal-token.ts
@@ -1,0 +1,14 @@
+import { CreateDataTypeRequestModel } from '@umbraco-cms/backoffice/backend-api';
+import { UmbModalToken, UmbWorkspaceData, UmbWorkspaceValue } from '@umbraco-cms/backoffice/modal';
+
+export const UMB_DATATYPE_WORKSPACE_MODAL = new UmbModalToken<
+	UmbWorkspaceData<CreateDataTypeRequestModel>,
+	UmbWorkspaceValue
+>('Umb.Modal.Workspace', {
+	modal: {
+		type: 'sidebar',
+		size: 'large',
+	},
+	data: { entityType: 'data-type', preset: {} },
+	// Recast the type, so the entityType data prop is not required:
+}) as UmbModalToken<Omit<UmbWorkspaceData<CreateDataTypeRequestModel>, 'entityType'>, UmbWorkspaceValue>;

--- a/src/packages/core/data-type/workspace/data-type-workspace.modal-token.ts
+++ b/src/packages/core/data-type/workspace/data-type-workspace.modal-token.ts
@@ -1,8 +1,8 @@
-import { CreateDataTypeRequestModel } from '@umbraco-cms/backoffice/backend-api';
+import { UmbDataTypeDetailModel } from '../types.js';
 import { UmbModalToken, UmbWorkspaceData, UmbWorkspaceValue } from '@umbraco-cms/backoffice/modal';
 
 export const UMB_DATATYPE_WORKSPACE_MODAL = new UmbModalToken<
-	UmbWorkspaceData<CreateDataTypeRequestModel>,
+	UmbWorkspaceData<UmbDataTypeDetailModel>,
 	UmbWorkspaceValue
 >('Umb.Modal.Workspace', {
 	modal: {
@@ -11,4 +11,4 @@ export const UMB_DATATYPE_WORKSPACE_MODAL = new UmbModalToken<
 	},
 	data: { entityType: 'data-type', preset: {} },
 	// Recast the type, so the entityType data prop is not required:
-}) as UmbModalToken<Omit<UmbWorkspaceData<CreateDataTypeRequestModel>, 'entityType'>, UmbWorkspaceValue>;
+}) as UmbModalToken<Omit<UmbWorkspaceData<UmbDataTypeDetailModel>, 'entityType'>, UmbWorkspaceValue>;

--- a/src/packages/core/data-type/workspace/index.ts
+++ b/src/packages/core/data-type/workspace/index.ts
@@ -1,1 +1,2 @@
 export * from './data-type-workspace.context-token.js';
+export * from './data-type-workspace.modal-token.js';

--- a/src/packages/core/data-type/workspace/views/info/workspace-view-data-type-info.element.ts
+++ b/src/packages/core/data-type/workspace/views/info/workspace-view-data-type-info.element.ts
@@ -41,11 +41,11 @@ export class UmbWorkspaceViewDataTypeInfoElement extends UmbLitElement implement
 					<div slot="editor">${this._dataType?.unique}</div>
 				</umb-property-layout>
 				<umb-property-layout label="Property Editor Alias">
-					<div slot="editor">${this._dataType?.propertyEditorAlias}</div>
+					<div slot="editor">${this._dataType?.editorAlias}</div>
 				</umb-property-layout>
 
 				<umb-property-layout label="Property Editor UI Alias">
-					<div slot="editor">${this._dataType?.propertyEditorUiAlias}</div>
+					<div slot="editor">${this._dataType?.editorUiAlias}</div>
 				</umb-property-layout>
 			</uui-box>
 		`;

--- a/src/packages/core/modal/token/workspace-modal.token.ts
+++ b/src/packages/core/modal/token/workspace-modal.token.ts
@@ -1,10 +1,7 @@
-import { CreateDataTypeRequestModel } from '@umbraco-cms/backoffice/backend-api';
 import { UmbModalToken } from '@umbraco-cms/backoffice/modal';
-
-// TODO: Change model:
-export interface UmbWorkspaceData {
+export interface UmbWorkspaceData<DataModelType = unknown> {
 	entityType: string;
-	preset: Partial<CreateDataTypeRequestModel>;
+	preset: Partial<DataModelType>;
 }
 
 // TODO: It would be good with a WorkspaceValueBaseType, to avoid the  hardcoded type for unique here:


### PR DESCRIPTION
A specific token for the data-type workspace modal


And then as part of my work i renamed the propertyEditorAlias fields to editorAlias, similar to the server model. That showed later not to be needed, but I think its okay to align. so kept it anyway.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
