### PR TITLE
#844 fixes headline and button label for content type edit property

### DIFF
--- a/src/assets/lang/en-us.ts
+++ b/src/assets/lang/en-us.ts
@@ -1522,6 +1522,7 @@ export default {
 		addGroup: 'Add group',
 		inheritedFrom: 'Inherited from',
 		addProperty: 'Add property',
+		editProperty : 'Edit property',
 		requiredLabel: 'Required label',
 		enableListViewHeading: 'Enable list view',
 		enableListViewDescription:

--- a/src/packages/core/modal/common/property-settings/property-settings-modal.element.ts
+++ b/src/packages/core/modal/common/property-settings/property-settings-modal.element.ts
@@ -50,6 +50,9 @@ export class UmbPropertySettingsModalElement extends UmbModalBaseElement<
 
 	protected _originalPropertyData!: UmbPropertySettingsModalValue;
 
+	/** Indicates if the currently edited property is a new property or an existing */
+	#isNew = false;
+
 	#context = new UmbPropertyTypeWorkspaceContext(this);
 
 	@state()
@@ -69,6 +72,7 @@ export class UmbPropertySettingsModalElement extends UmbModalBaseElement<
 		}).skipOrigin();
 
 		this._originalPropertyData = this.value;
+		this.#isNew = this.value.alias === '';
 
 		const regEx = this.value.validation?.regEx ?? null;
 		if (regEx) {
@@ -222,7 +226,7 @@ export class UmbPropertySettingsModalElement extends UmbModalBaseElement<
 		return html`
 			<uui-form>
 				<form @submit="${this.#onSubmit}">
-					<umb-workspace-editor alias=${UMB_PROPERTY_TYPE_WORKSPACE_ALIAS} headline="Property settings">
+					<umb-workspace-editor alias=${UMB_PROPERTY_TYPE_WORKSPACE_ALIAS} headline=${this.localize.term(this.#isNew ? 'contentTypeEditor_addProperty' : 'contentTypeEditor_editProperty')}>
 						<div id="content">
 							<uui-box>
 								<div class="container">
@@ -273,7 +277,7 @@ export class UmbPropertySettingsModalElement extends UmbModalBaseElement<
 							</uui-box>
 						</div>
 						<div slot="actions">
-							<uui-button label="Submit" look="primary" color="positive" type="submit"></uui-button>
+							<uui-button label="${this.localize.term(this.#isNew ? 'general_add' : 'general_update')}" look="primary" color="positive" type="submit"></uui-button>
 						</div>
 					</umb-workspace-editor>
 				</form>


### PR DESCRIPTION
Partial PR for this issues: https://github.com/umbraco/Umbraco.CMS.Backoffice/issues/844

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Screenshots
After this change the headline and buttons is "contextual" based on if we're adding or updating:

![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/1782524/1d179dfb-49be-4827-848d-61aea6020979)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
