### PR TITLE
Lower z-index to not hide actions menu

### DIFF
--- a/src/packages/core/components/input-tiny-mce/input-tiny-mce.element.ts
+++ b/src/packages/core/components/input-tiny-mce/input-tiny-mce.element.ts
@@ -335,6 +335,11 @@ export class UmbInputTinyMceElement extends FormControlMixin(UmbLitElement) {
 			.tox .tox-collection__item-label {
 				line-height: 1 !important;
 			}
+
+			// Solves issue 1019 by lowering un-needed z-index on header.
+			.tox.tox-tinymce .tox-editor-header {
+				z-index:0;
+			}
 		`,
 	];
 }

--- a/src/packages/core/components/input-tiny-mce/input-tiny-mce.element.ts
+++ b/src/packages/core/components/input-tiny-mce/input-tiny-mce.element.ts
@@ -336,7 +336,7 @@ export class UmbInputTinyMceElement extends FormControlMixin(UmbLitElement) {
 				line-height: 1 !important;
 			}
 
-			// Solves issue 1019 by lowering un-needed z-index on header.
+			/* Solves issue 1019 by lowering un-needed z-index on header.*/
 			.tox.tox-tinymce .tox-editor-header {
 				z-index:0;
 			}


### PR DESCRIPTION
Fixes this issue: https://github.com/umbraco/Umbraco.CMS.Backoffice/issues/1019

## Description

Changed the `z-index` on the `.tox-editor-header` for TinyMCE - I've tested this quite a bit and could not find anything that was broken by this - might be missing something but hopefully not.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Screenshots
1. Before
2. After
![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/1782524/f3a733f5-bf6f-4c48-a1d0-0168a44f1c31)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
