### PR TITLE
Tree Picker: Pass in "filter" to picker

### DIFF
--- a/src/packages/core/property-editor/uis/tree-picker/property-editor-ui-tree-picker.element.ts
+++ b/src/packages/core/property-editor/uis/tree-picker/property-editor-ui-tree-picker.element.ts
@@ -28,7 +28,7 @@ export class UmbPropertyEditorUITreePickerElement extends UmbLitElement implemen
 	max = 0;
 
 	@state()
-	filter?: string | null;
+	allowedContentTypeIds?: string | null;
 
 	@state()
 	showOpenButton?: boolean;
@@ -47,7 +47,7 @@ export class UmbPropertyEditorUITreePickerElement extends UmbLitElement implemen
 		this.min = Number(config?.getValueByAlias('minNumber')) || 0;
 		this.max = Number(config?.getValueByAlias('maxNumber')) || 0;
 
-		this.filter = config?.getValueByAlias('filter');
+		this.allowedContentTypeIds = config?.getValueByAlias('filter');
 		this.showOpenButton = config?.getValueByAlias('showOpenButton');
 		this.ignoreUserStartNodes = config?.getValueByAlias('ignoreUserStartNodes');
 	}
@@ -64,7 +64,7 @@ export class UmbPropertyEditorUITreePickerElement extends UmbLitElement implemen
 			.startNodeId=${this.startNodeId ?? ''}
 			.min=${this.min}
 			.max=${this.max}
-			.filter=${this.filter ?? ''}
+			.allowedContentTypeIds=${this.allowedContentTypeIds ?? ''}
 			?showOpenButton=${this.showOpenButton}
 			?ignoreUserStartNodes=${this.ignoreUserStartNodes}
 			@change=${this.#onChange}></umb-input-tree>`;

--- a/src/packages/core/tree/components/input-tree/input-tree.element.ts
+++ b/src/packages/core/tree/components/input-tree/input-tree.element.ts
@@ -115,7 +115,7 @@ export class UmbInputTreeElement extends FormControlMixin(UmbLitElement) {
 	#renderMediaPicker() {
 		return html`<umb-input-media
 			.selectedIds=${this.selectedIds}
-			.filter=${this.filter}
+			.filter=${this._filter}
 			.min=${this.min}
 			.max=${this.max}
 			?showOpenButton=${this.showOpenButton}

--- a/src/packages/core/tree/components/input-tree/input-tree.element.ts
+++ b/src/packages/core/tree/components/input-tree/input-tree.element.ts
@@ -35,13 +35,13 @@ export class UmbInputTreeElement extends FormControlMixin(UmbLitElement) {
 	@property({ type: Number })
 	max = 0;
 
-	private _filter: Array<string> = [];
+	private _allowedContentTypeIds: Array<string> = [];
 	@property()
-	public set filter(value: string) {
-		this._filter = value ? value.split(',') : [];
+	public set allowedContentTypeIds(value: string) {
+		this._allowedContentTypeIds = value ? value.split(',') : [];
 	}
-	public get filter(): string {
-		return this._filter.join(',');
+	public get allowedContentTypeIds(): string {
+		return this._allowedContentTypeIds.join(',');
 	}
 
 	@property({ type: Boolean })
@@ -104,7 +104,7 @@ export class UmbInputTreeElement extends FormControlMixin(UmbLitElement) {
 		return html`<umb-input-document
 			.selectedIds=${this.selectedIds}
 			.startNodeId=${this.startNodeId}
-			.filter=${this._filter}
+			.allowedContentTypeIds=${this._allowedContentTypeIds}
 			.min=${this.min}
 			.max=${this.max}
 			?showOpenButton=${this.showOpenButton}
@@ -115,7 +115,7 @@ export class UmbInputTreeElement extends FormControlMixin(UmbLitElement) {
 	#renderMediaPicker() {
 		return html`<umb-input-media
 			.selectedIds=${this.selectedIds}
-			.filter=${this._filter}
+			.allowedContentTypeIds=${this._allowedContentTypeIds}
 			.min=${this.min}
 			.max=${this.max}
 			?showOpenButton=${this.showOpenButton}
@@ -126,7 +126,7 @@ export class UmbInputTreeElement extends FormControlMixin(UmbLitElement) {
 	#renderMemberPicker() {
 		return html`<umb-input-member
 			.selectedIds=${this.selectedIds}
-			.filter=${this._filter}
+			.allowedContentTypeIds=${this._allowedContentTypeIds}
 			.min=${this.min}
 			.max=${this.max}
 			?showOpenButton=${this.showOpenButton}

--- a/src/packages/core/tree/components/input-tree/input-tree.element.ts
+++ b/src/packages/core/tree/components/input-tree/input-tree.element.ts
@@ -38,7 +38,7 @@ export class UmbInputTreeElement extends FormControlMixin(UmbLitElement) {
 	private _filter: Array<string> = [];
 	@property()
 	public set filter(value: string) {
-		this._filter = value.split(',');
+		this._filter = value ? value.split(',') : [];
 	}
 	public get filter(): string {
 		return this._filter.join(',');
@@ -104,7 +104,7 @@ export class UmbInputTreeElement extends FormControlMixin(UmbLitElement) {
 		return html`<umb-input-document
 			.selectedIds=${this.selectedIds}
 			.startNodeId=${this.startNodeId}
-			.filter=${this.filter}
+			.filter=${this._filter}
 			.min=${this.min}
 			.max=${this.max}
 			?showOpenButton=${this.showOpenButton}

--- a/src/packages/core/tree/components/input-tree/input-tree.element.ts
+++ b/src/packages/core/tree/components/input-tree/input-tree.element.ts
@@ -126,7 +126,7 @@ export class UmbInputTreeElement extends FormControlMixin(UmbLitElement) {
 	#renderMemberPicker() {
 		return html`<umb-input-member
 			.selectedIds=${this.selectedIds}
-			.filter=${this.filter}
+			.filter=${this._filter}
 			.min=${this.min}
 			.max=${this.max}
 			?showOpenButton=${this.showOpenButton}

--- a/src/packages/documents/documents/components/input-document/input-document.element.ts
+++ b/src/packages/documents/documents/components/input-document/input-document.element.ts
@@ -64,7 +64,7 @@ export class UmbInputDocumentElement extends FormControlMixin(UmbLitElement) {
 	startNodeId?: string;
 
 	@property({ type: Array })
-	filter?: string[] | undefined;
+	allowedContentTypeIds?: string[] | undefined;
 
 	@property({ type: Boolean })
 	showOpenButton?: boolean;
@@ -111,8 +111,8 @@ export class UmbInputDocumentElement extends FormControlMixin(UmbLitElement) {
 	}
 
 	#pickableFilter: (item: DocumentTreeItemResponseModel) => boolean = (item) => {
-		if (this.filter && this.filter.length > 0) {
-			return this.filter.includes(item.contentTypeId);
+		if (this.allowedContentTypeIds && this.allowedContentTypeIds.length > 0) {
+			return this.allowedContentTypeIds.includes(item.contentTypeId);
 		}
 		return true;
 	}

--- a/src/packages/documents/documents/components/input-document/input-document.element.ts
+++ b/src/packages/documents/documents/components/input-document/input-document.element.ts
@@ -142,7 +142,7 @@ export class UmbInputDocumentElement extends FormControlMixin(UmbLitElement) {
 			>${repeat(
 				this._items,
 				(item) => item.id,
-				(item) => this._renderItem(item),
+				(item) => this.#renderItem(item),
 			)}
 		</uui-ref-list>`;
 	}
@@ -156,13 +156,13 @@ export class UmbInputDocumentElement extends FormControlMixin(UmbLitElement) {
 			label=${this.localize.term('general_choose')}></uui-button>`;
 	}
 
-	private _renderItem(item: DocumentItemResponseModel) {
+	#renderItem(item: DocumentItemResponseModel) {
 		if (!item.id) return;
 		return html`
 			<uui-ref-node name=${ifDefined(item.name)} detail=${ifDefined(item.id)}>
-				${this._renderIsTrashed(item)}
+				${this.#renderIsTrashed(item)}
 				<uui-action-bar slot="actions">
-					${this._renderOpenButton(item)}
+					${this.#renderOpenButton(item)}
 					<uui-button
 						@click=${() => this.#pickerContext.requestRemoveItem(item.id!)}
 						label="Remove document ${item.name}"
@@ -173,12 +173,12 @@ export class UmbInputDocumentElement extends FormControlMixin(UmbLitElement) {
 		`;
 	}
 
-	private _renderIsTrashed(item: DocumentItemResponseModel) {
+	#renderIsTrashed(item: DocumentItemResponseModel) {
 		if (!item.isTrashed) return;
 		return html`<uui-tag size="s" slot="tag" color="danger">Trashed</uui-tag>`;
 	}
 
-	private _renderOpenButton(item: DocumentItemResponseModel) {
+	#renderOpenButton(item: DocumentItemResponseModel) {
 		if (!this.showOpenButton) return;
 		return html`<uui-button @click=${() => this.#openItem(item)} label="Open document ${item.name}"
 			>${this.localize.term('general_open')}</uui-button

--- a/src/packages/media/media/components/input-media/input-media.element.ts
+++ b/src/packages/media/media/components/input-media/input-media.element.ts
@@ -61,7 +61,7 @@ export class UmbInputMediaElement extends FormControlMixin(UmbLitElement) {
 	}
 
 	@property({ type: Array })
-	filter?: string[] | undefined;
+	allowedContentTypeIds?: string[] | undefined;
 
 	@property({ type: Boolean })
 	showOpenButton?: boolean;
@@ -111,15 +111,15 @@ export class UmbInputMediaElement extends FormControlMixin(UmbLitElement) {
 		/* TODO: Media item doesn't have the content/media-type ID available to query.
 			 Commenting out until the Management API model is updated. [LK]
 		*/
-		// if (this.filter && this.filter.length > 0) {
-		// 	return this.filter.includes(item.contentTypeId);
+		// if (this.allowedContentTypeIds && this.allowedContentTypeIds.length > 0) {
+		// 	return this.allowedContentTypeIds.includes(item.contentTypeId);
 		// }
 		return true;
 	};
 
 	#openPicker() {
-		// TODO: Configure the media picker, with `filter` and `ignoreUserStartNodes` [LK]
-		console.log('#openPicker', [this.filter, this.ignoreUserStartNodes]);
+		// TODO: Configure the media picker, with `allowedContentTypeIds` and `ignoreUserStartNodes` [LK]
+		console.log('#openPicker', [this.allowedContentTypeIds, this.ignoreUserStartNodes]);
 		this.#pickerContext.openPicker({
 			hideTreeRoot: true,
 			pickableFilter: this.#pickableFilter,

--- a/src/packages/media/media/components/input-media/input-media.element.ts
+++ b/src/packages/media/media/components/input-media/input-media.element.ts
@@ -132,7 +132,7 @@ export class UmbInputMediaElement extends FormControlMixin(UmbLitElement) {
 	}
 
 	render() {
-		return html` ${this.#renderItems()} ${this.#renderButton()} `;
+		return html` ${this.#renderItems()} ${this.#renderAddButton()} `;
 	}
 
 	#renderItems() {
@@ -147,7 +147,7 @@ export class UmbInputMediaElement extends FormControlMixin(UmbLitElement) {
 		`;
 	}
 
-	#renderButton() {
+	#renderAddButton() {
 		if (this._items && this.max && this._items.length >= this.max) return;
 		return html`
 			<uui-button
@@ -169,7 +169,7 @@ export class UmbInputMediaElement extends FormControlMixin(UmbLitElement) {
 				name=${ifDefined(item.name === null ? undefined : item.name)}
 				detail=${ifDefined(item.id)}
 				file-ext="jpg">
-				${this._renderIsTrashed(item)}
+				${this.#renderIsTrashed(item)}
 				<uui-action-bar slot="actions">
 					<uui-button label="Copy media">
 						<uui-icon name="icon-documents"></uui-icon>
@@ -182,7 +182,7 @@ export class UmbInputMediaElement extends FormControlMixin(UmbLitElement) {
 		`;
 	}
 
-	private _renderIsTrashed(item: MediaItemResponseModel) {
+	#renderIsTrashed(item: MediaItemResponseModel) {
 		if (!item.isTrashed) return;
 		return html`<uui-tag size="s" slot="tag" color="danger">Trashed</uui-tag>`;
 	}

--- a/src/packages/members/members/components/input-member/input-member.element.ts
+++ b/src/packages/members/members/components/input-member/input-member.element.ts
@@ -69,7 +69,7 @@ export class UmbInputMemberElement extends FormControlMixin(UmbLitElement) {
 	}
 
 	@property({ type: Array })
-	filter?: string[] | undefined;
+	allowedContentTypeIds?: string[] | undefined;
 
 	@property()
 	public set value(idsString: string) {
@@ -109,8 +109,8 @@ export class UmbInputMemberElement extends FormControlMixin(UmbLitElement) {
 	#pickableFilter: (item: MemberItemResponseModel) => boolean = (item) => {
 		// TODO: Uncomment, once `UmbMemberPickerContext` has been implemented. [LK]
 		console.log('member.pickableFilter', item);
-		// 	if (this.filter && this.filter.length > 0) {
-		// 		return this.filter.includes(item.contentTypeId);
+		// 	if (this.allowedContentTypeIds && this.allowedContentTypeIds.length > 0) {
+		// 		return this.allowedContentTypeIds.includes(item.contentTypeId);
 		// 	}
 		return true;
 	};

--- a/src/packages/members/members/components/input-member/input-member.element.ts
+++ b/src/packages/members/members/components/input-member/input-member.element.ts
@@ -14,10 +14,12 @@ export class UmbInputMemberElement extends FormControlMixin(UmbLitElement) {
 	 */
 	@property({ type: Number })
 	public get min(): number {
+		// TODO: Uncomment, once `UmbMemberPickerContext` has been implemented. [LK]
 		//return this.#pickerContext.min;
 		return 0;
 	}
 	public set min(value: number) {
+		// TODO: Uncomment, once `UmbMemberPickerContext` has been implemented. [LK]
 		//this.#pickerContext.min = value;
 	}
 
@@ -38,10 +40,12 @@ export class UmbInputMemberElement extends FormControlMixin(UmbLitElement) {
 	 */
 	@property({ type: Number })
 	public get max(): number {
+		// TODO: Uncomment, once `UmbMemberPickerContext` has been implemented. [LK]
 		//return this.#pickerContext.max;
 		return Infinity;
 	}
 	public set max(value: number) {
+		// TODO: Uncomment, once `UmbMemberPickerContext` has been implemented. [LK]
 		//this.#pickerContext.max = value;
 	}
 
@@ -55,10 +59,12 @@ export class UmbInputMemberElement extends FormControlMixin(UmbLitElement) {
 	maxMessage = 'This field exceeds the allowed amount of items';
 
 	public get selectedIds(): Array<string> {
+		// TODO: Uncomment, once `UmbMemberPickerContext` has been implemented. [LK]
 		//return this.#pickerContext.getSelection();
 		return [];
 	}
 	public set selectedIds(ids: Array<string>) {
+		// TODO: Uncomment, once `UmbMemberPickerContext` has been implemented. [LK]
 		//this.#pickerContext.setSelection(ids);
 	}
 
@@ -80,6 +86,7 @@ export class UmbInputMemberElement extends FormControlMixin(UmbLitElement) {
 	constructor() {
 		super();
 
+		// TODO: Uncomment, once `UmbMemberPickerContext` has been implemented. [LK]
 		// this.addValidator(
 		// 	'rangeUnderflow',
 		// 	() => this.minMessage,
@@ -109,6 +116,7 @@ export class UmbInputMemberElement extends FormControlMixin(UmbLitElement) {
 	};
 
 	#openPicker() {
+		// TODO: Uncomment, once `UmbMemberPickerContext` has been implemented. [LK]
 		console.log('member.openPicker');
 		// this.#pickerContext.openPicker({
 		// 	hideTreeRoot: true,
@@ -117,6 +125,7 @@ export class UmbInputMemberElement extends FormControlMixin(UmbLitElement) {
 	}
 
 	#requestRemoveItem(item: MemberItemResponseModel) {
+		// TODO: Uncomment, once `UmbMemberPickerContext` has been implemented. [LK]
 		console.log('member.requestRemoveItem', item);
 		//this.#pickerContext.requestRemoveItem(item.id!);
 	}

--- a/src/packages/members/members/components/input-member/input-member.element.ts
+++ b/src/packages/members/members/components/input-member/input-member.element.ts
@@ -62,6 +62,9 @@ export class UmbInputMemberElement extends FormControlMixin(UmbLitElement) {
 		//this.#pickerContext.setSelection(ids);
 	}
 
+	@property({ type: Array })
+	filter?: string[] | undefined;
+
 	@property()
 	public set value(idsString: string) {
 		// Its with full purpose we don't call super.value, as thats being handled by the observation of the context selection.
@@ -93,10 +96,20 @@ export class UmbInputMemberElement extends FormControlMixin(UmbLitElement) {
 		// this.observe(this.#pickerContext.selectedItems, (selectedItems) => (this._items = selectedItems));
 	}
 
+	#pickableFilter: (item: MemberItemResponseModel) => boolean = (item) => {
+		// TODO: Uncomment, once `UmbMemberPickerContext` has been implemented. [LK]
+		console.log('member.pickableFilter', item);
+		// 	if (this.filter && this.filter.length > 0) {
+		// 		return this.filter.includes(item.contentTypeId);
+		// 	}
+		return true;
+	};
+
 	protected _openPicker() {
 		console.log("member.openPicker");
 		// this.#pickerContext.openPicker({
 		// 	hideTreeRoot: true,
+		//	pickableFilter: this.#pickableFilter,
 		// });
 	}
 

--- a/src/packages/members/members/components/input-member/input-member.element.ts
+++ b/src/packages/members/members/components/input-member/input-member.element.ts
@@ -95,6 +95,9 @@ export class UmbInputMemberElement extends FormControlMixin(UmbLitElement) {
 		// this.observe(this.#pickerContext.selection, (selection) => (super.value = selection.join(',')));
 		// this.observe(this.#pickerContext.selectedItems, (selectedItems) => (this._items = selectedItems));
 	}
+	protected getFormElement() {
+		return undefined;
+	}
 
 	#pickableFilter: (item: MemberItemResponseModel) => boolean = (item) => {
 		// TODO: Uncomment, once `UmbMemberPickerContext` has been implemented. [LK]
@@ -105,28 +108,21 @@ export class UmbInputMemberElement extends FormControlMixin(UmbLitElement) {
 		return true;
 	};
 
-	protected _openPicker() {
-		console.log("member.openPicker");
+	#openPicker() {
+		console.log('member.openPicker');
 		// this.#pickerContext.openPicker({
 		// 	hideTreeRoot: true,
 		//	pickableFilter: this.#pickableFilter,
 		// });
 	}
 
-	protected _requestRemoveItem(item: MemberItemResponseModel){
-		console.log("member.requestRemoveItem", item);
+	#requestRemoveItem(item: MemberItemResponseModel) {
+		console.log('member.requestRemoveItem', item);
 		//this.#pickerContext.requestRemoveItem(item.id!);
 	}
 
-	protected getFormElement() {
-		return undefined;
-	}
-
 	render() {
-		return html`
-			${this.#renderItems()}
-			${this.#renderAddButton()}
-		`;
+		return html` ${this.#renderItems()} ${this.#renderAddButton()} `;
 	}
 
 	#renderItems() {
@@ -136,7 +132,7 @@ export class UmbInputMemberElement extends FormControlMixin(UmbLitElement) {
 			>${repeat(
 				this._items,
 				(item) => item.id,
-				(item) => this._renderItem(item),
+				(item) => this.#renderItem(item),
 			)}
 		</uui-ref-list>`;
 	}
@@ -146,24 +142,28 @@ export class UmbInputMemberElement extends FormControlMixin(UmbLitElement) {
 		return html`<uui-button
 			id="add-button"
 			look="placeholder"
-			@click=${this._openPicker}
-			label=${this.localize.term('general_add')}></uui-button>`;
+			@click=${this.#openPicker}
+			label=${this.localize.term('general_choose')}></uui-button>`;
 	}
 
-	private _renderItem(item: MemberItemResponseModel) {
+	#renderItem(item: MemberItemResponseModel) {
 		if (!item.id) return;
 		return html`
 			<uui-ref-node name=${ifDefined(item.name)} detail=${ifDefined(item.id)}>
-				<!-- TODO: implement is deleted <uui-tag size="s" slot="tag" color="danger">Deleted</uui-tag> -->
+				${this.#renderIsTrashed(item)}
 				<uui-action-bar slot="actions">
-					<uui-button
-						@click=${() => this._requestRemoveItem(item)}
-						label="Remove member ${item.name}"
+					<uui-button @click=${() => this.#requestRemoveItem(item)} label="Remove member ${item.name}"
 						>Remove</uui-button
 					>
 				</uui-action-bar>
 			</uui-ref-node>
 		`;
+	}
+
+	#renderIsTrashed(item: MemberItemResponseModel) {
+		// TODO: Uncomment, once the Management API model support deleted members. [LK]
+		//if (!item.isTrashed) return;
+		//return html`<uui-tag size="s" slot="tag" color="danger">Trashed</uui-tag>`;
 	}
 
 	static styles = [


### PR DESCRIPTION
For Multinode Treepicker, the "filter" option is passed in to the corresponding Document/Media/Member picker.

This is then used by the `pickableFilter` option on the Tree modal to filter out the selectable items.

For the Member picker, I've put placeholder code and commented out, (until the Member repository code has been implemented).
