### PR TITLE
UmbState method rename from 'next' to 'setValue'

### DIFF
--- a/examples/workspace-context-counter/counter-workspace-context.ts
+++ b/examples/workspace-context-counter/counter-workspace-context.ts
@@ -16,7 +16,7 @@ export class WorkspaceContextCounter extends UmbBaseController {
 
 	// Lets expose methods to update the state:
 	increment() {
-		this.#counter.next(this.#counter.value + 1);
+		this.#counter.setValue(this.#counter.value + 1);
 	}
 }
 

--- a/src/apps/app/server-connection.ts
+++ b/src/apps/app/server-connection.ts
@@ -56,7 +56,7 @@ export class UmbServerConnection {
 			throw error;
 		}
 
-		this.#isConnected.next(true);
+		this.#isConnected.setValue(true);
 		this.#status = data?.serverStatus ?? RuntimeLevelModel.UNKNOWN;
 	}
 }

--- a/src/apps/backoffice/backoffice.context.ts
+++ b/src/apps/backoffice/backoffice.context.ts
@@ -19,12 +19,12 @@ export class UmbBackofficeContext extends UmbContextBase<UmbBackofficeContext> {
 	constructor(host: UmbControllerHost) {
 		super(host, UMB_BACKOFFICE_CONTEXT_TOKEN);
 		new UmbExtensionsManifestInitializer(this, umbExtensionsRegistry, 'section', null, (sections) => {
-			this.#allowedSections.next([...sections]);
+			this.#allowedSections.setValue([...sections]);
 		});
 	}
 
 	public setActiveSectionAlias(alias: string) {
-		this.#activeSectionAlias.next(alias);
+		this.#activeSectionAlias.setValue(alias);
 	}
 }
 

--- a/src/apps/installer/installer.context.ts
+++ b/src/apps/installer/installer.context.ts
@@ -62,7 +62,7 @@ export class UmbInstallerContext {
 	 * @memberof UmbInstallerContext
 	 */
 	public nextStep(): void {
-		this._currentStep.next(this._currentStep.getValue() + 1);
+		this._currentStep.setValue(this._currentStep.getValue() + 1);
 	}
 
 	/**
@@ -71,7 +71,7 @@ export class UmbInstallerContext {
 	 * @memberof UmbInstallerContext
 	 */
 	public prevStep(): void {
-		this._currentStep.next(this._currentStep.getValue() - 1);
+		this._currentStep.setValue(this._currentStep.getValue() - 1);
 	}
 
 	/**
@@ -80,8 +80,8 @@ export class UmbInstallerContext {
 	 * @memberof UmbInstallerContext
 	 */
 	public reset(): void {
-		this._installStatus.next(null);
-		this._currentStep.next(1);
+		this._installStatus.setValue(null);
+		this._currentStep.setValue(1);
 	}
 
 	/**
@@ -91,7 +91,7 @@ export class UmbInstallerContext {
 	 * @memberof UmbInstallerContext
 	 */
 	public appendData(data: Partial<InstallVResponseModel>): void {
-		this._data.next({ ...this.getData(), ...data });
+		this._data.setValue({ ...this.getData(), ...data });
 	}
 
 	/**
@@ -111,7 +111,7 @@ export class UmbInstallerContext {
 	 * @memberof UmbInstallerContext
 	 */
 	public setInstallStatus(status: ProblemDetails | null): void {
-		this._installStatus.next(status);
+		this._installStatus.setValue(status);
 	}
 
 	/**
@@ -122,9 +122,9 @@ export class UmbInstallerContext {
 	private async _loadInstallerSettings() {
 		const { data, error } = await tryExecute(InstallResource.getInstallSettings());
 		if (data) {
-			this._settings.next(data);
+			this._settings.setValue(data);
 		} else if (error) {
-			this._installStatus.next(error);
+			this._installStatus.setValue(error);
 		}
 	}
 }

--- a/src/libs/extension-api/registry/extension.registry.ts
+++ b/src/libs/extension-api/registry/extension.registry.ts
@@ -108,7 +108,7 @@ export class UmbExtensionRegistry<
 					),
 			);
 		nextData.push(kind as ManifestKind<ManifestTypes>);
-		this._kinds.next(nextData);
+		this._kinds.setValue(nextData);
 	}
 
 	register(manifest: ManifestTypes | ManifestKind<ManifestTypes>): void {
@@ -117,12 +117,12 @@ export class UmbExtensionRegistry<
 			return;
 		}
 
-		this._extensions.next([...this._extensions.getValue(), manifest as ManifestTypes]);
+		this._extensions.setValue([...this._extensions.getValue(), manifest as ManifestTypes]);
 	}
 
 	registerMany(manifests: Array<ManifestTypes | ManifestKind<ManifestTypes>>): void {
 		const validManifests = manifests.filter(this.checkExtension.bind(this));
-		this._extensions.next([...this._extensions.getValue(), ...(validManifests as Array<ManifestTypes>)]);
+		this._extensions.setValue([...this._extensions.getValue(), ...(validManifests as Array<ManifestTypes>)]);
 	}
 
 	unregisterMany(aliases: Array<string>): void {
@@ -133,8 +133,8 @@ export class UmbExtensionRegistry<
 		const newKindsValues = this._kinds.getValue().filter((kind) => kind.alias !== alias);
 		const newExtensionsValues = this._extensions.getValue().filter((extension) => extension.alias !== alias);
 
-		this._kinds.next(newKindsValues);
-		this._extensions.next(newExtensionsValues);
+		this._kinds.setValue(newKindsValues);
+		this._extensions.setValue(newExtensionsValues);
 	}
 
 	isRegistered(alias: string): boolean {

--- a/src/libs/observable-api/observer.test.ts
+++ b/src/libs/observable-api/observer.test.ts
@@ -48,6 +48,6 @@ describe('UmbObserver', () => {
 		});
 
 		expect(count).to.be.equal(1);
-		lateSubject.next(initialData);
+		lateSubject.setValue(initialData);
 	});
 });

--- a/src/libs/observable-api/states/array-state.ts
+++ b/src/libs/observable-api/states/array-state.ts
@@ -22,7 +22,7 @@ export class UmbArrayState<T> extends UmbDeepState<T[]> {
 
 	/**
 	 * @method sortBy
-	 * @param {(a: T, b: T) => number} sortMethod - A method to be used for sorting everytime data is set.
+	 * @param {(a: T, b: T) => number} sortMethod - A method to be used for sorting every time data is set.
 	 * @description - A sort method to this Subject.
 	 * @example <caption>Example add sort method</caption>
 	 * const data = [
@@ -37,13 +37,28 @@ export class UmbArrayState<T> extends UmbDeepState<T[]> {
 		return this;
 	}
 
-	next(value: T[]) {
+	/**
+	 * @method setValue
+	 * @param {T} data - The next data for this state to hold.
+	 * @description - Set the data of this state, if sortBy has been defined for this state the data will be sorted before set. If data is different than current this will trigger observations to update.
+	 * @example <caption>Example change the data of a state</caption>
+	 * const myState = new UmbArrayState('Good morning');
+	 * // myState.value is equal 'Good morning'.
+	 * myState.setValue('Goodnight')
+	 * // myState.value is equal 'Goodnight'.
+	 */
+	setValue(value: T[]) {
 		if (this.#sortMethod) {
-			super.next(value.sort(this.#sortMethod));
+			super.setValue(value.sort(this.#sortMethod));
 		} else {
-			super.next(value);
+			super.setValue(value);
 		}
 	}
+
+	/**
+	 * @deprecated - Use `setValue` instead.
+	 */
+	next = this.setValue;
 
 	/**
 	 * @method remove
@@ -69,7 +84,7 @@ export class UmbArrayState<T> extends UmbDeepState<T[]> {
 				});
 			});
 
-			this.next(next);
+			this.setValue(next);
 		}
 		return this;
 	}
@@ -96,7 +111,7 @@ export class UmbArrayState<T> extends UmbDeepState<T[]> {
 				return this.getUniqueMethod(x) !== unique;
 			});
 
-			this.next(next);
+			this.setValue(next);
 		}
 		return this;
 	}
@@ -123,7 +138,7 @@ export class UmbArrayState<T> extends UmbDeepState<T[]> {
 	 *
 	 */
 	filter(predicate: (value: T, index: number, array: T[]) => boolean) {
-		this.next(this.getValue().filter(predicate));
+		this.setValue(this.getValue().filter(predicate));
 		return this;
 	}
 
@@ -147,7 +162,7 @@ export class UmbArrayState<T> extends UmbDeepState<T[]> {
 		} else {
 			next.push(entry);
 		}
-		this.next(next);
+		this.setValue(next);
 		return this;
 	}
 
@@ -173,9 +188,9 @@ export class UmbArrayState<T> extends UmbDeepState<T[]> {
 			entries.forEach((entry) => {
 				pushToUniqueArray(next, entry, this.getUniqueMethod!);
 			});
-			this.next(next);
+			this.setValue(next);
 		} else {
-			this.next([...this.getValue(), ...entries]);
+			this.setValue([...this.getValue(), ...entries]);
 		}
 		return this;
 	}
@@ -198,7 +213,7 @@ export class UmbArrayState<T> extends UmbDeepState<T[]> {
 		if (!this.getUniqueMethod) {
 			throw new Error("Can't partial update an ArrayState without a getUnique method provided when constructed.");
 		}
-		this.next(partialUpdateFrozenArray(this.getValue(), entry, (x) => unique === this.getUniqueMethod!(x)));
+		this.setValue(partialUpdateFrozenArray(this.getValue(), entry, (x) => unique === this.getUniqueMethod!(x)));
 		return this;
 	}
 }

--- a/src/libs/observable-api/states/basic-state.ts
+++ b/src/libs/observable-api/states/basic-state.ts
@@ -30,7 +30,7 @@ export class UmbBasicState<T> {
 	 * @description - Holds the current data of this state.
 	 * @example <caption>Example retrieve the current data of a state</caption>
 	 * const myState = new UmbArrayState('Hello world');
-	 * console.log("Value is: ", myState.getValue());
+	 * console.log("Value is: ", myState.value);
 	 */
 	public get value(): BehaviorSubject<T>['value'] {
 		return this._subject.value;
@@ -57,18 +57,23 @@ export class UmbBasicState<T> {
 	}
 
 	/**
-	 * @method next
-	 * @param {T} data - The next set of data for this state to hold.
+	 * @method setValue
+	 * @param {T} data - The next data for this state to hold.
 	 * @description - Set the data of this state, if data is different than current this will trigger observations to update.
-	 * @example <caption>Example retrieve the current data of a state</caption>
+	 * @example <caption>Example change the data of a state</caption>
 	 * const myState = new UmbArrayState('Good morning');
 	 * // myState.value is equal 'Good morning'.
-	 * myState.next('Goodnight')
+	 * myState.setValue('Goodnight')
 	 * // myState.value is equal 'Goodnight'.
 	 */
-	next(newData: T): void {
-		if (newData !== this._subject.getValue()) {
-			this._subject.next(newData);
+	setValue(data: T): void {
+		if (data !== this._subject.getValue()) {
+			this._subject.next(data);
 		}
 	}
+
+	/**
+	 * @deprecated - Use `setValue` instead.
+	 */
+	next = this.setValue;
 }

--- a/src/libs/observable-api/states/class-state.ts
+++ b/src/libs/observable-api/states/class-state.ts
@@ -15,10 +15,15 @@ export class UmbClassState<T extends UmbClassStateData | undefined> extends UmbB
 		super(initialData);
 	}
 
-	next(newData: T): void {
+	/**
+	 * @method setValue
+	 * @param {T} data - The next data for this state to hold.
+	 * @description - Set the data of this state, if data is different than current this will trigger observations to update.
+	 */
+	setValue(data: T): void {
 		const oldValue = this._subject.getValue();
 
-		if (newData && oldValue?.equal(newData)) return;
-		this._subject.next(newData);
+		if (data && oldValue?.equal(data)) return;
+		this._subject.next(data);
 	}
 }

--- a/src/libs/observable-api/states/deep-state.test.ts
+++ b/src/libs/observable-api/states/deep-state.test.ts
@@ -17,7 +17,7 @@ describe('UmbDeepState', () => {
 	});
 
 	it('update via next', () => {
-		subject.next({ key: 'some', another: 'myNewValue' });
+		subject.setValue({ key: 'some', another: 'myNewValue' });
 		expect(subject.getValue().another).to.be.equal('myNewValue');
 	});
 
@@ -47,7 +47,7 @@ describe('UmbDeepState', () => {
 			}
 		});
 
-		subject.next({ key: 'change_this_first_should_not_trigger_update', another: 'myValue' });
-		subject.next({ key: 'some', another: 'myNewValue' });
+		subject.setValue({ key: 'change_this_first_should_not_trigger_update', another: 'myValue' });
+		subject.setValue({ key: 'some', another: 'myNewValue' });
 	});
 });

--- a/src/libs/observable-api/states/deep-state.ts
+++ b/src/libs/observable-api/states/deep-state.ts
@@ -24,8 +24,13 @@ export class UmbDeepState<T> extends UmbBasicState<T> {
 		return createObservablePart(this._subject, mappingFunction, memoizationFunction);
 	}
 
-	next(newData: T): void {
-		const frozenData = deepFreeze(newData);
+	/**
+	 * @method setValue
+	 * @param {T} data - The next data for this state to hold.
+	 * @description - Set the data of this state, if data is different than current this will trigger observations to update.
+	 */
+	setValue(data: T): void {
+		const frozenData = deepFreeze(data);
 		// Only update data if its different than current data.
 		if (!naiveObjectComparison(frozenData, this._subject.getValue())) {
 			this._subject.next(frozenData);

--- a/src/libs/observable-api/states/object-state.ts
+++ b/src/libs/observable-api/states/object-state.ts
@@ -21,7 +21,7 @@ export class UmbObjectState<T> extends UmbDeepState<T> {
 	 * myState.update({value: 'myNewValue'});
 	 */
 	update(partialData: Partial<T>) {
-		this.next({ ...this._subject.getValue(), ...partialData });
+		this.setValue({ ...this._subject.getValue(), ...partialData });
 		return this;
 	}
 }

--- a/src/packages/block/block-type/workspace/block-type-workspace.context.ts
+++ b/src/packages/block/block-type/workspace/block-type-workspace.context.ts
@@ -45,12 +45,12 @@ export class UmbBlockTypeWorkspaceContext<BlockTypeData extends UmbBlockTypeBase
 				if (value) {
 					const blockTypeData = value.find((x: UmbBlockTypeBase) => x.contentElementTypeKey === unique);
 					if (blockTypeData) {
-						this.#data.next(blockTypeData);
+						this.#data.setValue(blockTypeData);
 						return;
 					}
 				}
 				// Fallback to undefined:
-				this.#data.next(undefined);
+				this.#data.setValue(undefined);
 			});
 		});
 	}
@@ -61,7 +61,7 @@ export class UmbBlockTypeWorkspaceContext<BlockTypeData extends UmbBlockTypeBase
 		} as BlockTypeData;
 
 		this.setIsNew(true);
-		this.#data.next(data);
+		this.#data.setValue(data);
 		return { data };
 	}
 

--- a/src/packages/block/block/context/block.context.ts
+++ b/src/packages/block/block/context/block.context.ts
@@ -45,7 +45,7 @@ export class UmbBlockContext<
 	 * @returns {void}
 	 */
 	setLayout(layout: BlockLayoutType | undefined) {
-		this.#layout.next(layout);
+		this.#layout.setValue(layout);
 	}
 
 	constructor(host: UmbControllerHost) {
@@ -57,7 +57,7 @@ export class UmbBlockContext<
 			this.observe(
 				manager.workspacePath,
 				(workspacePath) => {
-					this.#workspacePath.next(workspacePath);
+					this.#workspacePath.setValue(workspacePath);
 				},
 				'observeWorkspacePath',
 			);
@@ -94,7 +94,7 @@ export class UmbBlockContext<
 		this.observe(
 			this.#manager.contentOf(contentUdi),
 			(content) => {
-				this.#content.next(content);
+				this.#content.setValue(content);
 			},
 			'observeContent',
 		);
@@ -105,7 +105,7 @@ export class UmbBlockContext<
 			this.observe(
 				this.#manager.contentOf(settingsUdi),
 				(content) => {
-					this.#settings.next(content);
+					this.#settings.setValue(content);
 				},
 				'observeSettings',
 			);
@@ -121,7 +121,7 @@ export class UmbBlockContext<
 		this.observe(
 			this.#manager.blockTypeOf(contentTypeKey),
 			(blockType) => {
-				this.#blockType.next(blockType as BlockType);
+				this.#blockType.setValue(blockType as BlockType);
 			},
 			'observeBlockType',
 		);
@@ -135,7 +135,7 @@ export class UmbBlockContext<
 		if (blockType.label) {
 			this.removeControllerByAlias('observeContentTypeName');
 			// Missing part for label syntax, as we need to store the syntax, interpretive it and then set the label: (here we are just parsing the label syntax)
-			this.#label.next(blockType.label);
+			this.#label.setValue(blockType.label);
 			return;
 		} else {
 			// TODO: Maybe this could be skipped if we had a fallback label which was set to get the content element type name?
@@ -143,7 +143,7 @@ export class UmbBlockContext<
 			this.observe(
 				this.blockTypeName,
 				(contentTypeName) => {
-					this.#label.next(contentTypeName ?? 'no name');
+					this.#label.setValue(contentTypeName ?? 'no name');
 				},
 				'observeBlockTypeName',
 			);
@@ -159,7 +159,7 @@ export class UmbBlockContext<
 		this.observe(
 			this.#manager.contentTypeNameOf(contentElementTypeKey),
 			(contentTypeName) => {
-				this.#blockTypeName.next(contentTypeName);
+				this.#blockTypeName.setValue(contentTypeName);
 			},
 			'observeBlockTypeContentElementTypeName',
 		);

--- a/src/packages/block/block/manager/block-manager.context.ts
+++ b/src/packages/block/block/manager/block-manager.context.ts
@@ -38,21 +38,21 @@ export class UmbBlockManagerContext<
 	public readonly settings = this.#settings.asObservable();
 
 	setBlockTypes(blockTypes: Array<BlockType>) {
-		this.#blockTypes.next(blockTypes);
+		this.#blockTypes.setValue(blockTypes);
 	}
 	getBlockTypes() {
 		return this.#blockTypes.value;
 	}
 
 	setLayouts(layouts: Array<BlockLayoutType>) {
-		this.#layouts.next(layouts);
+		this.#layouts.setValue(layouts);
 	}
 
 	setContents(contents: Array<UmbBlockDataType>) {
-		this.#contents.next(contents);
+		this.#contents.setValue(contents);
 	}
 	setSettings(settings: Array<UmbBlockDataType>) {
-		this.#settings.next(settings);
+		this.#settings.setValue(settings);
 	}
 
 	constructor(host: UmbControllerHost) {
@@ -67,7 +67,7 @@ export class UmbBlockManagerContext<
 			})
 			.observeRouteBuilder((routeBuilder) => {
 				const newPath = routeBuilder({});
-				this.#workspacePath.next(newPath);
+				this.#workspacePath.setValue(newPath);
 			});
 	}
 

--- a/src/packages/block/block/workspace/block-element-manager.ts
+++ b/src/packages/block/block/workspace/block-element-manager.ts
@@ -27,7 +27,7 @@ export class UmbBlockElementManager extends UmbBaseController {
 	}
 
 	setData(data: UmbBlockDataType | undefined) {
-		this.#data.next(data);
+		this.#data.setValue(data);
 		this.#getDataResolver();
 	}
 

--- a/src/packages/block/block/workspace/block-workspace.context.ts
+++ b/src/packages/block/block/workspace/block-workspace.context.ts
@@ -55,7 +55,7 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 			this.observe(
 				context.layoutOf(unique),
 				(layoutData) => {
-					this.#layout.next(layoutData as LayoutDataType);
+					this.#layout.setValue(layoutData as LayoutDataType);
 
 					//
 					// Content:
@@ -104,14 +104,14 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 		// TODO: If we have Settings dedicated to this block type, we initiate them here:
 
 		this.setIsNew(true);
-		this.#layout.next(layout as LayoutDataType);
+		this.#layout.setValue(layout as LayoutDataType);
 	}
 
 	getIsNew() {
 		return this.#isNew.value;
 	}
 	setIsNew(value: boolean): void {
-		this.#isNew.next(value);
+		this.#isNew.setValue(value);
 	}
 
 	getData() {

--- a/src/packages/core/collection/collection-view.manager.ts
+++ b/src/packages/core/collection/collection-view.manager.ts
@@ -33,7 +33,7 @@ export class UmbCollectionViewManager extends UmbBaseController {
 		// TODO: hack - we need to figure out how to get the "parent path" from the router
 		setTimeout(() => {
 			const currentUrl = new URL(window.location.href);
-			this.#rootPathname.next(currentUrl.pathname.substring(0, currentUrl.pathname.lastIndexOf('/')));
+			this.#rootPathname.setValue(currentUrl.pathname.substring(0, currentUrl.pathname.lastIndexOf('/')));
 		}, 100);
 	}
 
@@ -44,7 +44,7 @@ export class UmbCollectionViewManager extends UmbBaseController {
 	 * @memberof UmbCollectionContext
 	 */
 	public setCurrentView(view: ManifestCollectionView) {
-		this.#currentView.next(view);
+		this.#currentView.setValue(view);
 	}
 
 	/**
@@ -59,7 +59,7 @@ export class UmbCollectionViewManager extends UmbBaseController {
 	#observeViews() {
 		return new UmbExtensionsManifestInitializer(this, umbExtensionsRegistry, 'collectionView', null, (views) => {
 			const manifests = views.map((view) => view.manifest);
-			this.#views.next(manifests);
+			this.#views.setValue(manifests);
 			this.#createRoutes(manifests);
 		});
 	}
@@ -88,6 +88,6 @@ export class UmbCollectionViewManager extends UmbBaseController {
 			});
 		}
 
-		this.#routes.next(routes);
+		this.#routes.setValue(routes);
 	}
 }

--- a/src/packages/core/collection/default/collection-default.context.ts
+++ b/src/packages/core/collection/default/collection-default.context.ts
@@ -99,8 +99,8 @@ export class UmbDefaultCollectionContext<
 		const { data } = await this.repository.requestCollection(filter);
 
 		if (data) {
-			this.#items.next(data.items);
-			this.#totalItems.next(data.total);
+			this.#items.setValue(data.items);
+			this.#totalItems.setValue(data.total);
 			this.pagination.setTotalItems(data.total);
 		}
 	}
@@ -111,14 +111,14 @@ export class UmbDefaultCollectionContext<
 	 * @memberof UmbCollectionContext
 	 */
 	public setFilter(filter: Partial<FilterModelType>) {
-		this.#filter.next({ ...this.#filter.getValue(), ...filter });
+		this.#filter.setValue({ ...this.#filter.getValue(), ...filter });
 		this.requestCollection();
 	}
 
 	#configure(configuration: UmbCollectionConfiguration) {
 		this.selection.setMultiple(true);
 		this.pagination.setPageSize(configuration.pageSize!);
-		this.#filter.next({ ...this.#filter.getValue(), skip: 0, take: configuration.pageSize });
+		this.#filter.setValue({ ...this.#filter.getValue(), skip: 0, take: configuration.pageSize });
 	}
 
 	#onPageChange = (event: UmbChangeEvent) => {

--- a/src/packages/core/components/input-markdown-editor/input-markdown.element.ts
+++ b/src/packages/core/components/input-markdown-editor/input-markdown.element.ts
@@ -67,7 +67,7 @@ export class UmbInputMarkdownElement extends FormControlMixin(UmbLitElement) {
 				folding: false,
 			}); // Prefer to update options before showing the editor, to avoid seeing the changes in the UI.
 
-			this.#isCodeEditorReady.next(true);
+			this.#isCodeEditorReady.setValue(true);
 			this.#loadActions();
 		} catch (error) {
 			console.error(error);

--- a/src/packages/core/content-type/content-type-container-structure-helper.class.ts
+++ b/src/packages/core/content-type/content-type-container-structure-helper.class.ts
@@ -96,9 +96,9 @@ export class UmbContentTypeContainerStructureHelper {
 		if (!this.#structure || !this._ownerType) return;
 
 		if (this._isRoot) {
-			this.#containers.next([]);
+			this.#containers.setValue([]);
 			// We cannot have root properties currently, therefor we set it to false:
-			this.#hasProperties.next(false);
+			this.#hasProperties.setValue(false);
 			this._observeRootContainers();
 			new UmbObserverController(
 				this.#host,
@@ -113,7 +113,7 @@ export class UmbContentTypeContainerStructureHelper {
 				this.#host,
 				this.#structure.containersByNameAndType(this._ownerName, this._ownerType),
 				(ownerALikeContainers) => {
-					this.#containers.next([]);
+					this.#containers.setValue([]);
 					this._ownerContainers = ownerALikeContainers.filter((x) => x.id === this._ownerId) || [];
 					this._ownerAlikeContainers = ownerALikeContainers || [];
 					if (this._ownerAlikeContainers.length > 0) {
@@ -134,7 +134,7 @@ export class UmbContentTypeContainerStructureHelper {
 				this.#host,
 				this.#structure!.hasPropertyStructuresOf(container.id!),
 				(hasProperties) => {
-					this.#hasProperties.next(hasProperties);
+					this.#hasProperties.setValue(hasProperties);
 				},
 				'_observeOwnerHasProperties_' + container.id,
 			);
@@ -161,7 +161,7 @@ export class UmbContentTypeContainerStructureHelper {
 			this.#host,
 			this.#structure.rootContainers(this._childType!),
 			(rootContainers) => {
-				this.#containers.next([]);
+				this.#containers.setValue([]);
 				this._insertGroupContainers(rootContainers);
 			},
 			'_observeRootContainers',

--- a/src/packages/core/content-type/content-type-property-structure-helper.class.ts
+++ b/src/packages/core/content-type/content-type-property-structure-helper.class.ts
@@ -101,7 +101,7 @@ export class UmbContentTypePropertyStructureHelper {
 				});
 
 				// Fire update to subscribers:
-				this.#propertyStructure.next(_propertyStructure);
+				this.#propertyStructure.setValue(_propertyStructure);
 			},
 			'_observePropertyStructureOfGroup' + groupId,
 		);

--- a/src/packages/core/content-type/content-type-structure-manager.class.ts
+++ b/src/packages/core/content-type/content-type-structure-manager.class.ts
@@ -51,7 +51,7 @@ export class UmbContentTypePropertyStructureManager<
 			});
 		});
 		this.observe(this._contentTypeContainers, (contentTypeContainers) => {
-			this.#containers.next(contentTypeContainers);
+			this.#containers.setValue(contentTypeContainers);
 		});
 	}
 
@@ -449,8 +449,8 @@ export class UmbContentTypePropertyStructureManager<
 	private _reset() {
 		this.#contentTypeObservers.forEach((observer) => observer.destroy());
 		this.#contentTypeObservers = [];
-		this.#contentTypes.next([]);
-		this.#containers.next([]);
+		this.#contentTypes.setValue([]);
+		this.#containers.setValue([]);
 	}
 	public destroy() {
 		this._reset();

--- a/src/packages/core/data-type/workspace/data-type-workspace.context.ts
+++ b/src/packages/core/data-type/workspace/data-type-workspace.context.ts
@@ -113,8 +113,8 @@ export class UmbDataTypeWorkspaceContext
 		return this.observe(
 			umbExtensionsRegistry.getByTypeAndAlias('propertyEditorUi', propertyEditorUIAlias),
 			(manifest) => {
-				this.#propertyEditorUiIcon.next(manifest?.meta.icon || null);
-				this.#propertyEditorUiName.next(manifest?.name || null);
+				this.#propertyEditorUiIcon.setValue(manifest?.meta.icon || null);
+				this.#propertyEditorUiName.setValue(manifest?.name || null);
 
 				this._propertyEditorUISettingsSchemaAlias = manifest?.meta.propertyEditorSchemaAlias;
 				this._propertyEditorUISettingsProperties = manifest?.meta.settings?.properties || [];
@@ -126,7 +126,7 @@ export class UmbDataTypeWorkspaceContext
 	private _mergeConfigProperties() {
 		if (this._propertyEditorSchemaConfigProperties && this._propertyEditorUISettingsProperties) {
 			// TODO: Consider the ability to to omit a schema config if a UI config has same alias. Otherwise we should make an error when this case happens.
-			this.#properties.next([
+			this.#properties.setValue([
 				...this._propertyEditorSchemaConfigProperties,
 				...this._propertyEditorUISettingsProperties,
 			]);
@@ -140,7 +140,7 @@ export class UmbDataTypeWorkspaceContext
 			...this._propertyEditorSchemaConfigDefaultData,
 			...this._propertyEditorUISettingsDefaultData,
 		];
-		this.#defaults.next(this._configDefaultData);
+		this.#defaults.setValue(this._configDefaultData);
 	}
 
 	public getPropertyDefaultValue(alias: string) {
@@ -210,7 +210,7 @@ export class UmbDataTypeWorkspaceContext
 		this.setIsNew(true);
 		// TODO: This is a hack to get around the fact that the data is not typed correctly.
 		// Create and response models are different. We need to look into this.
-		this.#data.next(data as unknown as UmbDataTypeDetailModel);
+		this.#data.setValue(data as unknown as UmbDataTypeDetailModel);
 		return { data };
 	}
 

--- a/src/packages/core/menu/menu.context.ts
+++ b/src/packages/core/menu/menu.context.ts
@@ -8,7 +8,7 @@ export class UmbMenuContext {
 	public readonly alias = this.#manifest.asObservablePart((x) => x?.alias);
 
 	public setManifest(manifest: ManifestMenu | undefined) {
-		this.#manifest.next(manifest);
+		this.#manifest.setValue(manifest);
 	}
 }
 

--- a/src/packages/core/modal/common/code-editor/code-editor-modal.element.ts
+++ b/src/packages/core/modal/common/code-editor/code-editor-modal.element.ts
@@ -28,7 +28,7 @@ export class UmbCodeEditorModalElement extends UmbModalBaseElement<UmbCodeEditor
 	async #loadCodeEditor() {
 		try {
 			await loadCodeEditor();
-			this.#isCodeEditorReady.next(true);
+			this.#isCodeEditorReady.setValue(true);
 		} catch (error) {
 			console.error(error);
 		}

--- a/src/packages/core/modal/modal-manager.context.ts
+++ b/src/packages/core/modal/modal-manager.context.ts
@@ -42,7 +42,9 @@ export class UmbModalManagerContext extends UmbContextBase<UmbModalManagerContex
 		const modalContext = new UmbModalContext(modalAlias, args);
 
 		// Append to store:
-		this.#modals.next(appendToFrozenArray(this.#modals.value, modalContext, (entry) => entry.key === modalContext.key));
+		this.#modals.setValue(
+			appendToFrozenArray(this.#modals.value, modalContext, (entry) => entry.key === modalContext.key),
+		);
 
 		// Return to implementor:
 		return modalContext;
@@ -62,7 +64,7 @@ export class UmbModalManagerContext extends UmbContextBase<UmbModalManagerContex
 	}
 
 	public remove(key: string) {
-		this.#modals.next(this.#modals.getValue().filter((modal) => modal.key !== key));
+		this.#modals.setValue(this.#modals.getValue().filter((modal) => modal.key !== key));
 	}
 }
 

--- a/src/packages/core/notification/notification.context.ts
+++ b/src/packages/core/notification/notification.context.ts
@@ -47,7 +47,7 @@ export class UmbNotificationContext extends UmbContextBase<UmbNotificationContex
 		const notificationHandler = new UmbNotificationHandler(options);
 		notificationHandler.element.addEventListener('closed', () => this._handleClosed(notificationHandler));
 
-		this._notifications.next([...this._notifications.getValue(), notificationHandler]);
+		this._notifications.setValue([...this._notifications.getValue(), notificationHandler]);
 
 		return notificationHandler;
 	}
@@ -58,7 +58,7 @@ export class UmbNotificationContext extends UmbContextBase<UmbNotificationContex
 	 * @memberof UmbNotificationContext
 	 */
 	private _close(key: string) {
-		this._notifications.next(this._notifications.getValue().filter((notification) => notification.key !== key));
+		this._notifications.setValue(this._notifications.getValue().filter((notification) => notification.key !== key));
 	}
 
 	/**

--- a/src/packages/core/property/property-dataset/property-dataset-base-context.ts
+++ b/src/packages/core/property/property-dataset/property-dataset-base-context.ts
@@ -36,7 +36,7 @@ export class UmbPropertyDatasetBaseContext
 		return this.#name.getValue();
 	}
 	setName(name: string | undefined) {
-		this.#name.next(name);
+		this.#name.setValue(name);
 	}
 	getVariantId() {
 		return UmbVariantId.CreateInvariant();
@@ -69,6 +69,6 @@ export class UmbPropertyDatasetBaseContext
 		return this.#values.getValue();
 	}
 	setValues(map: Array<UmbPropertyValueData>) {
-		this.#values.next(map);
+		this.#values.setValue(map);
 	}
 }

--- a/src/packages/core/property/property/property.context.ts
+++ b/src/packages/core/property/property/property.context.ts
@@ -37,7 +37,7 @@ export class UmbPropertyContext<ValueType = any> extends UmbBaseController {
 	private _editor = new UmbBasicState<UmbPropertyEditorUiElement | undefined>(undefined);
 	public readonly editor = this._editor.asObservable();
 	setEditor(editor: UmbPropertyEditorUiElement | undefined) {
-		this._editor.next(editor ?? undefined);
+		this._editor.setValue(editor ?? undefined);
 	}
 	getEditor() {
 		return this._editor.getValue();
@@ -68,7 +68,7 @@ export class UmbPropertyContext<ValueType = any> extends UmbBaseController {
 		this._providerController = new UmbContextProviderController(host, UMB_PROPERTY_CONTEXT, this);
 
 		this.observe(this.configValues, (configValues) => {
-			this.#configCollection.next(configValues ? new UmbPropertyEditorConfigCollection(configValues) : undefined);
+			this.#configCollection.setValue(configValues ? new UmbPropertyEditorConfigCollection(configValues) : undefined);
 		});
 
 		this.observe(this.variantId, () => {
@@ -86,7 +86,7 @@ export class UmbPropertyContext<ValueType = any> extends UmbBaseController {
 		this._observePropertyVariant?.destroy();
 		if (variantIdSubject) {
 			this._observePropertyVariant = this.observe(variantIdSubject, (variantId) => {
-				this.#variantId.next(variantId);
+				this.#variantId.setValue(variantId);
 			});
 		}
 
@@ -96,7 +96,7 @@ export class UmbPropertyContext<ValueType = any> extends UmbBaseController {
 		this._observePropertyValue?.destroy();
 		if (subject) {
 			this._observePropertyValue = this.observe(subject, (value) => {
-				this.#value.next(value);
+				this.#value.setValue(value);
 			});
 		}
 	}
@@ -104,19 +104,19 @@ export class UmbPropertyContext<ValueType = any> extends UmbBaseController {
 	private _generateVariantDifferenceString() {
 		if (!this.#datasetContext) return;
 		const contextVariantId = this.#datasetContext.getVariantId?.() ?? undefined;
-		this._variantDifference.next(
+		this._variantDifference.setValue(
 			contextVariantId ? this.#variantId.getValue()?.toDifferencesString(contextVariantId) : '',
 		);
 	}
 
 	public setAlias(alias: string | undefined) {
-		this.#alias.next(alias);
+		this.#alias.setValue(alias);
 	}
 	public setLabel(label: string | undefined) {
-		this.#label.next(label);
+		this.#label.setValue(label);
 	}
 	public setDescription(description: string | undefined) {
-		this.#description.next(description);
+		this.#description.setValue(description);
 	}
 	/**
 	 * Set the value of this property.
@@ -136,10 +136,10 @@ export class UmbPropertyContext<ValueType = any> extends UmbBaseController {
 		return this.#value.getValue();
 	}
 	public setConfig(config: Array<UmbPropertyEditorConfigProperty> | undefined) {
-		this.#configValues.next(config ?? []);
+		this.#configValues.setValue(config ?? []);
 	}
 	public setVariantId(variantId: UmbVariantId | undefined) {
-		this.#variantId.next(variantId);
+		this.#variantId.setValue(variantId);
 	}
 	public getVariantId() {
 		return this.#variantId.getValue();

--- a/src/packages/core/repository/repository-items.manager.ts
+++ b/src/packages/core/repository/repository-items.manager.ts
@@ -51,11 +51,11 @@ export class UmbRepositoryItemsManager<ItemType> extends UmbBaseController {
 	}
 
 	setUniques(uniques: string[]) {
-		this.#uniques.next(uniques);
+		this.#uniques.setValue(uniques);
 		//TODO: Check if it's safe to call requestItems here.
 		// We don't have to request items if there is no uniques.
 		if (uniques.length === 0) {
-			this.#items.next([]);
+			this.#items.setValue([]);
 			return;
 		}
 
@@ -76,7 +76,7 @@ export class UmbRepositoryItemsManager<ItemType> extends UmbBaseController {
 		const { asObservable } = await this.repository.requestItems(this.getUniques());
 
 		if (asObservable) {
-			this.observe(asObservable(), (data) => this.#items.next(data), '_observeRequestedItems');
+			this.observe(asObservable(), (data) => this.#items.setValue(data), '_observeRequestedItems');
 		}
 	}
 

--- a/src/packages/core/section/section-sidebar/section-sidebar.context.ts
+++ b/src/packages/core/section/section-sidebar/section-sidebar.context.ts
@@ -27,17 +27,17 @@ export class UmbSectionSidebarContext {
 	// TODO: we wont get notified about tree item name changes because we don't have a subscription
 	// we need to figure out how we best can handle this when we only know the entity and unique id
 	openContextMenu(entityType: string, unique: string | null | undefined, headline: string | undefined) {
-		this.#entityType.next(entityType);
-		this.#unique.next(unique);
-		this.#headline.next(headline);
-		this.#contextMenuIsOpen.next(true);
+		this.#entityType.setValue(entityType);
+		this.#unique.setValue(unique);
+		this.#headline.setValue(headline);
+		this.#contextMenuIsOpen.setValue(true);
 	}
 
 	closeContextMenu() {
-		this.#contextMenuIsOpen.next(false);
-		this.#entityType.next(undefined);
-		this.#unique.next(undefined);
-		this.#headline.next(undefined);
+		this.#contextMenuIsOpen.setValue(false);
+		this.#entityType.setValue(undefined);
+		this.#unique.setValue(undefined);
+		this.#headline.setValue(undefined);
 	}
 }
 

--- a/src/packages/core/section/section.context.ts
+++ b/src/packages/core/section/section.context.ts
@@ -15,9 +15,9 @@ export class UmbSectionContext {
 	}
 
 	public setManifest(manifest?: ManifestSection) {
-		this.#manifestAlias.next(manifest?.alias);
-		this.#manifestPathname.next(manifest?.meta?.pathname);
-		this.#manifestLabel.next(manifest ? manifest.meta?.label || manifest.name : undefined);
+		this.#manifestAlias.setValue(manifest?.alias);
+		this.#manifestPathname.setValue(manifest?.meta?.pathname);
+		this.#manifestLabel.setValue(manifest ? manifest.meta?.label || manifest.name : undefined);
 	}
 }
 

--- a/src/packages/core/temporary-file/temporary-file-manager.class.ts
+++ b/src/packages/core/temporary-file/temporary-file-manager.class.ts
@@ -48,7 +48,7 @@ export class UmbTemporaryFileManager extends UmbBaseController {
 
 		if (!queue.length && this.getIsReady()) return;
 
-		this.#isReady.next(false);
+		this.#isReady.setValue(false);
 
 		queue.forEach(async (item) => {
 			if (item.status !== 'waiting') return;
@@ -64,7 +64,7 @@ export class UmbTemporaryFileManager extends UmbBaseController {
 		});
 
 		if (!queue.find((item) => item.status === 'waiting') && !this.getIsReady()) {
-			this.#isReady.next(true);
+			this.#isReady.setValue(true);
 		}
 	}
 

--- a/src/packages/core/themes/theme.context.ts
+++ b/src/packages/core/themes/theme.context.ts
@@ -28,7 +28,7 @@ export class UmbThemeContext extends UmbBaseController {
 	}
 
 	public setThemeByAlias(themeAlias: string) {
-		this.#theme.next(themeAlias);
+		this.#theme.setValue(themeAlias);
 
 		this.#themeObserver?.destroy();
 		if (themeAlias) {

--- a/src/packages/core/tree/tree-item-base/tree-item-base.context.ts
+++ b/src/packages/core/tree/tree-item-base/tree-item-base.context.ts
@@ -63,7 +63,7 @@ export class UmbTreeItemContextBase<TreeItemType extends UmbTreeItemModelBase>
 
 	public setTreeItem(treeItem: TreeItemType | undefined) {
 		if (!treeItem) {
-			this.#treeItem.next(undefined);
+			this.#treeItem.setValue(undefined);
 			return;
 		}
 
@@ -75,8 +75,8 @@ export class UmbTreeItemContextBase<TreeItemType extends UmbTreeItemModelBase>
 		if (!treeItem.entityType) throw new Error('Could not create tree item context, tree item type is missing');
 		this.entityType = treeItem.entityType;
 
-		this.#hasChildren.next(treeItem.hasChildren || false);
-		this.#treeItem.next(treeItem);
+		this.#hasChildren.setValue(treeItem.hasChildren || false);
+		this.#treeItem.setValue(treeItem);
 
 		// Update observers:
 		this.#observeActions();
@@ -89,9 +89,9 @@ export class UmbTreeItemContextBase<TreeItemType extends UmbTreeItemModelBase>
 		if (this.unique === undefined) throw new Error('Could not request children, unique key is missing');
 
 		// TODO: wait for tree context to be ready
-		this.#isLoading.next(true);
+		this.#isLoading.setValue(true);
 		const response = await this.treeContext!.requestChildrenOf(this.unique);
-		this.#isLoading.next(false);
+		this.#isLoading.setValue(false);
 		return response;
 	}
 
@@ -140,12 +140,12 @@ export class UmbTreeItemContextBase<TreeItemType extends UmbTreeItemModelBase>
 		this.observe(
 			this.treeContext.selection.selectable,
 			(value) => {
-				this.#isSelectableContext.next(value);
+				this.#isSelectableContext.setValue(value);
 
 				// If the tree is selectable, check if this item is selectable
 				if (value === true) {
 					const isSelectable = this.treeContext?.selectableFilter?.(this.getTreeItem()!) ?? true;
-					this.#isSelectable.next(isSelectable);
+					this.#isSelectable.setValue(isSelectable);
 				}
 			},
 			'observeIsSelectable',
@@ -158,7 +158,7 @@ export class UmbTreeItemContextBase<TreeItemType extends UmbTreeItemModelBase>
 		this.observe(
 			this.treeContext.selection.selection.pipe(map((selection) => selection.includes(this.unique!))),
 			(isSelected) => {
-				this.#isSelected.next(isSelected);
+				this.#isSelected.setValue(isSelected);
 			},
 			'observeIsSelected',
 		);
@@ -172,7 +172,7 @@ export class UmbTreeItemContextBase<TreeItemType extends UmbTreeItemModelBase>
 			(pathname) => {
 				if (!pathname || !this.entityType || this.unique === undefined) return;
 				const path = this.constructPath(pathname, this.entityType, this.unique);
-				this.#path.next(path);
+				this.#path.setValue(path);
 			},
 			'observeSectionPath',
 		);
@@ -184,7 +184,7 @@ export class UmbTreeItemContextBase<TreeItemType extends UmbTreeItemModelBase>
 				.extensionsOfType('entityAction')
 				.pipe(map((actions) => actions.filter((action) => action.meta.entityTypes.includes(this.entityType!)))),
 			(actions) => {
-				this.#hasActions.next(actions.length > 0);
+				this.#hasActions.setValue(actions.length > 0);
 			},
 			'observeActions',
 		);
@@ -200,7 +200,7 @@ export class UmbTreeItemContextBase<TreeItemType extends UmbTreeItemModelBase>
 			// we need to skip the first value, because it will also return false until a child is in the store
 			// we therefor rely on the value from the tree item itself
 			if (this.#hasChildrenInitValueFlag === true) {
-				this.#hasChildren.next(hasChildren);
+				this.#hasChildren.setValue(hasChildren);
 			}
 			this.#hasChildrenInitValueFlag = true;
 		});

--- a/src/packages/core/workspace/workspace-context/editable-workspace-context-base.ts
+++ b/src/packages/core/workspace/workspace-context/editable-workspace-context-base.ts
@@ -31,7 +31,7 @@ export abstract class UmbEditableWorkspaceContextBase<WorkspaceData>
 	}
 
 	setIsNew(isNew: boolean) {
-		this.#isNew.next(isNew);
+		this.#isNew.setValue(isNew);
 	}
 
 	protected saveComplete(data: WorkspaceData) {

--- a/src/packages/core/workspace/workspace-context/entity-manager-controller.ts
+++ b/src/packages/core/workspace/workspace-context/entity-manager-controller.ts
@@ -53,7 +53,7 @@ export class UmbEntityWorkspaceManager<
 
 		if (this.#isNew) {
 			const newData = this._store.getScaffold(this._entityType, this._createAtParentKey || null);
-			this.state.next(newData);
+			this.state.setValue(newData);
 		} else {
 			this._storeSubscription?.destroy();
 			this._storeSubscription = new UmbObserverController(
@@ -61,7 +61,7 @@ export class UmbEntityWorkspaceManager<
 				this._store.getByKey(this._entityId),
 				(content) => {
 					if (!content) return; // TODO: Handle nicely if there is no content data.
-					this.state.next(content as any);
+					this.state.setValue(content as any);
 				},
 			);
 		}

--- a/src/packages/core/workspace/workspace-split-view/workspace-split-view.context.ts
+++ b/src/packages/core/workspace/workspace-split-view/workspace-split-view.context.ts
@@ -77,7 +77,7 @@ export class UmbWorkspaceSplitViewContext extends UmbBaseController {
 		return this.#index.getValue();
 	}
 	public setSplitViewIndex(index: number) {
-		this.#index.next(index);
+		this.#index.setValue(index);
 	}
 
 	/**

--- a/src/packages/dictionary/dictionary/workspace/dictionary-workspace.context.ts
+++ b/src/packages/dictionary/dictionary/workspace/dictionary-workspace.context.ts
@@ -59,14 +59,14 @@ export class UmbDictionaryWorkspaceContext
 			updatedValue?.push({ isoCode, translation });
 		}
 
-		this.#data.next({ ...this.#data.value, translations: updatedValue });
+		this.#data.setValue({ ...this.#data.value, translations: updatedValue });
 	}
 
 	async load(entityId: string) {
 		const { data } = await this.repository.requestById(entityId);
 		if (data) {
 			this.setIsNew(false);
-			this.#data.next(data);
+			this.#data.setValue(data);
 		}
 	}
 
@@ -75,7 +75,7 @@ export class UmbDictionaryWorkspaceContext
 		if (!data) return;
 		this.setIsNew(true);
 
-		this.#data.next(data as DictionaryItemResponseModel);
+		this.#data.setValue(data as DictionaryItemResponseModel);
 	}
 
 	async save() {

--- a/src/packages/documents/document-types/workspace/document-type-workspace.context.ts
+++ b/src/packages/documents/document-types/workspace/document-type-workspace.context.ts
@@ -72,7 +72,7 @@ export class UmbDocumentTypeWorkspaceContext
 	}
 
 	setIsSorting(isSorting: boolean) {
-		this.#isSorting.next(isSorting);
+		this.#isSorting.setValue(isSorting);
 	}
 
 	getData() {

--- a/src/packages/documents/documents/property-dataset-context/document-property-dataset-context.ts
+++ b/src/packages/documents/documents/property-dataset-context/document-property-dataset-context.ts
@@ -60,7 +60,7 @@ export class UmbDocumentPropertyDataContext
 			this.#workspace.variantById(this.#variantId),
 			async (variantInfo) => {
 				if (!variantInfo) return;
-				this.#currentVariant.next(variantInfo);
+				this.#currentVariant.setValue(variantInfo);
 			},
 			'_observeActiveVariant',
 		);

--- a/src/packages/documents/documents/workspace/document-workspace.context.ts
+++ b/src/packages/documents/documents/workspace/document-workspace.context.ts
@@ -63,7 +63,7 @@ export class UmbDocumentWorkspaceContext
 
 		this.setIsNew(false);
 		//this.#persisted.next(data);
-		this.#currentData.next(data);
+		this.#currentData.setValue(data);
 		return data || undefined;
 	}
 
@@ -73,7 +73,7 @@ export class UmbDocumentWorkspaceContext
 		if (!data) return undefined;
 
 		this.setIsNew(true);
-		this.#currentData.next(data);
+		this.#currentData.setValue(data);
 		return data || undefined;
 	}
 

--- a/src/packages/log-viewer/workspace/logviewer.context.ts
+++ b/src/packages/log-viewer/workspace/logviewer.context.ts
@@ -158,7 +158,7 @@ export class UmbLogViewerWorkspaceContext extends UmbBaseController implements U
 			return;
 		}
 
-		this.#dateRange.next({ startDate, endDate });
+		this.#dateRange.setValue({ startDate, endDate });
 		this.validateLogSize();
 		this.getLogCount();
 		this.getMessageTemplates(0, 10);
@@ -171,10 +171,10 @@ export class UmbLogViewerWorkspaceContext extends UmbBaseController implements U
 	async getSavedSearches() {
 		const { data } = await this.#repository.getSavedSearches({ skip: 0, take: 100 });
 		if (data) {
-			this.#savedSearches.next(data);
+			this.#savedSearches.setValue(data);
 		} else {
 			//falback to some default searches resembling Umbraco <= 12
-			this.#savedSearches.next({
+			this.#savedSearches.setValue({
 				items: [
 					{
 						name: 'Find all logs where the Level is NOT Verbose and NOT Debug',
@@ -230,7 +230,7 @@ export class UmbLogViewerWorkspaceContext extends UmbBaseController implements U
 		const { data } = await this.#repository.getLogCount({ ...this.#dateRange.getValue() });
 
 		if (data) {
-			this.#logCount.next(data);
+			this.#logCount.setValue(data);
 		}
 	}
 
@@ -238,7 +238,7 @@ export class UmbLogViewerWorkspaceContext extends UmbBaseController implements U
 		const { data } = await this.#repository.getMessageTemplates({ skip, take, ...this.#dateRange.getValue() });
 
 		if (data) {
-			this.#messageTemplates.next(data);
+			this.#messageTemplates.setValue(data);
 		}
 	}
 
@@ -246,17 +246,17 @@ export class UmbLogViewerWorkspaceContext extends UmbBaseController implements U
 		const { data } = await this.#repository.getLogLevels({ skip, take });
 
 		if (data) {
-			this.#loggers.next(data);
+			this.#loggers.setValue(data);
 		}
 	}
 
 	async validateLogSize() {
 		const { error } = await this.#repository.getLogViewerValidateLogsSize({ ...this.#dateRange.getValue() });
 		if (error) {
-			this.#canShowLogs.next(false);
+			this.#canShowLogs.setValue(false);
 			return;
 		}
-		this.#canShowLogs.next(true);
+		this.#canShowLogs.setValue(true);
 	}
 
 	setCurrentPage(page: number) {
@@ -270,7 +270,7 @@ export class UmbLogViewerWorkspaceContext extends UmbBaseController implements U
 
 		const isPollingEnabled = this.#polling.getValue().enabled;
 
-		if (!isPollingEnabled) this.#isLoadingLogs.next(true);
+		if (!isPollingEnabled) this.#isLoadingLogs.setValue(true);
 
 		const skip = (this.currentPage - 1) * 100;
 		const take = 100;
@@ -285,18 +285,18 @@ export class UmbLogViewerWorkspaceContext extends UmbBaseController implements U
 		};
 
 		const { data } = await this.#repository.getLogs(options);
-		this.#isLoadingLogs.next(false);
+		this.#isLoadingLogs.setValue(false);
 		if (data) {
-			this.#logs.next(data);
+			this.#logs.setValue(data);
 		}
 	};
 
 	setFilterExpression(query: string) {
-		this.#filterExpression.next(query);
+		this.#filterExpression.setValue(query);
 	}
 
 	setLogLevelsFilter(logLevels: LogLevelModel[]) {
-		this.#logLevelsFilter.next(logLevels);
+		this.#logLevelsFilter.setValue(logLevels);
 	}
 
 	togglePolling() {
@@ -323,7 +323,7 @@ export class UmbLogViewerWorkspaceContext extends UmbBaseController implements U
 	toggleSortOrder() {
 		const direction = this.#sortingDirection.getValue();
 		const newDirection = direction === DirectionModel.ASCENDING ? DirectionModel.DESCENDING : DirectionModel.ASCENDING;
-		this.#sortingDirection.next(newDirection);
+		this.#sortingDirection.setValue(newDirection);
 	}
 }
 

--- a/src/packages/media/media-types/workspace/media-type-workspace.context.ts
+++ b/src/packages/media/media-types/workspace/media-type-workspace.context.ts
@@ -58,7 +58,7 @@ export class UmbMediaTypeWorkspaceContext
 	}
 
 	setIsSorting(isSorting: boolean) {
-		this.#isSorting.next(isSorting);
+		this.#isSorting.setValue(isSorting);
 	}
 
 	getData() {

--- a/src/packages/media/media/workspace/media-workspace.context.ts
+++ b/src/packages/media/media/workspace/media-workspace.context.ts
@@ -57,7 +57,7 @@ export class UmbMediaWorkspaceContext
 		const { data } = await this.repository.requestById(entityId);
 		if (data) {
 			this.setIsNew(false);
-			this.#data.next(data);
+			this.#data.setValue(data);
 		}
 	}
 
@@ -67,7 +67,7 @@ export class UmbMediaWorkspaceContext
 		this.setIsNew(true);
 		// TODO: This is a hack to get around the fact that the data is not typed correctly.
 		// Create and response models are different. We need to look into this.
-		this.#data.next(data as unknown as UmbMediaDetailModel);
+		this.#data.setValue(data as unknown as UmbMediaDetailModel);
 	}
 
 	async save() {

--- a/src/packages/members/member-types/workspace/member-type-workspace.context.ts
+++ b/src/packages/members/member-types/workspace/member-type-workspace.context.ts
@@ -28,7 +28,7 @@ export class UmbMemberTypeWorkspaceContext
 		const { data } = await this.repository.requestById(entityId);
 		if (data) {
 			this.setIsNew(false);
-			this.#data.next(data);
+			this.#data.setValue(data);
 		}
 	}
 
@@ -36,7 +36,7 @@ export class UmbMemberTypeWorkspaceContext
 		const { data } = await this.repository.createScaffold();
 		if (!data) return;
 		this.setIsNew(true);
-		this.#data.next(data);
+		this.#data.setValue(data);
 	}
 
 	getData() {

--- a/src/packages/relations/relation-types/workspace/relation-type-workspace.context.ts
+++ b/src/packages/relations/relation-types/workspace/relation-type-workspace.context.ts
@@ -37,7 +37,7 @@ export class UmbRelationTypeWorkspaceContext
 		const { data } = await this.repository.createScaffold(parentId);
 		if (!data) return;
 		this.setIsNew(true);
-		this.#data.next(data);
+		this.#data.setValue(data);
 	}
 
 	async getRelations() {

--- a/src/packages/settings/languages/workspace/language/language-workspace.context.ts
+++ b/src/packages/settings/languages/workspace/language/language-workspace.context.ts
@@ -78,7 +78,7 @@ export class UmbLanguageWorkspaceContext
 	// TODO: this is a temp solution to bubble validation errors to the UI
 	setValidationErrors(errorMap: any) {
 		// TODO: I can't use the update method to set the value to undefined
-		this.#validationErrors.next(errorMap);
+		this.#validationErrors.setValue(errorMap);
 	}
 
 	async save() {

--- a/src/packages/templating/partial-views/workspace/partial-view-workspace.context.ts
+++ b/src/packages/templating/partial-views/workspace/partial-view-workspace.context.ts
@@ -66,7 +66,7 @@ export class UmbPartialViewWorkspaceContext
 	async #loadCodeEditor() {
 		try {
 			await loadCodeEditor();
-			this.#isCodeEditorReady.next(true);
+			this.#isCodeEditorReady.setValue(true);
 		} catch (error) {
 			console.error(error);
 		}
@@ -88,7 +88,7 @@ export class UmbPartialViewWorkspaceContext
 		const { data } = await this.repository.requestByKey(entityKey);
 		if (data) {
 			this.setIsNew(false);
-			this.#data.next(data);
+			this.#data.setValue(data);
 		}
 	}
 
@@ -103,7 +103,7 @@ export class UmbPartialViewWorkspaceContext
 		this.setIsNew(true);
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
-		this.#data.next(newPartial);
+		this.#data.setValue(newPartial);
 	}
 }
 

--- a/src/packages/templating/scripts/workspace/script-workspace.context.ts
+++ b/src/packages/templating/scripts/workspace/script-workspace.context.ts
@@ -28,7 +28,7 @@ export class UmbScriptWorkspaceContext extends UmbEditableWorkspaceContextBase<U
 	async #loadCodeEditor() {
 		try {
 			await loadCodeEditor();
-			this.#isCodeEditorReady.next(true);
+			this.#isCodeEditorReady.setValue(true);
 		} catch (error) {
 			console.error(error);
 		}
@@ -50,7 +50,7 @@ export class UmbScriptWorkspaceContext extends UmbEditableWorkspaceContextBase<U
 		const { data } = await this.repository.requestByKey(entityKey);
 		if (data) {
 			this.setIsNew(false);
-			this.#data.next(data);
+			this.#data.setValue(data);
 		}
 	}
 
@@ -60,7 +60,7 @@ export class UmbScriptWorkspaceContext extends UmbEditableWorkspaceContextBase<U
 			path: parentKey,
 			content: '',
 		};
-		this.#data.next(newScript);
+		this.#data.setValue(newScript);
 		this.setIsNew(true);
 	}
 

--- a/src/packages/templating/stylesheets/workspace/stylesheet-workspace.context.ts
+++ b/src/packages/templating/stylesheets/workspace/stylesheet-workspace.context.ts
@@ -39,7 +39,7 @@ export class UmbStylesheetWorkspaceContext
 	async #loadCodeEditor() {
 		try {
 			await loadCodeEditor();
-			this.#isCodeEditorReady.next(true);
+			this.#isCodeEditorReady.setValue(true);
 		} catch (error) {
 			console.error(error);
 		}
@@ -72,7 +72,7 @@ export class UmbStylesheetWorkspaceContext
 
 	setRules(rules: RichTextRuleModelSortable[]) {
 		const newRules = rules.map((r, i) => ({ ...r, sortOrder: i }));
-		this.#rules.next(newRules);
+		this.#rules.setValue(newRules);
 		this.sendRulesGetContent();
 	}
 
@@ -99,9 +99,9 @@ export class UmbStylesheetWorkspaceContext
 
 		if (rules.data) {
 			const x = rules.data.rules?.map((r, i) => ({ ...r, sortOrder: i })) ?? [];
-			this.#rules.next(x);
+			this.#rules.setValue(x);
 		} else {
-			this.#rules.next([]);
+			this.#rules.setValue([]);
 		}
 	}
 
@@ -175,7 +175,7 @@ export class UmbStylesheetWorkspaceContext
 			content: '',
 		};
 
-		this.#data.next(newStylesheet);
+		this.#data.setValue(newStylesheet);
 		this.setIsNew(true);
 	}
 

--- a/src/packages/templating/templates/workspace/template-workspace.context.ts
+++ b/src/packages/templating/templates/workspace/template-workspace.context.ts
@@ -41,7 +41,7 @@ export class UmbTemplateWorkspaceContext
 	async #loadCodeEditor() {
 		try {
 			await loadCodeEditor();
-			this.#isCodeEditorReady.next(true);
+			this.#isCodeEditorReady.setValue(true);
 		} catch (error) {
 			console.error(error);
 		}
@@ -84,20 +84,20 @@ export class UmbTemplateWorkspaceContext
 		if (data) {
 			this.setIsNew(false);
 			this.setMasterTemplate(data.masterTemplateId ?? null);
-			this.#data.next(data);
+			this.#data.setValue(data);
 		}
 	}
 
 	async setMasterTemplate(id: string | null) {
 		if (id === null) {
-			this.#masterTemplate.next(null);
+			this.#masterTemplate.setValue(null);
 			this.#updateMasterTemplateLayoutBlock();
 			return null;
 		}
 
 		const { data } = await this.repository.requestItems([id]);
 		if (data) {
-			this.#masterTemplate.next(data[0]);
+			this.#masterTemplate.setValue(data[0]);
 			this.#updateMasterTemplateLayoutBlock();
 			return data[0];
 		}
@@ -166,7 +166,7 @@ ${currentContent}`;
 		const { data } = await this.repository.createScaffold(parentId);
 		if (!data) return;
 		this.setIsNew(true);
-		this.#data.next({ ...data, id: '', name: '', alias: '' });
+		this.#data.setValue({ ...data, id: '', name: '', alias: '' });
 		if (!parentId) return;
 		await this.setMasterTemplate(parentId);
 	}

--- a/src/packages/user/current-user/current-user-history.store.ts
+++ b/src/packages/user/current-user/current-user-history.store.ts
@@ -47,7 +47,7 @@ export class UmbCurrentUserHistoryStore extends UmbStoreBase<UmbCurrentUserHisto
 
 		// This prevents duplicate entries in the history array.
 		if (!lastItem || lastItem.path !== historyItem.path) {
-			this._data.next([...this._data.getValue(), historyItem]);
+			this._data.setValue([...this._data.getValue(), historyItem]);
 		}
 	}
 
@@ -57,7 +57,7 @@ export class UmbCurrentUserHistoryStore extends UmbStoreBase<UmbCurrentUserHisto
 	 * @memberof UmbHistoryService
 	 */
 	public clear() {
-		this._data.next([]);
+		this._data.setValue([]);
 	}
 }
 

--- a/src/packages/user/current-user/current-user.context.ts
+++ b/src/packages/user/current-user/current-user.context.ts
@@ -45,7 +45,7 @@ export class UmbCurrentUserContext extends UmbBaseController {
 		// TODO: use repository
 		const { data, error } = await tryExecuteAndNotify(this._host, UserResource.getUserCurrent());
 		// TODO: add current user store
-		this.#currentUser.next(data);
+		this.#currentUser.setValue(data);
 		return { data, error };
 	}
 

--- a/src/packages/user/user-group/workspace/user-group-workspace.context.ts
+++ b/src/packages/user/user-group/workspace/user-group-workspace.context.ts
@@ -34,7 +34,7 @@ export class UmbUserGroupWorkspaceContext
 		const { data } = await this.repository.createScaffold(null);
 		this.setIsNew(true);
 		// TODO: Should the data be the base model or the presentation model?
-		this.#data.next(data as unknown as UserGroupResponseModel);
+		this.#data.setValue(data as unknown as UserGroupResponseModel);
 		return { data };
 	}
 
@@ -111,7 +111,7 @@ export class UmbUserGroupWorkspaceContext
 	}
 
 	updateUserKeys(keys: Array<string>) {
-		this.#userIds.next(keys);
+		this.#userIds.setValue(keys);
 	}
 
 	/**

--- a/src/shared/auth/auth.context.ts
+++ b/src/shared/auth/auth.context.ts
@@ -36,11 +36,11 @@ export class UmbAuthContext extends UmbBaseController implements IUmbAuthContext
 	 */
 	getIsAuthorized() {
 		if (this.#isBypassed) {
-			this.#isAuthorized.next(true);
+			this.#isAuthorized.setValue(true);
 			return true;
 		} else {
 			const isAuthorized = this.#authFlow.isAuthorized();
-			this.#isAuthorized.next(isAuthorized);
+			this.#isAuthorized.setValue(isAuthorized);
 			return isAuthorized;
 		}
 	}

--- a/src/shared/utils/pagination-manager/pagination.manager.ts
+++ b/src/shared/utils/pagination-manager/pagination.manager.ts
@@ -23,7 +23,7 @@ export class UmbPaginationManager extends EventTarget {
 	 * @memberof UmbPaginationManager
 	 */
 	public setPageSize(pageSize: number) {
-		this.#pageSize.next(pageSize);
+		this.#pageSize.setValue(pageSize);
 		this.#calculateTotalPages();
 	}
 
@@ -51,7 +51,7 @@ export class UmbPaginationManager extends EventTarget {
 	 * @memberof UmbPaginationManager
 	 */
 	public setTotalItems(totalItems: number) {
-		this.#totalItems.next(totalItems);
+		this.#totalItems.setValue(totalItems);
 		this.#calculateTotalPages();
 	}
 
@@ -87,7 +87,7 @@ export class UmbPaginationManager extends EventTarget {
 			pageNumber = this.#totalPages.getValue();
 		}
 
-		this.#currentPage.next(pageNumber);
+		this.#currentPage.setValue(pageNumber);
 		this.#calculateSkip();
 		this.dispatchEvent(new UmbChangeEvent());
 	}
@@ -107,7 +107,7 @@ export class UmbPaginationManager extends EventTarget {
 	 */
 	#calculateTotalPages() {
 		const totalPages = Math.ceil(this.#totalItems.getValue() / this.#pageSize.getValue());
-		this.#totalPages.next(totalPages);
+		this.#totalPages.setValue(totalPages);
 
 		/* If we currently are on a page higher than the total pages. We need to reset the current page to the last page.
     This can happen if we have a filter that returns less items than the current page size. */
@@ -118,6 +118,6 @@ export class UmbPaginationManager extends EventTarget {
 
 	#calculateSkip() {
 		const skip = (this.#currentPage.getValue() - 1) * this.#pageSize.getValue();
-		this.#skip.next(skip);
+		this.#skip.setValue(skip);
 	}
 }

--- a/src/shared/utils/selection-manager/selection.manager.ts
+++ b/src/shared/utils/selection-manager/selection.manager.ts
@@ -37,7 +37,7 @@ export class UmbSelectionManager extends UmbBaseController {
 	 * @memberof UmbSelectionManager
 	 */
 	public setSelectable(value: boolean) {
-		this.#selectable.next(value);
+		this.#selectable.setValue(value);
 	}
 
 	/**
@@ -58,7 +58,7 @@ export class UmbSelectionManager extends UmbBaseController {
 		if (this.getSelectable() === false) return;
 		if (value === undefined) throw new Error('Value cannot be undefined');
 		const newSelection = this.getMultiple() ? value : value.slice(0, 1);
-		this.#selection.next(newSelection);
+		this.#selection.setValue(newSelection);
 	}
 
 	/**
@@ -76,7 +76,7 @@ export class UmbSelectionManager extends UmbBaseController {
 	 * @memberof UmbSelectionManager
 	 */
 	public setMultiple(value: boolean) {
-		this.#multiple.next(value);
+		this.#multiple.setValue(value);
 
 		/* If multiple is set to false, and the current selection is more than one,
 		then we need to set the selection to the first item. */
@@ -104,7 +104,7 @@ export class UmbSelectionManager extends UmbBaseController {
 		if (this.getSelectable() === false) return;
 		if (this.isSelected(unique)) return;
 		const newSelection = this.getMultiple() ? [...this.getSelection(), unique] : [unique];
-		this.#selection.next(newSelection);
+		this.#selection.setValue(newSelection);
 		this.getHostElement().dispatchEvent(new UmbSelectionChangeEvent());
 	}
 
@@ -116,7 +116,7 @@ export class UmbSelectionManager extends UmbBaseController {
 	public deselect(unique: string | null) {
 		if (this.getSelectable() === false) return;
 		const newSelection = this.getSelection().filter((x) => x !== unique);
-		this.#selection.next(newSelection);
+		this.#selection.setValue(newSelection);
 		this.getHostElement().dispatchEvent(new UmbSelectionChangeEvent());
 	}
 
@@ -136,6 +136,6 @@ export class UmbSelectionManager extends UmbBaseController {
 	 */
 	public clearSelection() {
 		if (this.getSelectable() === false) return;
-		this.#selection.next([]);
+		this.#selection.setValue([]);
 	}
 }


### PR DESCRIPTION
This also creates a legacy next method which is marked for deprecation.

Documentation did not contain this before. But I improved on the matter so there is a PR for that here: https://github.com/umbraco/UmbracoDocs/pull/5784

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
