### PR TITLE
Bugfix: Prevent extension double registration

### DIFF
--- a/src/libs/extension-api/registry/extension.registry.ts
+++ b/src/libs/extension-api/registry/extension.registry.ts
@@ -121,8 +121,8 @@ export class UmbExtensionRegistry<
 	}
 
 	registerMany(manifests: Array<ManifestTypes | ManifestKind<ManifestTypes>>): void {
-		const validManifests = manifests.filter(this.checkExtension.bind(this));
-		this._extensions.setValue([...this._extensions.getValue(), ...(validManifests as Array<ManifestTypes>)]);
+		// we have to register extensions individually, so we ensure a manifest is valid before continuing to the next one
+		manifests.forEach((manifest) => this.register(manifest));
 	}
 
 	unregisterMany(aliases: Array<string>): void {

--- a/src/packages/block/block-rte/workspace/views/manifests.ts
+++ b/src/packages/block/block-rte/workspace/views/manifests.ts
@@ -4,7 +4,7 @@ import type { ManifestWorkspaceView } from '@umbraco-cms/backoffice/extension-re
 export const workspaceViews: Array<ManifestWorkspaceView> = [
 	{
 		type: 'workspaceView',
-		alias: 'Umb.WorkspaceView.BlockType.List.Settings',
+		alias: 'Umb.WorkspaceView.BlockType.RTE.Settings',
 		name: 'Block List Type Workspace Settings View',
 		js: () => import('./block-rte-type-workspace-view.element.js'),
 		weight: 1000,

--- a/src/packages/documents/manifests.ts
+++ b/src/packages/documents/manifests.ts
@@ -4,7 +4,6 @@ import { manifests as contentMenuManifest } from './documents/menu.manifests.js'
 import { manifests as documentBlueprintManifests } from './document-blueprints/manifests.js';
 import { manifests as documentTypeManifests } from './document-types/manifests.js';
 import { manifests as documentManifests } from './documents/manifests.js';
-import { manifests as documentPermissionManifests } from './documents/user-permissions/index.js';
 
 export const manifests = [
 	...dashboardManifests,
@@ -13,5 +12,4 @@ export const manifests = [
 	...documentBlueprintManifests,
 	...documentTypeManifests,
 	...documentManifests,
-	...documentPermissionManifests,
 ];

--- a/src/packages/media/media-types/entity-actions/manifests.ts
+++ b/src/packages/media/media-types/entity-actions/manifests.ts
@@ -1,24 +1,10 @@
 import { UMB_MEDIA_TYPE_ENTITY_TYPE } from '../entity.js';
 import { UMB_MEDIA_TYPE_DETAIL_REPOSITORY_ALIAS } from '../repository/index.js';
-import { UmbCreateMediaTypeEntityAction } from './create/create.action.js';
 import { manifests as createManifests } from './create/manifests.js';
 import { UmbDeleteEntityAction, UmbMoveEntityAction, UmbCopyEntityAction } from '@umbraco-cms/backoffice/entity-action';
 import type { ManifestEntityAction } from '@umbraco-cms/backoffice/extension-registry';
 
 const entityActions: Array<ManifestEntityAction> = [
-	{
-		type: 'entityAction',
-		alias: 'Umb.EntityAction.MediaType.Create',
-		name: 'Create Media Type Entity Action',
-		weight: 500,
-		api: UmbCreateMediaTypeEntityAction,
-		meta: {
-			icon: 'icon-add',
-			label: 'Create',
-			repositoryAlias: UMB_MEDIA_TYPE_DETAIL_REPOSITORY_ALIAS,
-			entityTypes: [UMB_MEDIA_TYPE_ENTITY_TYPE],
-		},
-	},
 	{
 		type: 'entityAction',
 		alias: 'Umb.EntityAction.MediaType.Move',


### PR DESCRIPTION
This PR fixes an issue with the `registerMany` method on the extensionRegistry where it was possible to have multiple manifests in the same array with the same alias.

Now we ensure that each manifest is validated before registering the next.