### PR TITLE
Content Type pickers - sets icons

### DIFF
--- a/src/packages/documents/document-types/components/input-document-type/input-document-type.element.ts
+++ b/src/packages/documents/document-types/components/input-document-type/input-document-type.element.ts
@@ -153,7 +153,7 @@ export class UmbInputDocumentTypeElement extends FormControlMixin(UmbLitElement)
 				>${repeat(
 					this._items,
 					(item) => item.id,
-					(item) => this._renderItem(item),
+					(item) => this.#renderItem(item),
 				)}</uui-ref-list
 			>
 		`;
@@ -172,10 +172,11 @@ export class UmbInputDocumentTypeElement extends FormControlMixin(UmbLitElement)
 		`;
 	}
 
-	private _renderItem(item: DocumentTypeItemResponseModel) {
+	#renderItem(item: DocumentTypeItemResponseModel) {
 		if (!item.id) return;
 		return html`
 			<uui-ref-node-document-type name=${ifDefined(item.name)}>
+				${this.#renderIcon(item)}
 				<uui-action-bar slot="actions">
 					<uui-button
 						compact
@@ -192,6 +193,11 @@ export class UmbInputDocumentTypeElement extends FormControlMixin(UmbLitElement)
 				</uui-action-bar>
 			</uui-ref-node-document-type>
 		`;
+	}
+
+	#renderIcon(item: DocumentTypeItemResponseModel) {
+		if (!item.icon) return;
+		return html`<uui-icon slot="icon" name=${item.icon}></uui-icon>`;
 	}
 
 	static styles = [

--- a/src/packages/media/media-types/components/input-media-type/input-media-type.element.ts
+++ b/src/packages/media/media-types/components/input-media-type/input-media-type.element.ts
@@ -115,7 +115,7 @@ export class UmbInputMediaTypeElement extends FormControlMixin(UmbLitElement) {
 				>${repeat(
 					this._items,
 					(item) => item.id,
-					(item) => this._renderItem(item),
+					(item) => this.#renderItem(item),
 				)}</uui-ref-list
 			>
 		`;
@@ -134,10 +134,11 @@ export class UmbInputMediaTypeElement extends FormControlMixin(UmbLitElement) {
 		`;
 	}
 
-	private _renderItem(item: MediaTypeItemResponseModel) {
+	#renderItem(item: MediaTypeItemResponseModel) {
 		if (!item.id) return;
 		return html`
 			<uui-ref-node-document-type name=${ifDefined(item.name)}>
+				${this.#renderIcon(item)}
 				<uui-action-bar slot="actions">
 					<uui-button
 						@click=${() => this.#pickerContext.requestRemoveItem(item.id!)}
@@ -147,6 +148,11 @@ export class UmbInputMediaTypeElement extends FormControlMixin(UmbLitElement) {
 				</uui-action-bar>
 			</uui-ref-node-document-type>
 		`;
+	}
+
+	#renderIcon(item: MediaTypeItemResponseModel) {
+		if (!item.icon) return;
+		return html`<uui-icon slot="icon" name=${item.icon}></uui-icon>`;
 	}
 
 	static styles = [

--- a/src/packages/members/member-types/components/input-member-type/input-member-type.element.ts
+++ b/src/packages/members/member-types/components/input-member-type/input-member-type.element.ts
@@ -115,7 +115,7 @@ export class UmbInputMemberTypeElement extends FormControlMixin(UmbLitElement) {
 				>${repeat(
 					this._items,
 					(item) => item.id,
-					(item) => this._renderItem(item),
+					(item) => this.#renderItem(item),
 				)}</uui-ref-list
 			>
 		`;
@@ -134,10 +134,11 @@ export class UmbInputMemberTypeElement extends FormControlMixin(UmbLitElement) {
 		`;
 	}
 
-	private _renderItem(item: MemberTypeItemResponseModel) {
+	#renderItem(item: MemberTypeItemResponseModel) {
 		if (!item.id) return;
 		return html`
 			<uui-ref-node-document-type name=${ifDefined(item.name)}>
+			${this.#renderIcon(item)}
 				<uui-action-bar slot="actions">
 					<uui-button
 						@click=${() => this.#pickerContext.requestRemoveItem(item.id!)}
@@ -147,6 +148,11 @@ export class UmbInputMemberTypeElement extends FormControlMixin(UmbLitElement) {
 				</uui-action-bar>
 			</uui-ref-node-document-type>
 		`;
+	}
+
+	#renderIcon(item: MemberTypeItemResponseModel) {
+		if (!item.icon) return;
+		return html`<uui-icon slot="icon" name=${item.icon}></uui-icon>`;
 	}
 
 	static styles = [


### PR DESCRIPTION
Sets the icons for the selected content types in the Document Type, Media Type and Member Type pickers.

I've also normalized the `#renderItem` private method calls, (from `private` to `#` prefix).