### PR TITLE
Rename context tokens, to align naming

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -9,7 +9,7 @@ import { setCustomElements } from '@storybook/web-components';
 
 import { startMockServiceWorker } from '../src/mocks';
 
-import { UMB_MODAL_MANAGER_CONTEXT_TOKEN, UmbModalManagerContext } from '../src/packages/core/modal';
+import { UMB_MODAL_MANAGER_CONTEXT, UmbModalManagerContext } from '../src/packages/core/modal';
 import { UmbDataTypeTreeStore } from '../src/packages/core/data-type/tree/data-type-tree.store';
 import { UmbDocumentStore } from '../src/packages/documents/documents/repository/document.store';
 import { UmbDocumentTreeStore } from '../src/packages/documents/documents/tree/document-tree.store';
@@ -35,7 +35,7 @@ class UmbStoryBookElement extends UmbLitElement {
 		super();
 		this._umbIconRegistry.attach(this);
 		this._registerExtensions(documentManifests);
-		this.provideContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, new UmbModalManagerContext(this));
+		this.provideContext(UMB_MODAL_MANAGER_CONTEXT, new UmbModalManagerContext(this));
 
 		this._registerExtensions(localizationManifests);
 		umbLocalizationRegistry.loadLanguage('en-us'); // register default language

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Then create a dashboard.js file the same folder.
 
 ```javascript
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import { UMB_NOTIFICATION_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/notification';
+import { UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
 
 const template = document.createElement('template');
 template.innerHTML = `
@@ -75,7 +75,7 @@ export default class MyDashboardElement extends UmbElementMixin(HTMLElement) {
 
 		this.shadowRoot.getElementById('clickMe').addEventListener('click', this.onClick.bind(this));
 
-		this.consumeContext(UMB_NOTIFICATION_CONTEXT_TOKEN, (_instance) => {
+		this.consumeContext(UMB_NOTIFICATION_CONTEXT, (_instance) => {
 			this.#notificationContext = _instance;
 		});
 	}
@@ -109,7 +109,7 @@ Then go to the element located in `src/my-element.ts` and replace it with the fo
 // src/my-element.ts
 import { LitElement, html, customElement } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
-import { UmbNotificationContext, UMB_NOTIFICATION_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/notification';
+import { UmbNotificationContext, UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
 
 @customElement('my-element')
 export default class MyElement extends UmbElementMixin(LitElement) {
@@ -117,7 +117,7 @@ export default class MyElement extends UmbElementMixin(LitElement) {
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_NOTIFICATION_CONTEXT_TOKEN, (_instance) => {
+		this.consumeContext(UMB_NOTIFICATION_CONTEXT, (_instance) => {
 			this._notificationContext = _instance;
 		});
 	}

--- a/src/apps/backoffice/backoffice.context.ts
+++ b/src/apps/backoffice/backoffice.context.ts
@@ -17,7 +17,7 @@ export class UmbBackofficeContext extends UmbContextBase<UmbBackofficeContext> {
 	public readonly allowedSections = this.#allowedSections.asObservable();
 
 	constructor(host: UmbControllerHost) {
-		super(host, UMB_BACKOFFICE_CONTEXT_TOKEN);
+		super(host, UMB_BACKOFFICE_CONTEXT);
 		new UmbExtensionsManifestInitializer(this, umbExtensionsRegistry, 'section', null, (sections) => {
 			this.#allowedSections.setValue([...sections]);
 		});
@@ -28,4 +28,4 @@ export class UmbBackofficeContext extends UmbContextBase<UmbBackofficeContext> {
 	}
 }
 
-export const UMB_BACKOFFICE_CONTEXT_TOKEN = new UmbContextToken<UmbBackofficeContext>('UmbBackofficeContext');
+export const UMB_BACKOFFICE_CONTEXT = new UmbContextToken<UmbBackofficeContext>('UmbBackofficeContext');

--- a/src/apps/backoffice/components/backoffice-header-sections.element.ts
+++ b/src/apps/backoffice/components/backoffice-header-sections.element.ts
@@ -1,4 +1,4 @@
-import { UMB_BACKOFFICE_CONTEXT_TOKEN } from '../backoffice.context.js';
+import { UMB_BACKOFFICE_CONTEXT } from '../backoffice.context.js';
 import type { UmbBackofficeContext } from '../backoffice.context.js';
 import { css, CSSResultGroup, html, customElement, state, repeat } from '@umbraco-cms/backoffice/external/lit';
 import type { ManifestSection } from '@umbraco-cms/backoffice/extension-registry';
@@ -18,7 +18,7 @@ export class UmbBackofficeHeaderSectionsElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_BACKOFFICE_CONTEXT_TOKEN, (backofficeContext) => {
+		this.consumeContext(UMB_BACKOFFICE_CONTEXT, (backofficeContext) => {
 			this._backofficeContext = backofficeContext;
 			this._observeSections();
 			this._observeCurrentSection();

--- a/src/apps/backoffice/components/backoffice-main.element.ts
+++ b/src/apps/backoffice/components/backoffice-main.element.ts
@@ -1,6 +1,6 @@
-import { UmbBackofficeContext, UMB_BACKOFFICE_CONTEXT_TOKEN } from '../backoffice.context.js';
+import { UmbBackofficeContext, UMB_BACKOFFICE_CONTEXT } from '../backoffice.context.js';
 import { css, html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
-import { UmbSectionContext, UMB_SECTION_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/section';
+import { UmbSectionContext, UMB_SECTION_CONTEXT } from '@umbraco-cms/backoffice/section';
 import type { UmbRoute, UmbRouterSlotChangeEvent } from '@umbraco-cms/backoffice/router';
 import type { ManifestSection, UmbSectionElement } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbExtensionManifestInitializer, createExtensionElement } from '@umbraco-cms/backoffice/extension-api';
@@ -21,7 +21,7 @@ export class UmbBackofficeMainElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_BACKOFFICE_CONTEXT_TOKEN, (_instance) => {
+		this.consumeContext(UMB_BACKOFFICE_CONTEXT, (_instance) => {
 			this._backofficeContext = _instance;
 			this._observeBackoffice();
 		});
@@ -88,7 +88,7 @@ export class UmbBackofficeMainElement extends UmbLitElement {
 	private _provideSectionContext(sectionManifest: ManifestSection) {
 		if (!this._sectionContext) {
 			this._sectionContext = new UmbSectionContext(sectionManifest);
-			this.provideContext(UMB_SECTION_CONTEXT_TOKEN, this._sectionContext);
+			this.provideContext(UMB_SECTION_CONTEXT, this._sectionContext);
 		} else {
 			this._sectionContext.setManifest(sectionManifest);
 		}

--- a/src/apps/installer/consent/installer-consent.element.ts
+++ b/src/apps/installer/consent/installer-consent.element.ts
@@ -1,4 +1,4 @@
-import { UmbInstallerContext, UMB_INSTALLER_CONTEXT_TOKEN } from '../installer.context.js';
+import { UmbInstallerContext, UMB_INSTALLER_CONTEXT } from '../installer.context.js';
 import { css, CSSResultGroup, html, customElement, state, unsafeHTML } from '@umbraco-cms/backoffice/external/lit';
 
 import {
@@ -21,7 +21,7 @@ export class UmbInstallerConsentElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_INSTALLER_CONTEXT_TOKEN, (installerContext) => {
+		this.consumeContext(UMB_INSTALLER_CONTEXT, (installerContext) => {
 			this._installerContext = installerContext;
 			this._observeInstallerSettings();
 			this._observeInstallerData();

--- a/src/apps/installer/database/installer-database.element.ts
+++ b/src/apps/installer/database/installer-database.element.ts
@@ -1,4 +1,4 @@
-import { UmbInstallerContext, UMB_INSTALLER_CONTEXT_TOKEN } from '../installer.context.js';
+import { UmbInstallerContext, UMB_INSTALLER_CONTEXT } from '../installer.context.js';
 import { UUIButtonElement } from '@umbraco-cms/backoffice/external/uui';
 import {
 	css,
@@ -46,7 +46,7 @@ export class UmbInstallerDatabaseElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_INSTALLER_CONTEXT_TOKEN, (installerContext) => {
+		this.consumeContext(UMB_INSTALLER_CONTEXT, (installerContext) => {
 			this._installerContext = installerContext;
 			this._observeInstallerSettings();
 			this._observeInstallerData();

--- a/src/apps/installer/error/installer-error.element.ts
+++ b/src/apps/installer/error/installer-error.element.ts
@@ -1,4 +1,4 @@
-import { UmbInstallerContext, UMB_INSTALLER_CONTEXT_TOKEN } from '../installer.context.js';
+import { UmbInstallerContext, UMB_INSTALLER_CONTEXT } from '../installer.context.js';
 import { css, CSSResultGroup, html, nothing, customElement, state } from '@umbraco-cms/backoffice/external/lit';
 import { ProblemDetails } from '@umbraco-cms/backoffice/backend-api';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
@@ -13,7 +13,7 @@ export class UmbInstallerErrorElement extends UmbLitElement {
 	connectedCallback() {
 		super.connectedCallback();
 
-		this.consumeContext(UMB_INSTALLER_CONTEXT_TOKEN, (installerContext) => {
+		this.consumeContext(UMB_INSTALLER_CONTEXT, (installerContext) => {
 			this._installerContext = installerContext;
 			this._observeInstallStatus();
 		});

--- a/src/apps/installer/installer.context.ts
+++ b/src/apps/installer/installer.context.ts
@@ -129,4 +129,4 @@ export class UmbInstallerContext {
 	}
 }
 
-export const UMB_INSTALLER_CONTEXT_TOKEN = new UmbContextToken<UmbInstallerContext>('UmbInstallerContext');
+export const UMB_INSTALLER_CONTEXT = new UmbContextToken<UmbInstallerContext>('UmbInstallerContext');

--- a/src/apps/installer/installer.element.ts
+++ b/src/apps/installer/installer.element.ts
@@ -1,4 +1,4 @@
-import { UmbInstallerContext, UMB_INSTALLER_CONTEXT_TOKEN } from './installer.context.js';
+import { UmbInstallerContext, UMB_INSTALLER_CONTEXT } from './installer.context.js';
 import { css, CSSResultGroup, html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 
@@ -18,7 +18,7 @@ export class UmbInstallerElement extends UmbLitElement {
 
 	constructor() {
 		super();
-		this.provideContext(UMB_INSTALLER_CONTEXT_TOKEN, this._umbInstallerContext);
+		this.provideContext(UMB_INSTALLER_CONTEXT, this._umbInstallerContext);
 	}
 
 	connectedCallback(): void {

--- a/src/apps/installer/user/installer-user.element.ts
+++ b/src/apps/installer/user/installer-user.element.ts
@@ -1,4 +1,4 @@
-import { UmbInstallerContext, UMB_INSTALLER_CONTEXT_TOKEN } from '../installer.context.js';
+import { UmbInstallerContext, UMB_INSTALLER_CONTEXT } from '../installer.context.js';
 import { css, CSSResultGroup, html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 
@@ -12,7 +12,7 @@ export class UmbInstallerUserElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_INSTALLER_CONTEXT_TOKEN, (installerContext) => {
+		this.consumeContext(UMB_INSTALLER_CONTEXT, (installerContext) => {
 			this._installerContext = installerContext;
 			this._observeInstallerData();
 		});

--- a/src/packages/audit-log/repository/audit-log.repository.ts
+++ b/src/packages/audit-log/repository/audit-log.repository.ts
@@ -1,7 +1,7 @@
 import { UmbAuditLogServerDataSource } from './audit-log.server.data.js';
 import { UmbContextConsumerController } from '@umbraco-cms/backoffice/context-api';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
-import { UmbNotificationContext, UMB_NOTIFICATION_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/notification';
+import { UmbNotificationContext, UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
 import { AuditTypeModel, DirectionModel } from '@umbraco-cms/backoffice/backend-api';
 import { UmbBaseController } from '@umbraco-cms/backoffice/class-api';
 
@@ -14,7 +14,7 @@ export class UmbAuditLogRepository extends UmbBaseController {
 		super(host);
 		this.#dataSource = new UmbAuditLogServerDataSource(host);
 
-		this.#init = new UmbContextConsumerController(host, UMB_NOTIFICATION_CONTEXT_TOKEN, (instance) => {
+		this.#init = new UmbContextConsumerController(host, UMB_NOTIFICATION_CONTEXT, (instance) => {
 			this.#notificationService = instance;
 		}).asPromise();
 	}

--- a/src/packages/block/block-list/components/block-list-block/block-list-block.element.ts
+++ b/src/packages/block/block-list/components/block-list-block/block-list-block.element.ts
@@ -5,7 +5,7 @@ import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 import { type UmbBlockLayoutBaseModel } from '@umbraco-cms/backoffice/block';
 import '../ref-list-block/index.js';
 import '../inline-list-block/index.js';
-import { UMB_CONFIRM_MODAL, UMB_MODAL_MANAGER_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/modal';
+import { UMB_CONFIRM_MODAL, UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
 
 /**
  * @element umb-property-editor-ui-block-list-block
@@ -55,7 +55,7 @@ export class UmbPropertyEditorUIBlockListBlockElement extends UmbLitElement impl
 	}
 
 	#requestDelete() {
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, async (modalManager) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, async (modalManager) => {
 			const modalContext = modalManager.open(UMB_CONFIRM_MODAL, {
 				data: {
 					headline: `Delete ${this._label}`,

--- a/src/packages/block/block-type/components/block-type-card/block-type-card.element.ts
+++ b/src/packages/block/block-type/components/block-type-card/block-type-card.element.ts
@@ -4,7 +4,7 @@ import {
 } from '@umbraco-cms/backoffice/document-type';
 import { UmbDeleteEvent } from '@umbraco-cms/backoffice/event';
 import { html, customElement, property, state } from '@umbraco-cms/backoffice/external/lit';
-import { UMB_CONFIRM_MODAL, UMB_MODAL_MANAGER_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/modal';
+import { UMB_CONFIRM_MODAL, UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
 import { UmbRepositoryItemsManager } from '@umbraco-cms/backoffice/repository';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 
@@ -53,7 +53,7 @@ export class UmbBlockTypeCardElement extends UmbLitElement {
 	}
 
 	#onRequestDelete() {
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, async (modalManager) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, async (modalManager) => {
 			const modalContext = modalManager.open(UMB_CONFIRM_MODAL, {
 				data: {
 					color: 'danger',

--- a/src/packages/block/block-type/components/input-block-type/input-block-type.element.ts
+++ b/src/packages/block/block-type/components/input-block-type/input-block-type.element.ts
@@ -1,7 +1,7 @@
 import { UmbBlockTypeBaseModel } from '../../types.js';
 import {
 	UMB_DOCUMENT_TYPE_PICKER_MODAL,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UMB_WORKSPACE_MODAL,
 	UmbModalRouteRegistrationController,
 } from '@umbraco-cms/backoffice/modal';
@@ -63,7 +63,7 @@ export class UmbInputBlockTypeElement<
 	}
 
 	create() {
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, async (modalManager) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, async (modalManager) => {
 			if (modalManager) {
 				// TODO: Make as mode for the Picker Modal, so the click to select immediately submits the modal(And in that mode we do not want to see a Submit button).
 				const modalContext = modalManager.open(UMB_DOCUMENT_TYPE_PICKER_MODAL, {

--- a/src/packages/block/block/modals/block-catalogue/block-catalogue-modal.element.ts
+++ b/src/packages/block/block/modals/block-catalogue/block-catalogue-modal.element.ts
@@ -7,7 +7,7 @@ import {
 import { css, html, customElement, state, repeat, ifDefined, nothing } from '@umbraco-cms/backoffice/external/lit';
 import { groupBy } from '@umbraco-cms/backoffice/external/lodash';
 import {
-	UMB_MODAL_CONTEXT_TOKEN,
+	UMB_MODAL_CONTEXT,
 	UmbModalBaseElement,
 	UmbModalRouteRegistrationController,
 } from '@umbraco-cms/backoffice/modal';
@@ -32,7 +32,7 @@ export class UmbBlockCatalogueModalElement extends UmbModalBaseElement<
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_MODAL_CONTEXT_TOKEN, (modalContext) => {
+		this.consumeContext(UMB_MODAL_CONTEXT, (modalContext) => {
 			new UmbModalRouteRegistrationController(this, UMB_BLOCK_WORKSPACE_MODAL)
 				//.addAdditionalPath('block') // No need for additional path specification in this context as this is for sure the only workspace we want to open here.
 				.onSetup(() => {

--- a/src/packages/block/block/workspace/block-workspace.context.ts
+++ b/src/packages/block/block/workspace/block-workspace.context.ts
@@ -7,7 +7,7 @@ import { ManifestWorkspace } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbId } from '@umbraco-cms/backoffice/id';
 import { UMB_BLOCK_MANAGER_CONTEXT, UmbBlockWorkspaceData } from '@umbraco-cms/backoffice/block';
 import { buildUdi } from '@umbraco-cms/backoffice/utils';
-import { UMB_MODAL_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/modal';
+import { UMB_MODAL_CONTEXT } from '@umbraco-cms/backoffice/modal';
 
 export class UmbBlockWorkspaceContext<
 	LayoutDataType extends UmbBlockLayoutBaseModel = UmbBlockLayoutBaseModel,
@@ -19,7 +19,7 @@ export class UmbBlockWorkspaceContext<
 
 	#blockManager?: typeof UMB_BLOCK_MANAGER_CONTEXT.TYPE;
 	#retrieveBlockManager;
-	#modalContext?: typeof UMB_MODAL_CONTEXT_TOKEN.TYPE;
+	#modalContext?: typeof UMB_MODAL_CONTEXT.TYPE;
 	#retrieveModalContext;
 	#editorConfigPromise?: Promise<unknown>;
 
@@ -49,7 +49,7 @@ export class UmbBlockWorkspaceContext<
 		this.#entityType = workspaceArgs.manifest.meta?.entityType;
 		this.workspaceAlias = workspaceArgs.manifest.alias;
 
-		this.#retrieveModalContext = this.consumeContext(UMB_MODAL_CONTEXT_TOKEN, (context) => {
+		this.#retrieveModalContext = this.consumeContext(UMB_MODAL_CONTEXT, (context) => {
 			this.#modalContext = context;
 			context.onSubmit().catch(this.#modalRejected);
 		}).asPromise();

--- a/src/packages/core/components/backoffice-modal-container/backoffice-modal-container.element.ts
+++ b/src/packages/core/components/backoffice-modal-container/backoffice-modal-container.element.ts
@@ -2,7 +2,7 @@ import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { css, CSSResultGroup, html, repeat, customElement, state } from '@umbraco-cms/backoffice/external/lit';
 import {
 	UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UmbModalElement,
 	UmbModalContext,
 } from '@umbraco-cms/backoffice/modal';
@@ -21,7 +21,7 @@ export class UmbBackofficeModalContainerElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this._modalManager = instance;
 			this._observeModals();
 		});

--- a/src/packages/core/components/backoffice-notification-container/backoffice-notification-container.element.ts
+++ b/src/packages/core/components/backoffice-notification-container/backoffice-notification-container.element.ts
@@ -3,7 +3,7 @@ import { css, CSSResultGroup, html, customElement, state, repeat, query } from '
 import {
 	UmbNotificationHandler,
 	UmbNotificationContext,
-	UMB_NOTIFICATION_CONTEXT_TOKEN,
+	UMB_NOTIFICATION_CONTEXT,
 } from '@umbraco-cms/backoffice/notification';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 
@@ -20,7 +20,7 @@ export class UmbBackofficeNotificationContainerElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_NOTIFICATION_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => {
 			this._notificationContext = instance;
 			this._observeNotifications();
 		});

--- a/src/packages/core/components/entity-actions-bundle/entity-actions-bundle.element.ts
+++ b/src/packages/core/components/entity-actions-bundle/entity-actions-bundle.element.ts
@@ -1,7 +1,7 @@
 import { css, html, nothing, customElement, property, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { map } from '@umbraco-cms/backoffice/external/rxjs';
-import { UmbSectionSidebarContext, UMB_SECTION_SIDEBAR_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/section';
+import { UmbSectionSidebarContext, UMB_SECTION_SIDEBAR_CONTEXT } from '@umbraco-cms/backoffice/section';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 
@@ -35,7 +35,7 @@ export class UmbEntityActionsBundleElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_SECTION_SIDEBAR_CONTEXT_TOKEN, (sectionContext) => {
+		this.consumeContext(UMB_SECTION_SIDEBAR_CONTEXT, (sectionContext) => {
 			this.#sectionSidebarContext = sectionContext;
 		});
 	}

--- a/src/packages/core/components/input-list-base/input-list-base.ts
+++ b/src/packages/core/components/input-list-base/input-list-base.ts
@@ -4,7 +4,7 @@ import {
 	UmbModalManagerContext,
 	UmbModalToken,
 	UmbModalType,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UmbPickerModalValue,
 } from '@umbraco-cms/backoffice/modal';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
@@ -29,7 +29,7 @@ export class UmbInputListBaseElement extends UmbLitElement {
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this._modalContext = instance;
 		});
 	}

--- a/src/packages/core/components/input-markdown-editor/input-markdown.element.ts
+++ b/src/packages/core/components/input-markdown-editor/input-markdown.element.ts
@@ -9,7 +9,7 @@ import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 import {
 	UMB_LINK_PICKER_MODAL,
 	UMB_MEDIA_TREE_PICKER_MODAL,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UmbModalManagerContext,
 } from '@umbraco-cms/backoffice/modal';
 import { UMB_APP_CONTEXT } from '@umbraco-cms/backoffice/app';
@@ -47,7 +47,7 @@ export class UmbInputMarkdownElement extends FormControlMixin(UmbLitElement) {
 	constructor() {
 		super();
 		this.#loadCodeEditor();
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this._modalContext = instance;
 		});
 		this.consumeContext(UMB_APP_CONTEXT, (instance) => {

--- a/src/packages/core/components/multiple-color-picker-input/multiple-color-picker-item-input.element.ts
+++ b/src/packages/core/components/multiple-color-picker-input/multiple-color-picker-item-input.element.ts
@@ -5,11 +5,7 @@ import {
 	UUIInputElement,
 	UUIInputEvent,
 } from '@umbraco-cms/backoffice/external/uui';
-import {
-	UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
-	UMB_CONFIRM_MODAL,
-} from '@umbraco-cms/backoffice/modal';
+import { UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT, UMB_CONFIRM_MODAL } from '@umbraco-cms/backoffice/modal';
 import { UmbChangeEvent, UmbInputEvent, UmbDeleteEvent } from '@umbraco-cms/backoffice/event';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 
@@ -53,7 +49,7 @@ export class UmbMultipleColorPickerItemInputElement extends FormControlMixin(Umb
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this._modalContext = instance;
 		});
 	}
@@ -65,7 +61,7 @@ export class UmbMultipleColorPickerItemInputElement extends FormControlMixin(Umb
 				content: this.localize.term('content_nestedContentDeleteItem'),
 				color: 'danger',
 				confirmLabel: this.localize.term('actions_delete'),
-			}
+			},
 		});
 
 		modalContext?.onSubmit().then(() => {

--- a/src/packages/core/components/multiple-text-string-input/input-multiple-text-string-item.element.ts
+++ b/src/packages/core/components/multiple-text-string-input/input-multiple-text-string-item.element.ts
@@ -1,10 +1,6 @@
 import { css, html, nothing, customElement, property, query } from '@umbraco-cms/backoffice/external/lit';
 import { FormControlMixin, UUIInputElement, UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
-import {
-	UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
-	UMB_CONFIRM_MODAL,
-} from '@umbraco-cms/backoffice/modal';
+import { UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT, UMB_CONFIRM_MODAL } from '@umbraco-cms/backoffice/modal';
 import { UmbChangeEvent, UmbInputEvent, UmbDeleteEvent } from '@umbraco-cms/backoffice/event';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 
@@ -39,7 +35,7 @@ export class UmbInputMultipleTextStringItemElement extends FormControlMixin(UmbL
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this._modalContext = instance;
 		});
 	}

--- a/src/packages/core/data-type/entity-actions/copy/copy.action.ts
+++ b/src/packages/core/data-type/entity-actions/copy/copy.action.ts
@@ -3,7 +3,7 @@ import { UmbEntityActionBase } from '@umbraco-cms/backoffice/entity-action';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
 import {
 	UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UMB_DATA_TYPE_PICKER_MODAL,
 } from '@umbraco-cms/backoffice/modal';
 
@@ -14,7 +14,7 @@ export class UmbCopyDataTypeEntityAction extends UmbEntityActionBase<UmbCopyData
 	constructor(host: UmbControllerHostElement, repositoryAlias: string, unique: string) {
 		super(host, repositoryAlias, unique);
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalManagerContext = instance;
 		});
 	}

--- a/src/packages/core/data-type/entity-actions/create/create.action.ts
+++ b/src/packages/core/data-type/entity-actions/create/create.action.ts
@@ -2,7 +2,7 @@ import { UmbDataTypeDetailRepository } from '../../repository/detail/data-type-d
 import { UMB_DATA_TYPE_CREATE_OPTIONS_MODAL } from './modal/index.js';
 import { UmbEntityActionBase } from '@umbraco-cms/backoffice/entity-action';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
-import { UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/modal';
+import { UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
 
 export class UmbCreateDataTypeEntityAction extends UmbEntityActionBase<UmbDataTypeDetailRepository> {
 	#modalManagerContext?: UmbModalManagerContext;
@@ -10,7 +10,7 @@ export class UmbCreateDataTypeEntityAction extends UmbEntityActionBase<UmbDataTy
 	constructor(host: UmbControllerHostElement, repositoryAlias: string, unique: string) {
 		super(host, repositoryAlias, unique);
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalManagerContext = instance;
 		});
 	}

--- a/src/packages/core/data-type/entity-actions/create/modal/data-type-create-options-modal.element.ts
+++ b/src/packages/core/data-type/entity-actions/create/modal/data-type-create-options-modal.element.ts
@@ -5,7 +5,7 @@ import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import {
 	type UmbModalManagerContext,
 	UmbModalBaseElement,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 } from '@umbraco-cms/backoffice/modal';
 import { UMB_FOLDER_CREATE_MODAL } from '@umbraco-cms/backoffice/tree';
 
@@ -15,7 +15,7 @@ export class UmbDataTypeCreateOptionsModalElement extends UmbModalBaseElement<Um
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalContext = instance;
 		});
 	}

--- a/src/packages/core/data-type/entity-actions/move/move.action.ts
+++ b/src/packages/core/data-type/entity-actions/move/move.action.ts
@@ -3,7 +3,7 @@ import { UmbEntityActionBase } from '@umbraco-cms/backoffice/entity-action';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
 import {
 	UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UMB_DATA_TYPE_PICKER_MODAL,
 } from '@umbraco-cms/backoffice/modal';
 
@@ -14,7 +14,7 @@ export class UmbMoveDataTypeEntityAction extends UmbEntityActionBase<UmbMoveData
 	constructor(host: UmbControllerHostElement, repositoryAlias: string, unique: string) {
 		super(host, repositoryAlias, unique);
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalManagerContext = instance;
 		});
 	}

--- a/src/packages/core/data-type/repository/copy/data-type-copy.repository.ts
+++ b/src/packages/core/data-type/repository/copy/data-type-copy.repository.ts
@@ -1,7 +1,7 @@
 import { UMB_DATA_TYPE_TREE_STORE_CONTEXT, UmbDataTypeTreeStore } from '../../tree/data-type-tree.store.js';
 import { UmbDataTypeDetailRepository } from '../detail/data-type-detail.repository.js';
 import { UmbDataTypeCopyServerDataSource } from './data-type-copy.server.data-source.js';
-import { UMB_NOTIFICATION_CONTEXT_TOKEN, UmbNotificationContext } from '@umbraco-cms/backoffice/notification';
+import { UMB_NOTIFICATION_CONTEXT, UmbNotificationContext } from '@umbraco-cms/backoffice/notification';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbCopyDataSource, UmbCopyRepository, UmbRepositoryBase } from '@umbraco-cms/backoffice/repository';
 
@@ -22,7 +22,7 @@ export class UmbCopyDataTypeRepository extends UmbRepositoryBase implements UmbC
 				this.#treeStore = instance;
 			}).asPromise(),
 
-			this.consumeContext(UMB_NOTIFICATION_CONTEXT_TOKEN, (instance) => {
+			this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => {
 				this.#notificationContext = instance;
 			}).asPromise(),
 		]);

--- a/src/packages/core/data-type/repository/move/data-type-move.repository.ts
+++ b/src/packages/core/data-type/repository/move/data-type-move.repository.ts
@@ -1,6 +1,6 @@
 import { UMB_DATA_TYPE_TREE_STORE_CONTEXT, UmbDataTypeTreeStore } from '../../tree/data-type-tree.store.js';
 import { UmbDataTypeMoveServerDataSource } from './data-type-move.server.data-source.js';
-import { UMB_NOTIFICATION_CONTEXT_TOKEN, UmbNotificationContext } from '@umbraco-cms/backoffice/notification';
+import { UMB_NOTIFICATION_CONTEXT, UmbNotificationContext } from '@umbraco-cms/backoffice/notification';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbMoveDataSource, UmbMoveRepository, UmbRepositoryBase } from '@umbraco-cms/backoffice/repository';
 
@@ -19,7 +19,7 @@ export class UmbMoveDataTypeRepository extends UmbRepositoryBase implements UmbM
 				this.#treeStore = instance;
 			}).asPromise(),
 
-			this.consumeContext(UMB_NOTIFICATION_CONTEXT_TOKEN, (instance) => {
+			this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => {
 				this.#notificationContext = instance;
 			}).asPromise(),
 		]);

--- a/src/packages/core/data-type/workspace/views/details/data-type-details-workspace-view.element.ts
+++ b/src/packages/core/data-type/workspace/views/details/data-type-details-workspace-view.element.ts
@@ -4,7 +4,7 @@ import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { css, html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
 import {
 	UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UMB_PROPERTY_EDITOR_UI_PICKER_MODAL,
 } from '@umbraco-cms/backoffice/modal';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
@@ -33,7 +33,7 @@ export class UmbDataTypeDetailsWorkspaceViewEditElement extends UmbLitElement im
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this._modalContext = instance;
 		});
 

--- a/src/packages/core/debug/debug.element.ts
+++ b/src/packages/core/debug/debug.element.ts
@@ -19,7 +19,7 @@ import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 import {
 	UmbModalManagerContext,
 	UMB_CONTEXT_DEBUGGER_MODAL,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 } from '@umbraco-cms/backoffice/modal';
 
 @customElement('umb-debug')
@@ -40,7 +40,7 @@ export class UmbDebugElement extends UmbLitElement {
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this._modalContext = instance;
 		});
 	}

--- a/src/packages/core/entity-action/common/delete/delete.action.ts
+++ b/src/packages/core/entity-action/common/delete/delete.action.ts
@@ -1,11 +1,7 @@
 import { UmbEntityActionBase } from '../../entity-action.js';
 import { UmbContextConsumerController } from '@umbraco-cms/backoffice/context-api';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
-import {
-	UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
-	UMB_CONFIRM_MODAL,
-} from '@umbraco-cms/backoffice/modal';
+import { UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT, UMB_CONFIRM_MODAL } from '@umbraco-cms/backoffice/modal';
 import { UmbDetailRepository, UmbItemRepository } from '@umbraco-cms/backoffice/repository';
 
 export class UmbDeleteEntityAction<
@@ -16,7 +12,7 @@ export class UmbDeleteEntityAction<
 	constructor(host: UmbControllerHostElement, repositoryAlias: string, unique: string) {
 		super(host, repositoryAlias, unique);
 
-		new UmbContextConsumerController(this._host, UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		new UmbContextConsumerController(this._host, UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalManager = instance;
 		});
 	}

--- a/src/packages/core/entity-action/common/rename/rename-repository-base.ts
+++ b/src/packages/core/entity-action/common/rename/rename-repository-base.ts
@@ -1,5 +1,5 @@
 import { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
-import { UMB_NOTIFICATION_CONTEXT_TOKEN, UmbNotificationContext } from '@umbraco-cms/backoffice/notification';
+import { UMB_NOTIFICATION_CONTEXT, UmbNotificationContext } from '@umbraco-cms/backoffice/notification';
 import { UmbRepositoryBase } from '@umbraco-cms/backoffice/repository';
 import { UmbRenameDataSource, UmbRenameDataSourceConstructor } from '@umbraco-cms/backoffice/entity-action';
 import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
@@ -24,7 +24,7 @@ export abstract class UmbRenameRepositoryBase<DetailModelType extends { unique: 
 				this.#detailStore = instance;
 			}).asPromise(),
 
-			this.consumeContext(UMB_NOTIFICATION_CONTEXT_TOKEN, (instance) => {
+			this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => {
 				this.#notificationContext = instance;
 			}).asPromise(),
 		]);

--- a/src/packages/core/entity-action/common/rename/rename.action.ts
+++ b/src/packages/core/entity-action/common/rename/rename.action.ts
@@ -2,7 +2,7 @@ import { UMB_RENAME_MODAL } from './modal/rename-modal.token.js';
 import { type UmbRenameRepository } from './types.js';
 import { UmbEntityActionBase } from '@umbraco-cms/backoffice/entity-action';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
-import { UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/modal';
+import { UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
 
 export class UmbRenameEntityAction extends UmbEntityActionBase<UmbRenameRepository<{ unique: string }>> {
 	#modalManagerContext?: UmbModalManagerContext;
@@ -10,7 +10,7 @@ export class UmbRenameEntityAction extends UmbEntityActionBase<UmbRenameReposito
 	constructor(host: UmbControllerHostElement, repositoryAlias: string, unique: string) {
 		super(host, repositoryAlias, unique);
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalManagerContext = instance;
 		});
 	}

--- a/src/packages/core/entity-action/common/trash/trash.action.ts
+++ b/src/packages/core/entity-action/common/trash/trash.action.ts
@@ -1,11 +1,7 @@
 import { UmbEntityActionBase } from '../../entity-action.js';
 import { UmbContextConsumerController } from '@umbraco-cms/backoffice/context-api';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
-import {
-	UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
-	UMB_CONFIRM_MODAL,
-} from '@umbraco-cms/backoffice/modal';
+import { UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT, UMB_CONFIRM_MODAL } from '@umbraco-cms/backoffice/modal';
 import { UmbItemRepository } from '@umbraco-cms/backoffice/repository';
 
 export class UmbTrashEntityAction<
@@ -16,7 +12,7 @@ export class UmbTrashEntityAction<
 	constructor(host: UmbControllerHostElement, repositoryAlias: string, unique: string) {
 		super(host, repositoryAlias, unique);
 
-		new UmbContextConsumerController(this._host, UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		new UmbContextConsumerController(this._host, UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalContext = instance;
 		});
 	}

--- a/src/packages/core/extension-registry/conditions/menu-alias.condition.ts
+++ b/src/packages/core/extension-registry/conditions/menu-alias.condition.ts
@@ -1,4 +1,4 @@
-import { UMB_MENU_CONTEXT_TOKEN } from '../../menu/menu.context.js';
+import { UMB_MENU_CONTEXT } from '../../menu/menu.context.js';
 import { UmbBaseController } from '@umbraco-cms/backoffice/class-api';
 import {
 	ManifestCondition,
@@ -20,7 +20,7 @@ export class UmbMenuAliasCondition extends UmbBaseController implements UmbExten
 		super(args.host);
 		this.config = args.config;
 		this.#onChange = args.onChange;
-		this.consumeContext(UMB_MENU_CONTEXT_TOKEN, (context) => {
+		this.consumeContext(UMB_MENU_CONTEXT, (context) => {
 			this.observe(context.alias, (MenuAlias) => {
 				this.permitted = MenuAlias === this.config.match;
 				this.#onChange();

--- a/src/packages/core/extension-registry/conditions/section-alias.condition.ts
+++ b/src/packages/core/extension-registry/conditions/section-alias.condition.ts
@@ -5,7 +5,7 @@ import {
 	UmbConditionControllerArguments,
 	UmbExtensionCondition,
 } from '@umbraco-cms/backoffice/extension-api';
-import { UMB_SECTION_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/section';
+import { UMB_SECTION_CONTEXT } from '@umbraco-cms/backoffice/section';
 
 export class UmbSectionAliasCondition extends UmbBaseController implements UmbExtensionCondition {
 	config: SectionAliasConditionConfig;
@@ -16,7 +16,7 @@ export class UmbSectionAliasCondition extends UmbBaseController implements UmbEx
 		super(args.host);
 		this.config = args.config;
 		this.#onChange = args.onChange;
-		this.consumeContext(UMB_SECTION_CONTEXT_TOKEN, (context) => {
+		this.consumeContext(UMB_SECTION_CONTEXT, (context) => {
 			this.observe(context.alias, (sectionAlias) => {
 				this.permitted = sectionAlias === this.config.match;
 				this.#onChange();

--- a/src/packages/core/macro/macro.service.ts
+++ b/src/packages/core/macro/macro.service.ts
@@ -145,4 +145,4 @@ export class UmbMacroService {
 	}
 }
 
-export const UMB_MACRO_SERVICE_CONTEXT_TOKEN = new UmbContextToken<UmbMacroService>(UmbMacroService.name);
+export const UMB_MACRO_SERVICE_CONTEXT = new UmbContextToken<UmbMacroService>(UmbMacroService.name);

--- a/src/packages/core/menu/menu-item-layout/menu-item-layout.element.ts
+++ b/src/packages/core/menu/menu-item-layout/menu-item-layout.element.ts
@@ -1,6 +1,6 @@
 import { html, customElement, property, state, ifDefined } from '@umbraco-cms/backoffice/external/lit';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
-import { UmbSectionContext, UMB_SECTION_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/section';
+import { UmbSectionContext, UMB_SECTION_CONTEXT } from '@umbraco-cms/backoffice/section';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 
 @customElement('umb-menu-item-layout')
@@ -25,7 +25,7 @@ export class UmbMenuItemLayoutElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_SECTION_CONTEXT_TOKEN, (sectionContext) => {
+		this.consumeContext(UMB_SECTION_CONTEXT, (sectionContext) => {
 			this.#sectionContext = sectionContext;
 			this._observeSection();
 		});

--- a/src/packages/core/menu/menu.context.ts
+++ b/src/packages/core/menu/menu.context.ts
@@ -12,4 +12,4 @@ export class UmbMenuContext {
 	}
 }
 
-export const UMB_MENU_CONTEXT_TOKEN = new UmbContextToken<UmbMenuContext>('UMB_MENU_CONTEXT_TOKEN');
+export const UMB_MENU_CONTEXT = new UmbContextToken<UmbMenuContext>('UMB_MENU_CONTEXT');

--- a/src/packages/core/menu/menu.element.ts
+++ b/src/packages/core/menu/menu.element.ts
@@ -12,7 +12,7 @@ export class UmbMenuElement extends UmbLitElement {
 
 	constructor() {
 		super();
-		//this.provideContext(UMB_MENU_CONTEXT_TOKEN, new UmbMenuContext());
+		//this.provideContext(UMB_MENU_CONTEXT, new UmbMenuContext());
 	}
 
 	render() {

--- a/src/packages/core/modal/modal-manager.context.ts
+++ b/src/packages/core/modal/modal-manager.context.ts
@@ -20,7 +20,7 @@ export class UmbModalManagerContext extends UmbContextBase<UmbModalManagerContex
 	public readonly modals = this.#modals.asObservable();
 
 	constructor(host: UmbControllerHost) {
-		super(host, UMB_MODAL_MANAGER_CONTEXT_TOKEN);
+		super(host, UMB_MODAL_MANAGER_CONTEXT);
 	}
 
 	/**
@@ -68,6 +68,6 @@ export class UmbModalManagerContext extends UmbContextBase<UmbModalManagerContex
 	}
 }
 
-export const UMB_MODAL_MANAGER_CONTEXT_TOKEN = new UmbContextToken<UmbModalManagerContext, UmbModalManagerContext>(
+export const UMB_MODAL_MANAGER_CONTEXT = new UmbContextToken<UmbModalManagerContext, UmbModalManagerContext>(
 	'UmbModalManagerContext',
 );

--- a/src/packages/core/modal/modal-route-registration.controller.ts
+++ b/src/packages/core/modal/modal-route-registration.controller.ts
@@ -1,6 +1,6 @@
 import { UmbModalRouteRegistration } from './modal-route-registration.js';
 import { UmbModalToken } from './token/index.js';
-import { UMB_ROUTE_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/router';
+import { UMB_ROUTE_CONTEXT } from '@umbraco-cms/backoffice/router';
 import type { UmbController, UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbContextConsumerController } from '@umbraco-cms/backoffice/context-api';
 
@@ -15,7 +15,7 @@ export class UmbModalRouteRegistrationController<D extends object = object, R = 
 	#additionalPath?: string;
 	#uniquePaths: Map<string, string | undefined> = new Map();
 
-	#routeContext?: typeof UMB_ROUTE_CONTEXT_TOKEN.TYPE;
+	#routeContext?: typeof UMB_ROUTE_CONTEXT.TYPE;
 	#modalRegistration?: UmbModalRouteRegistration;
 
 	public get controllerAlias() {
@@ -35,7 +35,7 @@ export class UmbModalRouteRegistrationController<D extends object = object, R = 
 		super(alias, null);
 		this.#host = host;
 
-		this.#init = new UmbContextConsumerController(host, UMB_ROUTE_CONTEXT_TOKEN, (_routeContext) => {
+		this.#init = new UmbContextConsumerController(host, UMB_ROUTE_CONTEXT, (_routeContext) => {
 			this.#routeContext = _routeContext;
 			this.#registerModal();
 		}).asPromise();

--- a/src/packages/core/modal/modal.context.ts
+++ b/src/packages/core/modal/modal.context.ts
@@ -131,4 +131,4 @@ export class UmbModalContext<ModalPreset extends object = object, ModalValue = a
 	}
 }
 
-export const UMB_MODAL_CONTEXT_TOKEN = new UmbContextToken<UmbModalContext>('UmbModalContext');
+export const UMB_MODAL_CONTEXT = new UmbContextToken<UmbModalContext>('UmbModalContext');

--- a/src/packages/core/modal/modal.element.ts
+++ b/src/packages/core/modal/modal.element.ts
@@ -1,4 +1,4 @@
-import { UMB_MODAL_CONTEXT_TOKEN, UmbModalContext } from './modal.context.js';
+import { UMB_MODAL_CONTEXT, UmbModalContext } from './modal.context.js';
 import { ManifestModal, umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { CSSResultGroup, html, customElement } from '@umbraco-cms/backoffice/external/lit';
@@ -51,7 +51,7 @@ export class UmbModalElement extends UmbLitElement {
 					// Note for this hack (The if-sentence):
 					// We do not currently have a good enough control to ensure that the proxy is last, meaning if another context is provided at this element, it might respond after the proxy event has been dispatched.
 					// To avoid such this hack just prevents proxying the event if its a request for the Modal Context.
-					if (event.contextAlias !== UMB_MODAL_CONTEXT_TOKEN.contextAlias) {
+					if (event.contextAlias !== UMB_MODAL_CONTEXT.contextAlias) {
 						event.stopImmediatePropagation();
 						this.#modalContext.originTarget.dispatchEvent(event.clone());
 					}
@@ -86,7 +86,7 @@ export class UmbModalElement extends UmbLitElement {
 		this.element.appendChild(this.#modalRouterElement);
 		this.#observeModal(this.#modalContext.alias.toString());
 
-		const provider = new UmbContextProvider(this.element, UMB_MODAL_CONTEXT_TOKEN, this.#modalContext);
+		const provider = new UmbContextProvider(this.element, UMB_MODAL_CONTEXT, this.#modalContext);
 		provider.hostConnected();
 	}
 

--- a/src/packages/core/notification/notification.context.ts
+++ b/src/packages/core/notification/notification.context.ts
@@ -34,7 +34,7 @@ export class UmbNotificationContext extends UmbContextBase<UmbNotificationContex
 	public readonly notifications = this._notifications.asObservable();
 
 	constructor(host: UmbControllerHost) {
-		super(host, UMB_NOTIFICATION_CONTEXT_TOKEN);
+		super(host, UMB_NOTIFICATION_CONTEXT);
 	}
 
 	/**
@@ -94,4 +94,4 @@ export class UmbNotificationContext extends UmbContextBase<UmbNotificationContex
 	}
 }
 
-export const UMB_NOTIFICATION_CONTEXT_TOKEN = new UmbContextToken<UmbNotificationContext>('UmbNotificationContext');
+export const UMB_NOTIFICATION_CONTEXT = new UmbContextToken<UmbNotificationContext>('UmbNotificationContext');

--- a/src/packages/core/notification/stories/story-notification-default-example.element.ts
+++ b/src/packages/core/notification/stories/story-notification-default-example.element.ts
@@ -3,7 +3,7 @@ import {
 	UmbNotificationColor,
 	UmbNotificationOptions,
 	UmbNotificationContext,
-	UMB_NOTIFICATION_CONTEXT_TOKEN,
+	UMB_NOTIFICATION_CONTEXT,
 } from '@umbraco-cms/backoffice/notification';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 
@@ -14,7 +14,7 @@ export class UmbStoryNotificationDefaultExampleElement extends UmbLitElement {
 	connectedCallback(): void {
 		super.connectedCallback();
 
-		this.consumeContext(UMB_NOTIFICATION_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => {
 			this._notificationContext = instance;
 		});
 	}

--- a/src/packages/core/picker-input/picker-input.context.ts
+++ b/src/packages/core/picker-input/picker-input.context.ts
@@ -4,7 +4,7 @@ import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbBaseController } from '@umbraco-cms/backoffice/class-api';
 import {
 	UMB_CONFIRM_MODAL,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UmbModalManagerContext,
 	UmbModalToken,
 	UmbPickerModalData,
@@ -50,7 +50,7 @@ export class UmbPickerInputContext<ItemType extends { name: string }> extends Um
 
 		this.#init = Promise.all([
 			this.#itemManager.init,
-			this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+			this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 				this.modalManager = instance;
 			}).asPromise(),
 		]);

--- a/src/packages/core/property-action/common/copy/property-action-copy.element.ts
+++ b/src/packages/core/property-action/common/copy/property-action-copy.element.ts
@@ -3,9 +3,9 @@ import { html, customElement, property } from '@umbraco-cms/backoffice/external/
 import {
 	UmbNotificationDefaultData,
 	UmbNotificationContext,
-	UMB_NOTIFICATION_CONTEXT_TOKEN,
+	UMB_NOTIFICATION_CONTEXT,
 } from '@umbraco-cms/backoffice/notification';
-//import { UMB_WORKSPACE_PROPERTY_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/workspace';
+//import { UMB_WORKSPACE_PROPERTY_CONTEXT } from '@umbraco-cms/backoffice/workspace';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 
 @customElement('umb-property-action-copy')
@@ -18,12 +18,12 @@ export class UmbPropertyActionCopyElement extends UmbLitElement implements UmbPr
 	constructor() {
 		super();
 
-		//this.consumeContext(UMB_WORKSPACE_PROPERTY_CONTEXT_TOKEN, (property) => {
+		//this.consumeContext(UMB_WORKSPACE_PROPERTY_CONTEXT, (property) => {
 		//console.log('Got a reference to the editor element', property.getEditor());
 		// Be aware that the element might switch, so using the direct reference is not recommended, instead observe the .element Observable()
 		//});
 
-		this.consumeContext(UMB_NOTIFICATION_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => {
 			this._notificationContext = instance;
 		});
 	}

--- a/src/packages/core/property-editor/uis/collection-view/config/layout-configuration/property-editor-ui-collection-view-layout-configuration.element.ts
+++ b/src/packages/core/property-editor/uis/collection-view/config/layout-configuration/property-editor-ui-collection-view-layout-configuration.element.ts
@@ -4,7 +4,7 @@ import { UUIBooleanInputEvent, UUIInputEvent } from '@umbraco-cms/backoffice/ext
 import { extractUmbColorVariable } from '@umbraco-cms/backoffice/resources';
 import {
 	UMB_ICON_PICKER_MODAL,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UmbModalManagerContext,
 } from '@umbraco-cms/backoffice/modal';
 import {
@@ -40,7 +40,7 @@ export class UmbPropertyEditorUICollectionViewLayoutConfigurationElement
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this._modalContext = instance;
 		});
 	}

--- a/src/packages/core/property-editor/uis/icon-picker/property-editor-ui-icon-picker.element.ts
+++ b/src/packages/core/property-editor/uis/icon-picker/property-editor-ui-icon-picker.element.ts
@@ -3,7 +3,7 @@ import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extension-registry';
 import {
 	UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UMB_ICON_PICKER_MODAL,
 } from '@umbraco-cms/backoffice/modal';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
@@ -48,7 +48,7 @@ export class UmbPropertyEditorUIIconPickerElement extends UmbLitElement implemen
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this._modalContext = instance;
 		});
 	}

--- a/src/packages/core/property-editor/uis/tiny-mce/plugins/tiny-mce-code-editor.plugin.ts
+++ b/src/packages/core/property-editor/uis/tiny-mce/plugins/tiny-mce-code-editor.plugin.ts
@@ -4,7 +4,7 @@ import {
 	UmbCodeEditorModalValue,
 	UMB_CODE_EDITOR_MODAL,
 	UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 } from '@umbraco-cms/backoffice/modal';
 
 export default class UmbTinyMceCodeEditorPlugin extends UmbTinyMcePluginBase {
@@ -13,7 +13,7 @@ export default class UmbTinyMceCodeEditorPlugin extends UmbTinyMcePluginBase {
 	constructor(args: TinyMcePluginArguments) {
 		super(args);
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (modalContext) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (modalContext) => {
 			this.#modalContext = modalContext;
 		});
 

--- a/src/packages/core/property-editor/uis/tiny-mce/plugins/tiny-mce-embeddedmedia.plugin.ts
+++ b/src/packages/core/property-editor/uis/tiny-mce/plugins/tiny-mce-embeddedmedia.plugin.ts
@@ -4,7 +4,7 @@ import {
 	UmbEmbeddedMediaModalValue,
 	UMB_EMBEDDED_MEDIA_MODAL,
 	UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 } from '@umbraco-cms/backoffice/modal';
 
 export default class UmbTinyMceEmbeddedMediaPlugin extends UmbTinyMcePluginBase {
@@ -13,7 +13,7 @@ export default class UmbTinyMceEmbeddedMediaPlugin extends UmbTinyMcePluginBase 
 	constructor(args: TinyMcePluginArguments) {
 		super(args);
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (modalContext) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (modalContext) => {
 			this.#modalContext = modalContext;
 		});
 

--- a/src/packages/core/property-editor/uis/tiny-mce/plugins/tiny-mce-linkpicker.plugin.ts
+++ b/src/packages/core/property-editor/uis/tiny-mce/plugins/tiny-mce-linkpicker.plugin.ts
@@ -4,7 +4,7 @@ import {
 	UMB_LINK_PICKER_MODAL,
 	UmbLinkPickerLink,
 	UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 } from '@umbraco-cms/backoffice/modal';
 
 type AnchorElementAttributes = {
@@ -26,7 +26,7 @@ export default class UmbTinyMceLinkPickerPlugin extends UmbTinyMcePluginBase {
 	constructor(args: TinyMcePluginArguments) {
 		super(args);
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (modalContext) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (modalContext) => {
 			this.#modalContext = modalContext;
 		});
 

--- a/src/packages/core/property-editor/uis/tiny-mce/plugins/tiny-mce-macropicker.plugin.ts
+++ b/src/packages/core/property-editor/uis/tiny-mce/plugins/tiny-mce-macropicker.plugin.ts
@@ -1,10 +1,6 @@
 import { MacroSyntaxData, UmbMacroService } from '@umbraco-cms/backoffice/macro';
 import { TinyMcePluginArguments, UmbTinyMcePluginBase } from '@umbraco-cms/backoffice/components';
-import {
-	UMB_CONFIRM_MODAL,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
-	UmbModalManagerContext,
-} from '@umbraco-cms/backoffice/modal';
+import { UMB_CONFIRM_MODAL, UMB_MODAL_MANAGER_CONTEXT, UmbModalManagerContext } from '@umbraco-cms/backoffice/modal';
 import type { AstNode } from '@umbraco-cms/backoffice/external/tinymce';
 
 interface DialogData {
@@ -23,7 +19,7 @@ export default class UmbTinyMceMacroPickerPlugin extends UmbTinyMcePluginBase {
 	constructor(args: TinyMcePluginArguments) {
 		super(args);
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (modalContext) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (modalContext) => {
 			this.#modalContext = modalContext;
 		});
 

--- a/src/packages/core/property-editor/uis/tiny-mce/plugins/tiny-mce-mediapicker.plugin.ts
+++ b/src/packages/core/property-editor/uis/tiny-mce/plugins/tiny-mce-mediapicker.plugin.ts
@@ -3,7 +3,7 @@ import { UmbMediaHelper } from '@umbraco-cms/backoffice/utils';
 import {
 	UMB_MEDIA_TREE_PICKER_MODAL,
 	UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 } from '@umbraco-cms/backoffice/modal';
 import { UMB_CURRENT_USER_CONTEXT, UmbCurrentUser } from '@umbraco-cms/backoffice/current-user';
 import { RawEditorOptions } from '@umbraco-cms/backoffice/external/tinymce';
@@ -40,7 +40,7 @@ export default class UmbTinyMceMediaPickerPlugin extends UmbTinyMcePluginBase {
 		this.#mediaHelper = new UmbMediaHelper();
 		this.#temporaryFileRepository = new UmbTemporaryFileRepository(args.host);
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (modalContext) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (modalContext) => {
 			this.#modalContext = modalContext;
 		});
 

--- a/src/packages/core/repository/detail/detail-repository-base.ts
+++ b/src/packages/core/repository/detail/detail-repository-base.ts
@@ -2,7 +2,7 @@ import { UmbRepositoryBase } from '../repository-base.js';
 import { UmbDetailDataSource, UmbDetailDataSourceConstructor } from './detail-data-source.interface.js';
 import { UmbDetailRepository } from './detail-repository.interface.js';
 import { type UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
-import { UMB_NOTIFICATION_CONTEXT_TOKEN, UmbNotificationContext } from '@umbraco-cms/backoffice/notification';
+import { UMB_NOTIFICATION_CONTEXT, UmbNotificationContext } from '@umbraco-cms/backoffice/notification';
 import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
 import { UmbDetailStore } from '@umbraco-cms/backoffice/store';
 import { UmbApi } from '@umbraco-cms/backoffice/extension-api';
@@ -33,7 +33,7 @@ export abstract class UmbDetailRepositoryBase<
 				this.#detailStore = instance;
 			}).asPromise(),
 
-			this.consumeContext(UMB_NOTIFICATION_CONTEXT_TOKEN, (instance) => {
+			this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => {
 				this.#notificationContext = instance;
 			}).asPromise(),
 		]);

--- a/src/packages/core/section/section-sidebar-context-menu/section-sidebar-context-menu.element.ts
+++ b/src/packages/core/section/section-sidebar-context-menu/section-sidebar-context-menu.element.ts
@@ -1,4 +1,4 @@
-import { UmbSectionSidebarContext, UMB_SECTION_SIDEBAR_CONTEXT_TOKEN } from '../section-sidebar/index.js';
+import { UmbSectionSidebarContext, UMB_SECTION_SIDEBAR_CONTEXT } from '../section-sidebar/index.js';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { css, html, nothing, customElement, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
@@ -22,7 +22,7 @@ export class UmbSectionSidebarContextMenuElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_SECTION_SIDEBAR_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_SECTION_SIDEBAR_CONTEXT, (instance) => {
 			this.#sectionSidebarContext = instance;
 
 			if (this.#sectionSidebarContext) {

--- a/src/packages/core/section/section-sidebar/section-sidebar.context.ts
+++ b/src/packages/core/section/section-sidebar/section-sidebar.context.ts
@@ -41,6 +41,4 @@ export class UmbSectionSidebarContext {
 	}
 }
 
-export const UMB_SECTION_SIDEBAR_CONTEXT_TOKEN = new UmbContextToken<UmbSectionSidebarContext>(
-	'UmbSectionSidebarContext',
-);
+export const UMB_SECTION_SIDEBAR_CONTEXT = new UmbContextToken<UmbSectionSidebarContext>('UmbSectionSidebarContext');

--- a/src/packages/core/section/section-sidebar/section-sidebar.element.ts
+++ b/src/packages/core/section/section-sidebar/section-sidebar.element.ts
@@ -1,4 +1,4 @@
-import { UmbSectionSidebarContext, UMB_SECTION_SIDEBAR_CONTEXT_TOKEN } from './section-sidebar.context.js';
+import { UmbSectionSidebarContext, UMB_SECTION_SIDEBAR_CONTEXT } from './section-sidebar.context.js';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { css, html, customElement } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
@@ -9,7 +9,7 @@ export class UmbSectionSidebarElement extends UmbLitElement {
 
 	constructor() {
 		super();
-		this.provideContext(UMB_SECTION_SIDEBAR_CONTEXT_TOKEN, this.#sectionSidebarContext);
+		this.provideContext(UMB_SECTION_SIDEBAR_CONTEXT, this.#sectionSidebarContext);
 	}
 
 	render() {

--- a/src/packages/core/section/section.context.ts
+++ b/src/packages/core/section/section.context.ts
@@ -21,4 +21,4 @@ export class UmbSectionContext {
 	}
 }
 
-export const UMB_SECTION_CONTEXT_TOKEN = new UmbContextToken<UmbSectionContext>('UmbSectionContext');
+export const UMB_SECTION_CONTEXT = new UmbContextToken<UmbSectionContext>('UmbSectionContext');

--- a/src/packages/core/themes/theme.context.ts
+++ b/src/packages/core/themes/theme.context.ts
@@ -19,7 +19,7 @@ export class UmbThemeContext extends UmbBaseController {
 	constructor(host: UmbControllerHostElement) {
 		super(host);
 
-		this.provideContext(UMB_THEME_CONTEXT_TOKEN, this);
+		this.provideContext(UMB_THEME_CONTEXT, this);
 
 		const storedTheme = localStorage.getItem(LOCAL_STORAGE_KEY);
 		if (storedTheme) {
@@ -81,7 +81,7 @@ export class UmbThemeContext extends UmbBaseController {
 	}
 }
 
-export const UMB_THEME_CONTEXT_TOKEN = new UmbContextToken<UmbThemeContext>('umbThemeContext');
+export const UMB_THEME_CONTEXT = new UmbContextToken<UmbThemeContext>('umbThemeContext');
 
 // Default export to enable this as a globalContext extension js:
 export default UmbThemeContext;

--- a/src/packages/core/tree/folder/entity-action/create-folder/create-folder.action.ts
+++ b/src/packages/core/tree/folder/entity-action/create-folder/create-folder.action.ts
@@ -1,7 +1,7 @@
 import { UmbEntityActionBase } from '../../../../entity-action/entity-action.js';
 import { UmbContextConsumerController } from '@umbraco-cms/backoffice/context-api';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
-import { type UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/modal';
+import { type UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
 import { type UmbFolderRepository, UMB_FOLDER_CREATE_MODAL } from '@umbraco-cms/backoffice/tree';
 
 export class UmbCreateFolderEntityAction<T extends UmbFolderRepository> extends UmbEntityActionBase<T> {
@@ -10,7 +10,7 @@ export class UmbCreateFolderEntityAction<T extends UmbFolderRepository> extends 
 	constructor(host: UmbControllerHostElement, repositoryAlias: string, unique: string) {
 		super(host, repositoryAlias, unique);
 
-		new UmbContextConsumerController(this._host, UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		new UmbContextConsumerController(this._host, UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalContext = instance;
 		});
 	}

--- a/src/packages/core/tree/folder/entity-action/delete-folder/delete-folder.action.ts
+++ b/src/packages/core/tree/folder/entity-action/delete-folder/delete-folder.action.ts
@@ -1,11 +1,7 @@
 import { UmbEntityActionBase } from '../../../../entity-action/entity-action.js';
 import { UmbContextConsumerController } from '@umbraco-cms/backoffice/context-api';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
-import {
-	UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
-	UMB_CONFIRM_MODAL,
-} from '@umbraco-cms/backoffice/modal';
+import { UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT, UMB_CONFIRM_MODAL } from '@umbraco-cms/backoffice/modal';
 import { UmbFolderRepository } from '@umbraco-cms/backoffice/tree';
 
 export class UmbDeleteFolderEntityAction<T extends UmbFolderRepository> extends UmbEntityActionBase<T> {
@@ -14,7 +10,7 @@ export class UmbDeleteFolderEntityAction<T extends UmbFolderRepository> extends 
 	constructor(host: UmbControllerHostElement, repositoryAlias: string, unique: string) {
 		super(host, repositoryAlias, unique);
 
-		new UmbContextConsumerController(this._host, UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		new UmbContextConsumerController(this._host, UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalContext = instance;
 		});
 	}

--- a/src/packages/core/tree/folder/entity-action/folder-update/folder-update.action.ts
+++ b/src/packages/core/tree/folder/entity-action/folder-update/folder-update.action.ts
@@ -1,7 +1,7 @@
 import { UmbEntityActionBase } from '../../../../entity-action/entity-action.js';
 import { UmbContextConsumerController } from '@umbraco-cms/backoffice/context-api';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
-import { type UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/modal';
+import { type UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
 import { type UmbFolderRepository, UMB_FOLDER_UPDATE_MODAL } from '@umbraco-cms/backoffice/tree';
 
 export class UmbFolderUpdateEntityAction<
@@ -12,7 +12,7 @@ export class UmbFolderUpdateEntityAction<
 	constructor(host: UmbControllerHostElement, repositoryAlias: string, unique: string) {
 		super(host, repositoryAlias, unique);
 
-		new UmbContextConsumerController(this._host, UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		new UmbContextConsumerController(this._host, UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalContext = instance;
 		});
 	}

--- a/src/packages/core/tree/folder/folder-repository-base.ts
+++ b/src/packages/core/tree/folder/folder-repository-base.ts
@@ -6,7 +6,7 @@ import { type UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbTreeItemModelBase, UmbTreeStore } from '@umbraco-cms/backoffice/tree';
 import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
 import { UmbId } from '@umbraco-cms/backoffice/id';
-import { UMB_NOTIFICATION_CONTEXT_TOKEN, UmbNotificationContext } from '@umbraco-cms/backoffice/notification';
+import { UMB_NOTIFICATION_CONTEXT, UmbNotificationContext } from '@umbraco-cms/backoffice/notification';
 
 export type UmbFolderToTreeItemMapper<FolderTreeItemType extends UmbTreeItemModelBase> = (
 	item: UmbFolderModel,
@@ -37,7 +37,7 @@ export abstract class UmbFolderRepositoryBase<FolderTreeItemType extends UmbTree
 				this._treeStore = instance;
 			}).asPromise(),
 
-			this.consumeContext(UMB_NOTIFICATION_CONTEXT_TOKEN, (instance) => {
+			this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => {
 				this.#notificationContext = instance;
 			}).asPromise(),
 		]);

--- a/src/packages/core/tree/tree-item-base/tree-item-base.context.ts
+++ b/src/packages/core/tree/tree-item-base/tree-item-base.context.ts
@@ -2,7 +2,7 @@ import { UmbTreeItemContext } from '../tree-item-default/tree-item.context.inter
 import { UmbTreeContextBase } from '../tree.context.js';
 import { UmbTreeItemModelBase } from '../types.js';
 import { map } from '@umbraco-cms/backoffice/external/rxjs';
-import { UMB_SECTION_CONTEXT_TOKEN, UMB_SECTION_SIDEBAR_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/section';
+import { UMB_SECTION_CONTEXT, UMB_SECTION_SIDEBAR_CONTEXT } from '@umbraco-cms/backoffice/section';
 import type { UmbSectionContext, UmbSectionSidebarContext } from '@umbraco-cms/backoffice/section';
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbBooleanState, UmbDeepState, UmbStringState } from '@umbraco-cms/backoffice/observable-api';
@@ -58,7 +58,7 @@ export class UmbTreeItemContextBase<TreeItemType extends UmbTreeItemModelBase>
 		super(host);
 		this.#getUniqueFunction = getUniqueFunction;
 		this.#consumeContexts();
-		this.provideContext(UMB_TREE_ITEM_CONTEXT_TOKEN, this);
+		this.provideContext(UMB_TREE_ITEM_CONTEXT, this);
 	}
 
 	public setTreeItem(treeItem: TreeItemType | undefined) {
@@ -114,12 +114,12 @@ export class UmbTreeItemContextBase<TreeItemType extends UmbTreeItemModelBase>
 	}
 
 	#consumeContexts() {
-		this.consumeContext(UMB_SECTION_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_SECTION_CONTEXT, (instance) => {
 			this.#sectionContext = instance;
 			this.#observeSectionPath();
 		});
 
-		this.consumeContext(UMB_SECTION_SIDEBAR_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_SECTION_SIDEBAR_CONTEXT, (instance) => {
 			this.#sectionSidebarContext = instance;
 		});
 
@@ -212,4 +212,4 @@ export class UmbTreeItemContextBase<TreeItemType extends UmbTreeItemModelBase>
 	}
 }
 
-export const UMB_TREE_ITEM_CONTEXT_TOKEN = new UmbContextToken<UmbTreeItemContext<any>>('UmbTreeItemContext');
+export const UMB_TREE_ITEM_CONTEXT = new UmbContextToken<UmbTreeItemContext<any>>('UmbTreeItemContext');

--- a/src/packages/core/tree/tree-item-base/tree-item-base.element.ts
+++ b/src/packages/core/tree/tree-item-base/tree-item-base.element.ts
@@ -1,6 +1,6 @@
 import type { UmbTreeItemContext } from '../tree-item-default/index.js';
 import { UmbTreeItemModelBase } from '../types.js';
-import { UMB_TREE_ITEM_CONTEXT_TOKEN } from './tree-item-base.context.js';
+import { UMB_TREE_ITEM_CONTEXT } from './tree-item-base.context.js';
 import { css, html, nothing, customElement, state, ifDefined, repeat } from '@umbraco-cms/backoffice/external/lit';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
@@ -42,7 +42,7 @@ export class UmbTreeItemBaseElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_TREE_ITEM_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_TREE_ITEM_CONTEXT, (instance) => {
 			this.#treeItemContext = instance;
 			if (!this.#treeItemContext) return;
 			// TODO: investigate if we can make an observe decorator

--- a/src/packages/core/workspace/workspace-context/editable-workspace-context-base.ts
+++ b/src/packages/core/workspace/workspace-context/editable-workspace-context-base.ts
@@ -3,7 +3,7 @@ import { type UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbBaseController } from '@umbraco-cms/backoffice/class-api';
 import { UmbBooleanState } from '@umbraco-cms/backoffice/observable-api';
 import { UMB_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/workspace';
-import { UMB_MODAL_CONTEXT_TOKEN, UmbModalContext } from '@umbraco-cms/backoffice/modal';
+import { UMB_MODAL_CONTEXT, UmbModalContext } from '@umbraco-cms/backoffice/modal';
 
 export abstract class UmbEditableWorkspaceContextBase<WorkspaceData>
 	extends UmbBaseController
@@ -21,7 +21,7 @@ export abstract class UmbEditableWorkspaceContextBase<WorkspaceData>
 		super(host);
 		this.workspaceAlias = workspaceAlias;
 		this.provideContext(UMB_WORKSPACE_CONTEXT, this);
-		this.consumeContext(UMB_MODAL_CONTEXT_TOKEN, (context) => {
+		this.consumeContext(UMB_MODAL_CONTEXT, (context) => {
 			(this.modalContext as UmbModalContext) = context;
 		});
 	}

--- a/src/packages/core/workspace/workspace-context/entity-manager-controller.ts
+++ b/src/packages/core/workspace/workspace-context/entity-manager-controller.ts
@@ -4,7 +4,7 @@ import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api
 import {
 	UmbNotificationDefaultData,
 	UmbNotificationContext,
-	UMB_NOTIFICATION_CONTEXT_TOKEN,
+	UMB_NOTIFICATION_CONTEXT,
 } from '@umbraco-cms/backoffice/notification';
 import { UmbObjectState, UmbObserverController } from '@umbraco-cms/backoffice/observable-api';
 import { UmbEntityDetailStore } from '@umbraco-cms/backoffice/store';
@@ -35,7 +35,7 @@ export class UmbEntityWorkspaceManager<
 		this._host = host;
 		this._entityType = entityType;
 
-		new UmbContextConsumerController(this._host, UMB_NOTIFICATION_CONTEXT_TOKEN, (_instance) => {
+		new UmbContextConsumerController(this._host, UMB_NOTIFICATION_CONTEXT, (_instance) => {
 			this._notificationContext = _instance;
 		});
 

--- a/src/packages/core/workspace/workspace-context/variant-workspace-context.token.ts
+++ b/src/packages/core/workspace/workspace-context/variant-workspace-context.token.ts
@@ -2,7 +2,7 @@ import type { UmbWorkspaceContextInterface } from './workspace-context.interface
 import type { UmbVariantableWorkspaceContextInterface } from './workspace-variantable-context.interface.js';
 import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
 
-export const UMB_VARIANT_WORKSPACE_CONTEXT_TOKEN = new UmbContextToken<
+export const UMB_VARIANT_WORKSPACE_CONTEXT = new UmbContextToken<
 	UmbWorkspaceContextInterface,
 	UmbVariantableWorkspaceContextInterface
 >(

--- a/src/packages/core/workspace/workspace-footer/workspace-footer.element.ts
+++ b/src/packages/core/workspace/workspace-footer/workspace-footer.element.ts
@@ -3,7 +3,7 @@ import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { css, html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
 
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
-import { UMB_MODAL_CONTEXT_TOKEN, UmbModalContext } from '@umbraco-cms/backoffice/modal';
+import { UMB_MODAL_CONTEXT, UmbModalContext } from '@umbraco-cms/backoffice/modal';
 
 /**
  * @element umb-workspace-footer
@@ -31,7 +31,7 @@ export class UmbWorkspaceFooterLayoutElement extends UmbLitElement {
 		this.consumeContext(UMB_SAVEABLE_WORKSPACE_CONTEXT, (context) => {
 			this._isNew = context.getIsNew();
 		});
-		this.consumeContext(UMB_MODAL_CONTEXT_TOKEN, (context) => {
+		this.consumeContext(UMB_MODAL_CONTEXT, (context) => {
 			this._modalContext = context;
 		});
 	}

--- a/src/packages/core/workspace/workspace-split-view/workspace-split-view.context.ts
+++ b/src/packages/core/workspace/workspace-split-view/workspace-split-view.context.ts
@@ -1,5 +1,5 @@
 import { UmbPropertyDatasetContext } from '../../property/property-dataset/index.js';
-import { UMB_VARIANT_WORKSPACE_CONTEXT_TOKEN } from '../index.js';
+import { UMB_VARIANT_WORKSPACE_CONTEXT } from '../index.js';
 import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
 import { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
@@ -7,7 +7,7 @@ import { UmbBaseController } from '@umbraco-cms/backoffice/class-api';
 import { UmbNumberState } from '@umbraco-cms/backoffice/observable-api';
 
 export class UmbWorkspaceSplitViewContext extends UmbBaseController {
-	#workspaceContext?: typeof UMB_VARIANT_WORKSPACE_CONTEXT_TOKEN.TYPE;
+	#workspaceContext?: typeof UMB_VARIANT_WORKSPACE_CONTEXT.TYPE;
 	public getWorkspaceContext() {
 		return this.#workspaceContext;
 	}
@@ -23,7 +23,7 @@ export class UmbWorkspaceSplitViewContext extends UmbBaseController {
 	constructor(host: UmbControllerHost) {
 		super(host);
 
-		this.consumeContext(UMB_VARIANT_WORKSPACE_CONTEXT_TOKEN, (context) => {
+		this.consumeContext(UMB_VARIANT_WORKSPACE_CONTEXT, (context) => {
 			this.#workspaceContext = context;
 			this._observeVariant();
 		});

--- a/src/packages/dictionary/dictionary/entity-actions/export/export.action.ts
+++ b/src/packages/dictionary/dictionary/entity-actions/export/export.action.ts
@@ -4,7 +4,7 @@ import { UmbEntityActionBase } from '@umbraco-cms/backoffice/entity-action';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
 import {
 	UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UMB_EXPORT_DICTIONARY_MODAL,
 } from '@umbraco-cms/backoffice/modal';
 
@@ -16,7 +16,7 @@ export default class UmbExportDictionaryEntityAction extends UmbEntityActionBase
 	constructor(host: UmbControllerHostElement, repositoryAlias: string, unique: string) {
 		super(host, repositoryAlias, unique);
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalContext = instance;
 		});
 	}

--- a/src/packages/dictionary/dictionary/entity-actions/import/import.action.ts
+++ b/src/packages/dictionary/dictionary/entity-actions/import/import.action.ts
@@ -4,7 +4,7 @@ import { UmbEntityActionBase } from '@umbraco-cms/backoffice/entity-action';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
 import {
 	UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UMB_IMPORT_DICTIONARY_MODAL,
 } from '@umbraco-cms/backoffice/modal';
 import { UMB_DICTIONARY_TREE_STORE_CONTEXT, UmbDictionaryTreeStore } from '@umbraco-cms/backoffice/dictionary';
@@ -18,7 +18,7 @@ export default class UmbImportDictionaryEntityAction extends UmbEntityActionBase
 	constructor(host: UmbControllerHostElement, repositoryAlias: string, unique: string) {
 		super(host, repositoryAlias, unique);
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalContext = instance;
 		});
 		this.consumeContext(UMB_DICTIONARY_TREE_STORE_CONTEXT, (instance) => {

--- a/src/packages/dictionary/dictionary/repository/dictionary.repository.ts
+++ b/src/packages/dictionary/dictionary/repository/dictionary.repository.ts
@@ -1,5 +1,5 @@
 import { type UmbDictionaryTreeStore, UMB_DICTIONARY_TREE_STORE_CONTEXT } from '../tree/index.js';
-import { UmbDictionaryStore, UMB_DICTIONARY_STORE_CONTEXT_TOKEN } from './dictionary.store.js';
+import { UmbDictionaryStore, UMB_DICTIONARY_STORE_CONTEXT } from './dictionary.store.js';
 import { UmbDictionaryDetailServerDataSource } from './sources/dictionary-detail.server.data-source.js';
 import { type UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbBaseController } from '@umbraco-cms/backoffice/class-api';
@@ -7,7 +7,7 @@ import type {
 	CreateDictionaryItemRequestModel,
 	UpdateDictionaryItemRequestModel,
 } from '@umbraco-cms/backoffice/backend-api';
-import { type UmbNotificationContext, UMB_NOTIFICATION_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/notification';
+import { type UmbNotificationContext, UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
 import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
 import { UmbTemporaryFileRepository } from '@umbraco-cms/backoffice/temporary-file';
 
@@ -27,7 +27,7 @@ export class UmbDictionaryRepository extends UmbBaseController implements UmbApi
 		super(host);
 
 		this.#init = Promise.all([
-			this.consumeContext(UMB_DICTIONARY_STORE_CONTEXT_TOKEN, (instance) => {
+			this.consumeContext(UMB_DICTIONARY_STORE_CONTEXT, (instance) => {
 				this.#detailStore = instance;
 			}),
 
@@ -35,7 +35,7 @@ export class UmbDictionaryRepository extends UmbBaseController implements UmbApi
 				this.#treeStore = instance;
 			}),
 
-			this.consumeContext(UMB_NOTIFICATION_CONTEXT_TOKEN, (instance) => {
+			this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => {
 				this.#notificationContext = instance;
 			}),
 		]);

--- a/src/packages/dictionary/dictionary/repository/dictionary.store.ts
+++ b/src/packages/dictionary/dictionary/repository/dictionary.store.ts
@@ -14,7 +14,7 @@ export class UmbDictionaryStore extends UmbStoreBase {
 	constructor(host: UmbControllerHostElement) {
 		super(
 			host,
-			UMB_DICTIONARY_STORE_CONTEXT_TOKEN.toString(),
+			UMB_DICTIONARY_STORE_CONTEXT.toString(),
 			new UmbArrayState<DictionaryItemResponseModel>([], (x) => x.id),
 		);
 	}
@@ -37,4 +37,4 @@ export class UmbDictionaryStore extends UmbStoreBase {
 	}
 }
 
-export const UMB_DICTIONARY_STORE_CONTEXT_TOKEN = new UmbContextToken<UmbDictionaryStore>('UmbDictionaryStore');
+export const UMB_DICTIONARY_STORE_CONTEXT = new UmbContextToken<UmbDictionaryStore>('UmbDictionaryStore');

--- a/src/packages/documents/dashboards/redirect-management/dashboard-redirect-management.element.ts
+++ b/src/packages/documents/dashboards/redirect-management/dashboard-redirect-management.element.ts
@@ -1,10 +1,6 @@
 import { UUIButtonState, UUIPaginationElement, UUIPaginationEvent } from '@umbraco-cms/backoffice/external/uui';
 import { css, html, nothing, customElement, state, query, property } from '@umbraco-cms/backoffice/external/lit';
-import {
-	UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
-	UMB_CONFIRM_MODAL,
-} from '@umbraco-cms/backoffice/modal';
+import { UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT, UMB_CONFIRM_MODAL } from '@umbraco-cms/backoffice/modal';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 import {
 	RedirectManagementResource,
@@ -47,7 +43,7 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (_instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (_instance) => {
 			this._modalContext = _instance;
 		});
 	}

--- a/src/packages/documents/document-blueprints/document-blueprint.detail.store.ts
+++ b/src/packages/documents/document-blueprints/document-blueprint.detail.store.ts
@@ -14,7 +14,7 @@ export class UmbDocumentBlueprintStore extends UmbStoreBase {
 	constructor(host: UmbControllerHostElement) {
 		super(
 			host,
-			UMB_DOCUMENT_BLUEPRINT_STORE_CONTEXT_TOKEN.toString(),
+			UMB_DOCUMENT_BLUEPRINT_STORE_CONTEXT.toString(),
 			// TODO: use the right type:
 
 			new UmbArrayState<DocumentBlueprintDetails>([], (x) => x.id),
@@ -96,6 +96,6 @@ export class UmbDocumentBlueprintStore extends UmbStoreBase {
 	}
 }
 
-export const UMB_DOCUMENT_BLUEPRINT_STORE_CONTEXT_TOKEN = new UmbContextToken<UmbDocumentBlueprintStore>(
+export const UMB_DOCUMENT_BLUEPRINT_STORE_CONTEXT = new UmbContextToken<UmbDocumentBlueprintStore>(
 	'UmbDocumentBlueprintStore',
 );

--- a/src/packages/documents/document-blueprints/document-blueprint.tree.store.ts
+++ b/src/packages/documents/document-blueprints/document-blueprint.tree.store.ts
@@ -2,7 +2,7 @@ import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
 import { UmbEntityTreeStore } from '@umbraco-cms/backoffice/tree';
 import type { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
 
-export const UMB_DOCUMENT_BLUEPRINT_TREE_STORE_CONTEXT_TOKEN = new UmbContextToken<UmbDocumentBlueprintTreeStore>(
+export const UMB_DOCUMENT_BLUEPRINT_TREE_STORE_CONTEXT = new UmbContextToken<UmbDocumentBlueprintTreeStore>(
 	'UmbDocumentBlueprintTreeStore',
 );
 
@@ -14,6 +14,6 @@ export const UMB_DOCUMENT_BLUEPRINT_TREE_STORE_CONTEXT_TOKEN = new UmbContextTok
  */
 export class UmbDocumentBlueprintTreeStore extends UmbEntityTreeStore {
 	constructor(host: UmbControllerHostElement) {
-		super(host, UMB_DOCUMENT_BLUEPRINT_TREE_STORE_CONTEXT_TOKEN.toString());
+		super(host, UMB_DOCUMENT_BLUEPRINT_TREE_STORE_CONTEXT.toString());
 	}
 }

--- a/src/packages/documents/document-types/entity-actions/create/create.action.ts
+++ b/src/packages/documents/document-types/entity-actions/create/create.action.ts
@@ -2,7 +2,7 @@ import { UmbDocumentTypeDetailRepository } from '../../repository/detail/documen
 import { UMB_DOCUMENT_TYPE_CREATE_OPTIONS_MODAL } from './modal/index.js';
 import { UmbEntityActionBase } from '@umbraco-cms/backoffice/entity-action';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
-import { UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/modal';
+import { UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
 
 export class UmbCreateDataTypeEntityAction extends UmbEntityActionBase<UmbDocumentTypeDetailRepository> {
 	#modalManagerContext?: UmbModalManagerContext;
@@ -10,7 +10,7 @@ export class UmbCreateDataTypeEntityAction extends UmbEntityActionBase<UmbDocume
 	constructor(host: UmbControllerHostElement, repositoryAlias: string, unique: string) {
 		super(host, repositoryAlias, unique);
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalManagerContext = instance;
 		});
 	}

--- a/src/packages/documents/document-types/workspace/document-type-workspace-editor.element.ts
+++ b/src/packages/documents/document-types/workspace/document-type-workspace-editor.element.ts
@@ -4,7 +4,7 @@ import { css, html, customElement, state, ifDefined } from '@umbraco-cms/backoff
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 import {
 	UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UMB_ICON_PICKER_MODAL,
 } from '@umbraco-cms/backoffice/modal';
 import { generateAlias } from '@umbraco-cms/backoffice/utils';
@@ -38,7 +38,7 @@ export class UmbDocumentTypeWorkspaceEditorElement extends UmbLitElement {
 			this.#observeDocumentType();
 		});
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this._modalContext = instance;
 		});
 	}

--- a/src/packages/documents/document-types/workspace/views/design/document-type-workspace-view-edit-property.element.ts
+++ b/src/packages/documents/document-types/workspace/views/design/document-type-workspace-view-edit-property.element.ts
@@ -4,7 +4,7 @@ import { css, html, customElement, property, state, ifDefined, nothing } from '@
 import { PropertyTypeModelBaseModel } from '@umbraco-cms/backoffice/backend-api';
 import {
 	UMB_CONFIRM_MODAL,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UMB_PROPERTY_SETTINGS_MODAL,
 	UMB_WORKSPACE_MODAL,
 	UmbConfirmModalData,
@@ -56,7 +56,7 @@ export class UmbDocumentTypeWorkspacePropertyElement extends UmbLitElement {
 	#dataTypeDetailRepository = new UmbDataTypeDetailRepository(this);
 
 	#modalRegistration;
-	private _modalManagerContext?: typeof UMB_MODAL_MANAGER_CONTEXT_TOKEN.TYPE;
+	private _modalManagerContext?: typeof UMB_MODAL_MANAGER_CONTEXT.TYPE;
 
 	@state()
 	protected _modalRoute?: string;
@@ -110,7 +110,7 @@ export class UmbDocumentTypeWorkspacePropertyElement extends UmbLitElement {
 				this._editDocumentTypePath = routeBuilder({});
 			});
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (context) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (context) => {
 			this._modalManagerContext = context;
 		});
 	}

--- a/src/packages/documents/document-types/workspace/views/design/document-type-workspace-view-edit.element.ts
+++ b/src/packages/documents/document-types/workspace/views/design/document-type-workspace-view-edit.element.ts
@@ -13,7 +13,7 @@ import {
 import { UMB_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/workspace';
 import type { UmbRoute } from '@umbraco-cms/backoffice/router';
 import { UmbWorkspaceViewElement } from '@umbraco-cms/backoffice/extension-registry';
-import { UMB_CONFIRM_MODAL, UMB_MODAL_MANAGER_CONTEXT_TOKEN, UmbConfirmModalData } from '@umbraco-cms/backoffice/modal';
+import { UMB_CONFIRM_MODAL, UMB_MODAL_MANAGER_CONTEXT, UmbConfirmModalData } from '@umbraco-cms/backoffice/modal';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { UmbSorterConfig, UmbSorterController } from '@umbraco-cms/backoffice/sorter';
 
@@ -88,7 +88,7 @@ export class UmbDocumentTypeWorkspaceViewEditElement extends UmbLitElement imple
 
 	private _tabsStructureHelper = new UmbContentTypeContainerStructureHelper<UmbDocumentTypeDetailModel>(this);
 
-	private _modalManagerContext?: typeof UMB_MODAL_MANAGER_CONTEXT_TOKEN.TYPE;
+	private _modalManagerContext?: typeof UMB_MODAL_MANAGER_CONTEXT.TYPE;
 
 	constructor() {
 		super();
@@ -116,7 +116,7 @@ export class UmbDocumentTypeWorkspaceViewEditElement extends UmbLitElement imple
 			this._observeRootGroups();
 		});
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (context) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (context) => {
 			this._modalManagerContext = context;
 		});
 	}

--- a/src/packages/documents/documents/components/input-document-granular-permission/input-document-granular-permission.element.ts
+++ b/src/packages/documents/documents/components/input-document-granular-permission/input-document-granular-permission.element.ts
@@ -2,7 +2,7 @@ import { css, html, customElement, property, state, PropertyValueMap } from '@um
 import { FormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import {
 	UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UMB_CONFIRM_MODAL,
 	UMB_DOCUMENT_PICKER_MODAL,
 } from '@umbraco-cms/backoffice/modal';
@@ -41,7 +41,7 @@ export class UmbInputDocumentGranularPermissionElement extends FormControlMixin(
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => (this.#modalContext = instance));
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => (this.#modalContext = instance));
 	}
 
 	protected firstUpdated(_changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>): void {

--- a/src/packages/documents/documents/entity-actions/create/create.action.ts
+++ b/src/packages/documents/documents/entity-actions/create/create.action.ts
@@ -3,7 +3,7 @@ import { UmbEntityActionBase } from '@umbraco-cms/backoffice/entity-action';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
 import {
 	UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UMB_CREATE_DOCUMENT_MODAL as UMB_CREATE_DOCUMENT_MODAL,
 } from '@umbraco-cms/backoffice/modal';
 
@@ -13,7 +13,7 @@ export class UmbCreateDocumentEntityAction extends UmbEntityActionBase<UmbDocume
 	constructor(host: UmbControllerHostElement, repositoryAlias: string, unique: string) {
 		super(host, repositoryAlias, unique);
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalContext = instance;
 		});
 	}

--- a/src/packages/documents/documents/entity-actions/permissions/permissions-modal.element.ts
+++ b/src/packages/documents/documents/entity-actions/permissions/permissions-modal.element.ts
@@ -5,7 +5,7 @@ import { html, customElement, property, state, ifDefined, nothing } from '@umbra
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import {
 	UMB_ENTITY_USER_PERMISSION_MODAL,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UMB_USER_GROUP_PICKER_MODAL,
 	UmbEntityUserPermissionSettingsModalData,
 	UmbEntityUserPermissionSettingsModalValue,
@@ -54,7 +54,7 @@ export class UmbPermissionsModalElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalManagerContext = instance;
 		});
 	}

--- a/src/packages/documents/documents/entity-actions/permissions/permissions.action.ts
+++ b/src/packages/documents/documents/entity-actions/permissions/permissions.action.ts
@@ -2,7 +2,7 @@ import { type UmbDocumentRepository } from '../../repository/document.repository
 import { UmbEntityActionBase } from '@umbraco-cms/backoffice/entity-action';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
 import {
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UmbModalManagerContext,
 	UMB_PERMISSIONS_MODAL,
 } from '@umbraco-cms/backoffice/modal';
@@ -13,7 +13,7 @@ export class UmbDocumentPermissionsEntityAction extends UmbEntityActionBase<UmbD
 	constructor(host: UmbControllerHostElement, repositoryAlias: string, unique: string) {
 		super(host, repositoryAlias, unique);
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalManagerContext = instance;
 		});
 	}

--- a/src/packages/documents/documents/repository/document-item.store.ts
+++ b/src/packages/documents/documents/repository/document-item.store.ts
@@ -18,8 +18,8 @@ export class UmbDocumentItemStore extends UmbEntityItemStore<DocumentItemRespons
 	 * @memberof UmbDocumentItemStore
 	 */
 	constructor(host: UmbControllerHostElement) {
-		super(host, UMB_DOCUMENT_ITEM_STORE_CONTEXT_TOKEN.toString());
+		super(host, UMB_DOCUMENT_ITEM_STORE_CONTEXT.toString());
 	}
 }
 
-export const UMB_DOCUMENT_ITEM_STORE_CONTEXT_TOKEN = new UmbContextToken<UmbDocumentItemStore>('UmbDocumentItemStore');
+export const UMB_DOCUMENT_ITEM_STORE_CONTEXT = new UmbContextToken<UmbDocumentItemStore>('UmbDocumentItemStore');

--- a/src/packages/documents/documents/repository/document.repository.ts
+++ b/src/packages/documents/documents/repository/document.repository.ts
@@ -1,12 +1,12 @@
 import { UmbDocumentTreeStore, UMB_DOCUMENT_TREE_STORE_CONTEXT } from '../tree/document-tree.store.js';
 import { UmbDocumentServerDataSource } from './sources/document.server.data.js';
-import { UmbDocumentStore, UMB_DOCUMENT_STORE_CONTEXT_TOKEN } from './document.store.js';
-import { UMB_DOCUMENT_ITEM_STORE_CONTEXT_TOKEN, type UmbDocumentItemStore } from './document-item.store.js';
+import { UmbDocumentStore, UMB_DOCUMENT_STORE_CONTEXT } from './document.store.js';
+import { UMB_DOCUMENT_ITEM_STORE_CONTEXT, type UmbDocumentItemStore } from './document-item.store.js';
 import { UmbDocumentItemServerDataSource } from './sources/document-item.server.data.js';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbBaseController } from '@umbraco-cms/backoffice/class-api';
 import { CreateDocumentRequestModel, UpdateDocumentRequestModel } from '@umbraco-cms/backoffice/backend-api';
-import { UmbNotificationContext, UMB_NOTIFICATION_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/notification';
+import { UmbNotificationContext, UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
 import { UmbApi } from '@umbraco-cms/backoffice/extension-api';
 import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 
@@ -35,15 +35,15 @@ export class UmbDocumentRepository extends UmbBaseController implements UmbApi {
 				this.#treeStore = instance;
 			}).asPromise(),
 
-			this.consumeContext(UMB_DOCUMENT_STORE_CONTEXT_TOKEN, (instance) => {
+			this.consumeContext(UMB_DOCUMENT_STORE_CONTEXT, (instance) => {
 				this.#store = instance;
 			}).asPromise(),
 
-			this.consumeContext(UMB_DOCUMENT_ITEM_STORE_CONTEXT_TOKEN, (instance) => {
+			this.consumeContext(UMB_DOCUMENT_ITEM_STORE_CONTEXT, (instance) => {
 				this.#itemStore = instance;
 			}).asPromise(),
 
-			this.consumeContext(UMB_NOTIFICATION_CONTEXT_TOKEN, (instance) => {
+			this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => {
 				this.#notificationContext = instance;
 			}).asPromise(),
 		]);

--- a/src/packages/documents/documents/repository/document.store.ts
+++ b/src/packages/documents/documents/repository/document.store.ts
@@ -17,7 +17,7 @@ export class UmbDocumentStore extends UmbStoreBase {
 	 * @memberof UmbDocumentDetailStore
 	 */
 	constructor(host: UmbControllerHostElement) {
-		super(host, UMB_DOCUMENT_STORE_CONTEXT_TOKEN.toString(), new UmbArrayState<DocumentResponseModel>([], (x) => x.id));
+		super(host, UMB_DOCUMENT_STORE_CONTEXT.toString(), new UmbArrayState<DocumentResponseModel>([], (x) => x.id));
 	}
 
 	/**
@@ -30,4 +30,4 @@ export class UmbDocumentStore extends UmbStoreBase {
 	}
 }
 
-export const UMB_DOCUMENT_STORE_CONTEXT_TOKEN = new UmbContextToken<UmbDocumentStore>('UmbDocumentStore');
+export const UMB_DOCUMENT_STORE_CONTEXT = new UmbContextToken<UmbDocumentStore>('UmbDocumentStore');

--- a/src/packages/health-check/dashboard-health-check.element.ts
+++ b/src/packages/health-check/dashboard-health-check.element.ts
@@ -1,8 +1,5 @@
 import { UmbDashboardHealthCheckGroupElement } from './views/health-check-group.element.js';
-import {
-	UmbHealthCheckDashboardContext,
-	UMB_HEALTHCHECK_DASHBOARD_CONTEXT_TOKEN,
-} from './health-check-dashboard.context.js';
+import { UmbHealthCheckDashboardContext, UMB_HEALTHCHECK_DASHBOARD_CONTEXT } from './health-check-dashboard.context.js';
 import { UmbHealthCheckContext } from './health-check.context.js';
 import { html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
 import { HealthCheckGroupResponseModel, HealthCheckResource } from '@umbraco-cms/backoffice/backend-api';
@@ -33,7 +30,7 @@ export class UmbDashboardHealthCheckElement extends UmbLitElement {
 
 	constructor() {
 		super();
-		this.provideContext(UMB_HEALTHCHECK_DASHBOARD_CONTEXT_TOKEN, this._healthCheckDashboardContext);
+		this.provideContext(UMB_HEALTHCHECK_DASHBOARD_CONTEXT, this._healthCheckDashboardContext);
 
 		this.observe(umbExtensionsRegistry.extensionsOfType('healthCheck'), (healthCheckManifests) => {
 			this._healthCheckDashboardContext.manifests = healthCheckManifests;

--- a/src/packages/health-check/health-check-dashboard.context.ts
+++ b/src/packages/health-check/health-check-dashboard.context.ts
@@ -34,6 +34,6 @@ export class UmbHealthCheckDashboardContext {
 	}
 }
 
-export const UMB_HEALTHCHECK_DASHBOARD_CONTEXT_TOKEN = new UmbContextToken<UmbHealthCheckDashboardContext>(
+export const UMB_HEALTHCHECK_DASHBOARD_CONTEXT = new UmbContextToken<UmbHealthCheckDashboardContext>(
 	'UmbHealthCheckDashboardContext',
 );

--- a/src/packages/health-check/health-check.context.ts
+++ b/src/packages/health-check/health-check.context.ts
@@ -45,4 +45,4 @@ export class UmbHealthCheckContext {
 	}
 }
 
-export const UMB_HEALTHCHECK_CONTEXT_TOKEN = new UmbContextToken<UmbHealthCheckContext>('UmbHealthCheckContext');
+export const UMB_HEALTHCHECK_CONTEXT = new UmbContextToken<UmbHealthCheckContext>('UmbHealthCheckContext');

--- a/src/packages/health-check/views/health-check-group-box-overview.element.ts
+++ b/src/packages/health-check/views/health-check-group-box-overview.element.ts
@@ -1,6 +1,6 @@
 import { UmbHealthCheckContext } from '../health-check.context.js';
 import {
-	UMB_HEALTHCHECK_DASHBOARD_CONTEXT_TOKEN,
+	UMB_HEALTHCHECK_DASHBOARD_CONTEXT,
 	UmbHealthCheckDashboardContext,
 } from '../health-check-dashboard.context.js';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
@@ -28,7 +28,7 @@ export class UmbHealthCheckGroupBoxOverviewElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_HEALTHCHECK_DASHBOARD_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_HEALTHCHECK_DASHBOARD_CONTEXT, (instance) => {
 			this._healthCheckContext = instance;
 			if (!this._healthCheckContext || !this.manifest?.meta.label) return;
 			this._api = this._healthCheckContext?.apis.get(this.manifest?.meta.label);

--- a/src/packages/health-check/views/health-check-group.element.ts
+++ b/src/packages/health-check/views/health-check-group.element.ts
@@ -1,7 +1,7 @@
 import { UmbHealthCheckContext } from '../health-check.context.js';
 import {
 	UmbHealthCheckDashboardContext,
-	UMB_HEALTHCHECK_DASHBOARD_CONTEXT_TOKEN,
+	UMB_HEALTHCHECK_DASHBOARD_CONTEXT,
 } from '../health-check-dashboard.context.js';
 import { UUIButtonState } from '@umbraco-cms/backoffice/external/uui';
 import { css, html, nothing, customElement, property, state, unsafeHTML } from '@umbraco-cms/backoffice/external/lit';
@@ -42,7 +42,7 @@ export class UmbDashboardHealthCheckGroupElement extends UmbLitElement {
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_HEALTHCHECK_DASHBOARD_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_HEALTHCHECK_DASHBOARD_CONTEXT, (instance) => {
 			this._healthCheckContext = instance;
 
 			this._api = this._healthCheckContext?.apis.get(this.groupName);

--- a/src/packages/health-check/views/health-check-overview.element.ts
+++ b/src/packages/health-check/views/health-check-overview.element.ts
@@ -1,6 +1,6 @@
 import {
 	UmbHealthCheckDashboardContext,
-	UMB_HEALTHCHECK_DASHBOARD_CONTEXT_TOKEN,
+	UMB_HEALTHCHECK_DASHBOARD_CONTEXT,
 } from '../health-check-dashboard.context.js';
 import { UUIButtonState } from '@umbraco-cms/backoffice/external/uui';
 import { css, html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
@@ -19,7 +19,7 @@ export class UmbDashboardHealthCheckOverviewElement extends UmbLitElement {
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_HEALTHCHECK_DASHBOARD_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_HEALTHCHECK_DASHBOARD_CONTEXT, (instance) => {
 			this._healthCheckDashboardContext = instance;
 		});
 	}

--- a/src/packages/log-viewer/components/log-viewer-date-range-selector.element.ts
+++ b/src/packages/log-viewer/components/log-viewer-date-range-selector.element.ts
@@ -1,7 +1,7 @@
 import {
 	LogViewerDateRange,
 	UmbLogViewerWorkspaceContext,
-	UMB_APP_LOG_VIEWER_CONTEXT_TOKEN,
+	UMB_APP_LOG_VIEWER_CONTEXT,
 } from '../workspace/logviewer.context.js';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { css, html, customElement, property, queryAll, state } from '@umbraco-cms/backoffice/external/lit';
@@ -27,7 +27,7 @@ export class UmbLogViewerDateRangeSelectorElement extends UmbLitElement {
 	constructor() {
 		super();
 		this.addEventListener('input', this.#setDates);
-		this.consumeContext(UMB_APP_LOG_VIEWER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_APP_LOG_VIEWER_CONTEXT, (instance) => {
 			this.#logViewerContext = instance;
 			this.#observeStuff();
 		});

--- a/src/packages/log-viewer/repository/log-viewer.repository.ts
+++ b/src/packages/log-viewer/repository/log-viewer.repository.ts
@@ -1,7 +1,7 @@
 import { UmbLogMessagesServerDataSource, UmbLogSearchesServerDataSource } from './sources/log-viewer.server.data.js';
 import { UmbContextConsumerController } from '@umbraco-cms/backoffice/context-api';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
-import { UmbNotificationContext, UMB_NOTIFICATION_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/notification';
+import { UmbNotificationContext, UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
 import { DirectionModel, LogLevelModel, SavedLogSearchPresenationBaseModel } from '@umbraco-cms/backoffice/backend-api';
 
 // Move to documentation / JSdoc
@@ -20,7 +20,7 @@ export class UmbLogViewerRepository {
 		this.#searchDataSource = new UmbLogSearchesServerDataSource(this.#host);
 		this.#messagesDataSource = new UmbLogMessagesServerDataSource(this.#host);
 
-		this.#init = new UmbContextConsumerController(this.#host, UMB_NOTIFICATION_CONTEXT_TOKEN, (instance) => {
+		this.#init = new UmbContextConsumerController(this.#host, UMB_NOTIFICATION_CONTEXT, (instance) => {
 			this.#notificationService = instance;
 		}).asPromise();
 	}

--- a/src/packages/log-viewer/workspace/logviewer.context.ts
+++ b/src/packages/log-viewer/workspace/logviewer.context.ts
@@ -111,7 +111,7 @@ export class UmbLogViewerWorkspaceContext extends UmbBaseController implements U
 		super(host);
 		this.provideContext(UMB_WORKSPACE_CONTEXT, this);
 		// TODO: Revisit usage of workspace for this case... currently no other workspace context provides them self with their own token.
-		this.provideContext(UMB_APP_LOG_VIEWER_CONTEXT_TOKEN, this);
+		this.provideContext(UMB_APP_LOG_VIEWER_CONTEXT, this);
 		this.#repository = new UmbLogViewerRepository(host);
 	}
 
@@ -327,6 +327,6 @@ export class UmbLogViewerWorkspaceContext extends UmbBaseController implements U
 	}
 }
 
-export const UMB_APP_LOG_VIEWER_CONTEXT_TOKEN = new UmbContextToken<UmbLogViewerWorkspaceContext>(
+export const UMB_APP_LOG_VIEWER_CONTEXT = new UmbContextToken<UmbLogViewerWorkspaceContext>(
 	UmbLogViewerWorkspaceContext.name,
 );

--- a/src/packages/log-viewer/workspace/views/overview/components/log-viewer-log-level-overview.element.ts
+++ b/src/packages/log-viewer/workspace/views/overview/components/log-viewer-log-level-overview.element.ts
@@ -1,4 +1,4 @@
-import { UmbLogViewerWorkspaceContext, UMB_APP_LOG_VIEWER_CONTEXT_TOKEN } from '../../../logviewer.context.js';
+import { UmbLogViewerWorkspaceContext, UMB_APP_LOG_VIEWER_CONTEXT } from '../../../logviewer.context.js';
 import { html, nothing, customElement, property, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 import { LoggerResponseModel } from '@umbraco-cms/backoffice/backend-api';
@@ -9,7 +9,7 @@ export class UmbLogViewerLogLevelOverviewElement extends UmbLitElement {
 	#logViewerContext?: UmbLogViewerWorkspaceContext;
 	constructor() {
 		super();
-		this.consumeContext(UMB_APP_LOG_VIEWER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_APP_LOG_VIEWER_CONTEXT, (instance) => {
 			this.#logViewerContext = instance;
 			this.#logViewerContext?.getSavedSearches();
 			this.#observeLogLevels();

--- a/src/packages/log-viewer/workspace/views/overview/components/log-viewer-log-types-chart.element.ts
+++ b/src/packages/log-viewer/workspace/views/overview/components/log-viewer-log-types-chart.element.ts
@@ -1,4 +1,4 @@
-import { UmbLogViewerWorkspaceContext, UMB_APP_LOG_VIEWER_CONTEXT_TOKEN } from '../../../logviewer.context.js';
+import { UmbLogViewerWorkspaceContext, UMB_APP_LOG_VIEWER_CONTEXT } from '../../../logviewer.context.js';
 import { css, html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 import { LogLevelCountsReponseModel } from '@umbraco-cms/backoffice/backend-api';
@@ -8,7 +8,7 @@ export class UmbLogViewerLogTypesChartElement extends UmbLitElement {
 	#logViewerContext?: UmbLogViewerWorkspaceContext;
 	constructor() {
 		super();
-		this.consumeContext(UMB_APP_LOG_VIEWER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_APP_LOG_VIEWER_CONTEXT, (instance) => {
 			this.#logViewerContext = instance;
 			this.#logViewerContext?.getLogCount();
 			this.#observeStuff();

--- a/src/packages/log-viewer/workspace/views/overview/components/log-viewer-message-templates-overview.element.ts
+++ b/src/packages/log-viewer/workspace/views/overview/components/log-viewer-message-templates-overview.element.ts
@@ -1,4 +1,4 @@
-import { UmbLogViewerWorkspaceContext, UMB_APP_LOG_VIEWER_CONTEXT_TOKEN } from '../../../logviewer.context.js';
+import { UmbLogViewerWorkspaceContext, UMB_APP_LOG_VIEWER_CONTEXT } from '../../../logviewer.context.js';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { css, html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
@@ -13,7 +13,7 @@ export class UmbLogViewerMessageTemplatesOverviewElement extends UmbLitElement {
 	#logViewerContext?: UmbLogViewerWorkspaceContext;
 	constructor() {
 		super();
-		this.consumeContext(UMB_APP_LOG_VIEWER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_APP_LOG_VIEWER_CONTEXT, (instance) => {
 			this.#logViewerContext = instance;
 			this.#logViewerContext?.getMessageTemplates(0, 10);
 			this.#observeStuff();

--- a/src/packages/log-viewer/workspace/views/overview/components/log-viewer-saved-searches-overview.element.ts
+++ b/src/packages/log-viewer/workspace/views/overview/components/log-viewer-saved-searches-overview.element.ts
@@ -1,4 +1,4 @@
-import { UmbLogViewerWorkspaceContext, UMB_APP_LOG_VIEWER_CONTEXT_TOKEN } from '../../../logviewer.context.js';
+import { UmbLogViewerWorkspaceContext, UMB_APP_LOG_VIEWER_CONTEXT } from '../../../logviewer.context.js';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { css, html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
@@ -14,7 +14,7 @@ export class UmbLogViewerSavedSearchesOverviewElement extends UmbLitElement {
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_APP_LOG_VIEWER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_APP_LOG_VIEWER_CONTEXT, (instance) => {
 			this.#logViewerContext = instance;
 			this.#logViewerContext?.getSavedSearches();
 			this.#observeStuff();

--- a/src/packages/log-viewer/workspace/views/overview/log-overview-view.element.ts
+++ b/src/packages/log-viewer/workspace/views/overview/log-overview-view.element.ts
@@ -1,4 +1,4 @@
-import { UmbLogViewerWorkspaceContext, UMB_APP_LOG_VIEWER_CONTEXT_TOKEN } from '../../logviewer.context.js';
+import { UmbLogViewerWorkspaceContext, UMB_APP_LOG_VIEWER_CONTEXT } from '../../logviewer.context.js';
 import { css, html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
 import { LogLevelCountsReponseModel } from '@umbraco-cms/backoffice/backend-api';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
@@ -18,7 +18,7 @@ export class UmbLogViewerOverviewViewElement extends UmbLitElement {
 	#logViewerContext?: UmbLogViewerWorkspaceContext;
 	constructor() {
 		super();
-		this.consumeContext(UMB_APP_LOG_VIEWER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_APP_LOG_VIEWER_CONTEXT, (instance) => {
 			this.#logViewerContext = instance;
 			this.#observeErrorCount();
 			this.#observeCanShowLogs();

--- a/src/packages/log-viewer/workspace/views/search/components/log-viewer-log-level-filter-menu.element.ts
+++ b/src/packages/log-viewer/workspace/views/search/components/log-viewer-log-level-filter-menu.element.ts
@@ -1,4 +1,4 @@
-import { UmbLogViewerWorkspaceContext, UMB_APP_LOG_VIEWER_CONTEXT_TOKEN } from '../../../logviewer.context.js';
+import { UmbLogViewerWorkspaceContext, UMB_APP_LOG_VIEWER_CONTEXT } from '../../../logviewer.context.js';
 import { UUICheckboxElement } from '@umbraco-cms/backoffice/external/uui';
 import { css, html, customElement, queryAll, state } from '@umbraco-cms/backoffice/external/lit';
 import { debounce } from '@umbraco-cms/backoffice/external/lodash';
@@ -18,7 +18,7 @@ export class UmbLogViewerLogLevelFilterMenuElement extends UmbLitElement {
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_APP_LOG_VIEWER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_APP_LOG_VIEWER_CONTEXT, (instance) => {
 			this.#logViewerContext = instance;
 			this.#observeLogLevelFilter();
 		});

--- a/src/packages/log-viewer/workspace/views/search/components/log-viewer-message.element.ts
+++ b/src/packages/log-viewer/workspace/views/search/components/log-viewer-message.element.ts
@@ -1,4 +1,4 @@
-import { UmbLogViewerWorkspaceContext, UMB_APP_LOG_VIEWER_CONTEXT_TOKEN } from '../../../logviewer.context.js';
+import { UmbLogViewerWorkspaceContext, UMB_APP_LOG_VIEWER_CONTEXT } from '../../../logviewer.context.js';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import {
 	css,
@@ -58,7 +58,7 @@ export class UmbLogViewerMessageElement extends UmbLitElement {
 	#logViewerContext?: UmbLogViewerWorkspaceContext;
 	constructor() {
 		super();
-		this.consumeContext(UMB_APP_LOG_VIEWER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_APP_LOG_VIEWER_CONTEXT, (instance) => {
 			this.#logViewerContext = instance;
 		});
 	}

--- a/src/packages/log-viewer/workspace/views/search/components/log-viewer-messages-list.element.ts
+++ b/src/packages/log-viewer/workspace/views/search/components/log-viewer-messages-list.element.ts
@@ -1,4 +1,4 @@
-import { UmbLogViewerWorkspaceContext, UMB_APP_LOG_VIEWER_CONTEXT_TOKEN } from '../../../logviewer.context.js';
+import { UmbLogViewerWorkspaceContext, UMB_APP_LOG_VIEWER_CONTEXT } from '../../../logviewer.context.js';
 import { UUIScrollContainerElement, UUIPaginationElement } from '@umbraco-cms/backoffice/external/uui';
 import { css, html, customElement, query, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
@@ -25,7 +25,7 @@ export class UmbLogViewerMessagesListElement extends UmbLitElement {
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_APP_LOG_VIEWER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_APP_LOG_VIEWER_CONTEXT, (instance) => {
 			this.#logViewerContext = instance;
 			this.#observeLogs();
 		});

--- a/src/packages/log-viewer/workspace/views/search/components/log-viewer-polling-button.element.ts
+++ b/src/packages/log-viewer/workspace/views/search/components/log-viewer-polling-button.element.ts
@@ -2,7 +2,7 @@ import {
 	PoolingCOnfig,
 	PoolingInterval,
 	UmbLogViewerWorkspaceContext,
-	UMB_APP_LOG_VIEWER_CONTEXT_TOKEN,
+	UMB_APP_LOG_VIEWER_CONTEXT,
 } from '../../../logviewer.context.js';
 import { css, html, customElement, query, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
@@ -21,7 +21,7 @@ export class UmbLogViewerPollingButtonElement extends UmbLitElement {
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_APP_LOG_VIEWER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_APP_LOG_VIEWER_CONTEXT, (instance) => {
 			this.#logViewerContext = instance;
 			this.#observePoolingConfig();
 		});

--- a/src/packages/log-viewer/workspace/views/search/components/log-viewer-search-input.element.ts
+++ b/src/packages/log-viewer/workspace/views/search/components/log-viewer-search-input.element.ts
@@ -1,4 +1,4 @@
-import { UmbLogViewerWorkspaceContext, UMB_APP_LOG_VIEWER_CONTEXT_TOKEN } from '../../../logviewer.context.js';
+import { UmbLogViewerWorkspaceContext, UMB_APP_LOG_VIEWER_CONTEXT } from '../../../logviewer.context.js';
 import { UUIInputElement } from '@umbraco-cms/backoffice/external/uui';
 import { css, html, customElement, query, state } from '@umbraco-cms/backoffice/external/lit';
 import { Subject, debounceTime, tap } from '@umbraco-cms/backoffice/external/rxjs';
@@ -6,7 +6,7 @@ import { SavedLogSearchResponseModel } from '@umbraco-cms/backoffice/backend-api
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 import { query as getQuery, path, toQueryString } from '@umbraco-cms/backoffice/router';
 import {
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UmbModalManagerContext,
 	UmbModalContext,
 	UmbModalToken,
@@ -54,13 +54,13 @@ export class UmbLogViewerSearchInputElement extends UmbLitElement {
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_APP_LOG_VIEWER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_APP_LOG_VIEWER_CONTEXT, (instance) => {
 			this.#logViewerContext = instance;
 			this.#observeStuff();
 			this.#logViewerContext?.getSavedSearches();
 		});
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this._modalContext = instance;
 		});
 

--- a/src/packages/log-viewer/workspace/views/search/log-search-view.element.ts
+++ b/src/packages/log-viewer/workspace/views/search/log-search-view.element.ts
@@ -1,4 +1,4 @@
-import { UmbLogViewerWorkspaceContext, UMB_APP_LOG_VIEWER_CONTEXT_TOKEN } from '../../logviewer.context.js';
+import { UmbLogViewerWorkspaceContext, UMB_APP_LOG_VIEWER_CONTEXT } from '../../logviewer.context.js';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { css, html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
@@ -15,7 +15,7 @@ export class UmbLogViewerSearchViewElement extends UmbLitElement {
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_APP_LOG_VIEWER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_APP_LOG_VIEWER_CONTEXT, (instance) => {
 			this.#logViewerContext = instance;
 			this.#observeCanShowLogs();
 		});

--- a/src/packages/media/media-types/entity-actions/create/create.action.ts
+++ b/src/packages/media/media-types/entity-actions/create/create.action.ts
@@ -2,7 +2,7 @@ import { UmbMediaTypeDetailRepository } from '../../repository/detail/media-type
 import { UMB_MEDIA_TYPE_CREATE_OPTIONS_MODAL } from './modal/index.js';
 import { UmbEntityActionBase } from '@umbraco-cms/backoffice/entity-action';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
-import { UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/modal';
+import { UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
 
 export class UmbCreateMediaTypeEntityAction extends UmbEntityActionBase<UmbMediaTypeDetailRepository> {
 	#modalManagerContext?: UmbModalManagerContext;
@@ -10,7 +10,7 @@ export class UmbCreateMediaTypeEntityAction extends UmbEntityActionBase<UmbMedia
 	constructor(host: UmbControllerHostElement, repositoryAlias: string, unique: string) {
 		super(host, repositoryAlias, unique);
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalManagerContext = instance;
 		});
 	}

--- a/src/packages/media/media-types/entity-actions/create/modal/media-type-create-options-modal.element.ts
+++ b/src/packages/media/media-types/entity-actions/create/modal/media-type-create-options-modal.element.ts
@@ -5,7 +5,7 @@ import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import {
 	type UmbModalManagerContext,
 	type UmbModalContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 } from '@umbraco-cms/backoffice/modal';
 import { UMB_FOLDER_CREATE_MODAL } from '@umbraco-cms/backoffice/tree';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
@@ -22,7 +22,7 @@ export class UmbDataTypeCreateOptionsModalElement extends UmbLitElement {
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalContext = instance;
 		});
 	}

--- a/src/packages/media/media-types/workspace/media-type-workspace-editor.element.ts
+++ b/src/packages/media/media-types/workspace/media-type-workspace-editor.element.ts
@@ -4,7 +4,7 @@ import { css, html, customElement, state, ifDefined } from '@umbraco-cms/backoff
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 import {
 	UMB_ICON_PICKER_MODAL,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UmbModalManagerContext,
 } from '@umbraco-cms/backoffice/modal';
 import { UMB_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/workspace';
@@ -39,7 +39,7 @@ export class UmbMediaTypeWorkspaceEditorElement extends UmbLitElement {
 			this.#observeMediaType();
 		});
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this._modalContext = instance;
 		});
 	}

--- a/src/packages/media/media-types/workspace/views/design/media-type-workspace-view-edit-property.element.ts
+++ b/src/packages/media/media-types/workspace/views/design/media-type-workspace-view-edit-property.element.ts
@@ -4,7 +4,7 @@ import { css, html, customElement, property, state, ifDefined, nothing } from '@
 import { PropertyTypeModelBaseModel } from '@umbraco-cms/backoffice/backend-api';
 import {
 	UMB_CONFIRM_MODAL,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UMB_PROPERTY_SETTINGS_MODAL,
 	UMB_WORKSPACE_MODAL,
 	UmbConfirmModalData,
@@ -56,7 +56,7 @@ export class UmbMediaTypeWorkspacePropertyElement extends UmbLitElement {
 	#dataTypeDetailRepository = new UmbDataTypeDetailRepository(this);
 
 	#modalRegistration;
-	private _modalManagerContext?: typeof UMB_MODAL_MANAGER_CONTEXT_TOKEN.TYPE;
+	private _modalManagerContext?: typeof UMB_MODAL_MANAGER_CONTEXT.TYPE;
 
 	@state()
 	protected _modalRoute?: string;
@@ -110,7 +110,7 @@ export class UmbMediaTypeWorkspacePropertyElement extends UmbLitElement {
 				this._editMediaTypePath = routeBuilder({});
 			});
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (context) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (context) => {
 			this._modalManagerContext = context;
 		});
 	}

--- a/src/packages/media/media-types/workspace/views/design/media-type-workspace-view-edit.element.ts
+++ b/src/packages/media/media-types/workspace/views/design/media-type-workspace-view-edit.element.ts
@@ -13,7 +13,7 @@ import {
 import { UMB_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/workspace';
 import type { UmbRoute } from '@umbraco-cms/backoffice/router';
 import { UmbWorkspaceViewElement } from '@umbraco-cms/backoffice/extension-registry';
-import { UMB_CONFIRM_MODAL, UMB_MODAL_MANAGER_CONTEXT_TOKEN, UmbConfirmModalData } from '@umbraco-cms/backoffice/modal';
+import { UMB_CONFIRM_MODAL, UMB_MODAL_MANAGER_CONTEXT, UmbConfirmModalData } from '@umbraco-cms/backoffice/modal';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { UmbSorterConfig, UmbSorterController } from '@umbraco-cms/backoffice/sorter';
 
@@ -88,7 +88,7 @@ export class UmbMediaTypeWorkspaceViewEditElement extends UmbLitElement implemen
 
 	private _tabsStructureHelper = new UmbContentTypeContainerStructureHelper<UmbMediaTypeDetailModel>(this);
 
-	private _modalManagerContext?: typeof UMB_MODAL_MANAGER_CONTEXT_TOKEN.TYPE;
+	private _modalManagerContext?: typeof UMB_MODAL_MANAGER_CONTEXT.TYPE;
 
 	constructor() {
 		super();
@@ -116,7 +116,7 @@ export class UmbMediaTypeWorkspaceViewEditElement extends UmbLitElement implemen
 			this._observeRootGroups();
 		});
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (context) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (context) => {
 			this._modalManagerContext = context;
 		});
 	}

--- a/src/packages/media/media/entity-bulk-actions/move/move.action.ts
+++ b/src/packages/media/media/entity-bulk-actions/move/move.action.ts
@@ -4,7 +4,7 @@ import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api
 import { UmbContextConsumerController } from '@umbraco-cms/backoffice/context-api';
 import {
 	UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UMB_MEDIA_TREE_PICKER_MODAL,
 } from '@umbraco-cms/backoffice/modal';
 
@@ -14,7 +14,7 @@ export class UmbMediaMoveEntityBulkAction extends UmbEntityBulkActionBase<UmbMed
 	constructor(host: UmbControllerHostElement, repositoryAlias: string, selection: Array<string>) {
 		super(host, repositoryAlias, selection);
 
-		new UmbContextConsumerController(host, UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		new UmbContextConsumerController(host, UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalContext = instance;
 		});
 	}

--- a/src/packages/media/media/entity-bulk-actions/trash/trash.action.ts
+++ b/src/packages/media/media/entity-bulk-actions/trash/trash.action.ts
@@ -3,11 +3,7 @@ import { html } from '@umbraco-cms/backoffice/external/lit';
 import { UmbEntityBulkActionBase } from '@umbraco-cms/backoffice/entity-bulk-action';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
 import { UmbContextConsumerController } from '@umbraco-cms/backoffice/context-api';
-import {
-	UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
-	UMB_CONFIRM_MODAL,
-} from '@umbraco-cms/backoffice/modal';
+import { UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT, UMB_CONFIRM_MODAL } from '@umbraco-cms/backoffice/modal';
 
 export class UmbMediaTrashEntityBulkAction extends UmbEntityBulkActionBase<UmbMediaRepository> {
 	#modalContext?: UmbModalManagerContext;
@@ -15,7 +11,7 @@ export class UmbMediaTrashEntityBulkAction extends UmbEntityBulkActionBase<UmbMe
 	constructor(host: UmbControllerHostElement, repositoryAlias: string, selection: Array<string>) {
 		super(host, repositoryAlias, selection);
 
-		new UmbContextConsumerController(host, UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		new UmbContextConsumerController(host, UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalContext = instance;
 		});
 	}

--- a/src/packages/media/media/repository/media.repository.ts
+++ b/src/packages/media/media/repository/media.repository.ts
@@ -6,7 +6,7 @@ import { UMB_MEDIA_ITEM_STORE_CONTEXT, UmbMediaItemStore } from './media-item.st
 import { type UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbBaseController } from '@umbraco-cms/backoffice/class-api';
 import { CreateMediaRequestModel, UpdateMediaRequestModel } from '@umbraco-cms/backoffice/backend-api';
-import { UmbNotificationContext, UMB_NOTIFICATION_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/notification';
+import { UmbNotificationContext, UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
 import { UmbApi } from '@umbraco-cms/backoffice/extension-api';
 
 export class UmbMediaRepository extends UmbBaseController implements UmbApi {
@@ -42,7 +42,7 @@ export class UmbMediaRepository extends UmbBaseController implements UmbApi {
 				this.#itemStore = instance;
 			}).asPromise(),
 
-			this.consumeContext(UMB_NOTIFICATION_CONTEXT_TOKEN, (instance) => {
+			this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => {
 				this.#notificationContext = instance;
 			}).asPromise(),
 		]);

--- a/src/packages/members/member-types/repository/member-type.repository.ts
+++ b/src/packages/members/member-types/repository/member-type.repository.ts
@@ -4,7 +4,7 @@ import { UmbMemberTypeStore, UMB_MEMBER_TYPE_STORE_CONTEXT } from './member-type
 import { UmbMemberTypeDetailServerDataSource } from './sources/member-type.detail.server.data.js';
 import { type UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbBaseController } from '@umbraco-cms/backoffice/class-api';
-import { UmbNotificationContext, UMB_NOTIFICATION_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/notification';
+import { UmbNotificationContext, UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
 
 export class UmbMemberTypeRepository extends UmbBaseController {
 	#init!: Promise<unknown>;
@@ -31,7 +31,7 @@ export class UmbMemberTypeRepository extends UmbBaseController {
 				this.#treeStore = instance;
 			}),
 
-			this.consumeContext(UMB_NOTIFICATION_CONTEXT_TOKEN, (instance) => {
+			this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => {
 				this.#notificationContext = instance;
 			}),
 		]);

--- a/src/packages/packages/package-builder/workspace/workspace-package-builder.element.ts
+++ b/src/packages/packages/package-builder/workspace/workspace-package-builder.element.ts
@@ -16,7 +16,7 @@ import {
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 import { PackageDefinitionResponseModel, PackageResource } from '@umbraco-cms/backoffice/backend-api';
 import { tryExecuteAndNotify } from '@umbraco-cms/backoffice/resources';
-import { UmbNotificationContext, UMB_NOTIFICATION_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/notification';
+import { UmbNotificationContext, UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 
 @customElement('umb-workspace-package-builder')
@@ -36,7 +36,7 @@ export class UmbWorkspacePackageBuilderElement extends UmbLitElement {
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_NOTIFICATION_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => {
 			this._notificationContext = instance;
 		});
 	}

--- a/src/packages/packages/package-section/views/created/packages-created-overview.element.ts
+++ b/src/packages/packages/package-section/views/created/packages-created-overview.element.ts
@@ -3,11 +3,7 @@ import { UUIPaginationEvent } from '@umbraco-cms/backoffice/external/uui';
 import { PackageDefinitionResponseModel, PackageResource } from '@umbraco-cms/backoffice/backend-api';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 import { tryExecuteAndNotify } from '@umbraco-cms/backoffice/resources';
-import {
-	UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
-	UMB_CONFIRM_MODAL,
-} from '@umbraco-cms/backoffice/modal';
+import { UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT, UMB_CONFIRM_MODAL } from '@umbraco-cms/backoffice/modal';
 
 @customElement('umb-packages-created-overview')
 export class UmbPackagesCreatedOverviewElement extends UmbLitElement {
@@ -35,7 +31,7 @@ export class UmbPackagesCreatedOverviewElement extends UmbLitElement {
 		super.connectedCallback();
 		this.#getPackages();
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this._modalContext = instance;
 		});
 	}

--- a/src/packages/packages/package-section/views/installed/installed-packages-section-view-item.element.ts
+++ b/src/packages/packages/package-section/views/installed/installed-packages-section-view-item.element.ts
@@ -1,17 +1,13 @@
 import { html, css, nothing, ifDefined, customElement, property, state } from '@umbraco-cms/backoffice/external/lit';
 import { UUIButtonState } from '@umbraco-cms/backoffice/external/uui';
 import { map } from '@umbraco-cms/backoffice/external/rxjs';
-import {
-	UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
-	UMB_CONFIRM_MODAL,
-} from '@umbraco-cms/backoffice/modal';
+import { UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT, UMB_CONFIRM_MODAL } from '@umbraco-cms/backoffice/modal';
 import { createExtensionElement } from '@umbraco-cms/backoffice/extension-api';
 import { ManifestPackageView, umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 import { tryExecuteAndNotify } from '@umbraco-cms/backoffice/resources';
 import { PackageResource } from '@umbraco-cms/backoffice/backend-api';
-import { UmbNotificationContext, UMB_NOTIFICATION_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/notification';
+import { UmbNotificationContext, UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
 
 @customElement('umb-installed-packages-section-view-item')
 export class UmbInstalledPackagesSectionViewItemElement extends UmbLitElement {
@@ -49,10 +45,10 @@ export class UmbInstalledPackagesSectionViewItemElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_NOTIFICATION_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => {
 			this.#notificationContext = instance;
 		});
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalContext = instance;
 		});
 	}

--- a/src/packages/relations/relation-types/repository/relation-type.repository.ts
+++ b/src/packages/relations/relation-types/repository/relation-type.repository.ts
@@ -1,10 +1,10 @@
 import { UmbRelationTypeTreeStore, UMB_RELATION_TYPE_TREE_STORE_CONTEXT } from '../tree/index.js';
 import { UmbRelationTypeServerDataSource } from './sources/relation-type.server.data.js';
-import { UmbRelationTypeStore, UMB_RELATION_TYPE_STORE_CONTEXT_TOKEN } from './relation-type.store.js';
+import { UmbRelationTypeStore, UMB_RELATION_TYPE_STORE_CONTEXT } from './relation-type.store.js';
 import { type UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbBaseController } from '@umbraco-cms/backoffice/class-api';
 import { CreateRelationTypeRequestModel, UpdateRelationTypeRequestModel } from '@umbraco-cms/backoffice/backend-api';
-import { UmbNotificationContext, UMB_NOTIFICATION_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/notification';
+import { UmbNotificationContext, UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
 import { UmbApi } from '@umbraco-cms/backoffice/extension-api';
 
 export class UmbRelationTypeRepository extends UmbBaseController implements UmbApi {
@@ -28,11 +28,11 @@ export class UmbRelationTypeRepository extends UmbBaseController implements UmbA
 				this.#treeStore = instance;
 			}).asPromise(),
 
-			this.consumeContext(UMB_RELATION_TYPE_STORE_CONTEXT_TOKEN, (instance) => {
+			this.consumeContext(UMB_RELATION_TYPE_STORE_CONTEXT, (instance) => {
 				this.#detailStore = instance;
 			}).asPromise(),
 
-			this.consumeContext(UMB_NOTIFICATION_CONTEXT_TOKEN, (instance) => {
+			this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => {
 				this.#notificationContext = instance;
 			}).asPromise(),
 		]);

--- a/src/packages/relations/relation-types/repository/relation-type.store.ts
+++ b/src/packages/relations/relation-types/repository/relation-type.store.ts
@@ -4,7 +4,7 @@ import { UmbArrayState } from '@umbraco-cms/backoffice/observable-api';
 import { UmbStoreBase } from '@umbraco-cms/backoffice/store';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
 
-export const UMB_RELATION_TYPE_STORE_CONTEXT_TOKEN = new UmbContextToken<UmbRelationTypeStore>('UmbRelationTypeStore');
+export const UMB_RELATION_TYPE_STORE_CONTEXT = new UmbContextToken<UmbRelationTypeStore>('UmbRelationTypeStore');
 
 /**
  * @export
@@ -21,7 +21,7 @@ export class UmbRelationTypeStore extends UmbStoreBase {
 	constructor(host: UmbControllerHostElement) {
 		super(
 			host,
-			UMB_RELATION_TYPE_STORE_CONTEXT_TOKEN.toString(),
+			UMB_RELATION_TYPE_STORE_CONTEXT.toString(),
 			new UmbArrayState<RelationTypeResponseModel>([], (x) => x.id),
 		);
 	}

--- a/src/packages/relations/relations/repository/relation.repository.ts
+++ b/src/packages/relations/relations/repository/relation.repository.ts
@@ -1,7 +1,7 @@
 import { UmbRelationServerDataSource } from './sources/relation.server.data.js';
 import { type UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbBaseController } from '@umbraco-cms/backoffice/class-api';
-import { UmbNotificationContext, UMB_NOTIFICATION_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/notification';
+import { UmbNotificationContext, UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
 import { UmbApi } from '@umbraco-cms/backoffice/extension-api';
 
 export class UmbRelationRepository extends UmbBaseController implements UmbApi {
@@ -17,7 +17,7 @@ export class UmbRelationRepository extends UmbBaseController implements UmbApi {
 		this.#detailDataSource = new UmbRelationServerDataSource(this._host);
 
 		this.#init = Promise.all([
-			this.consumeContext(UMB_NOTIFICATION_CONTEXT_TOKEN, (instance) => {
+			this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => {
 				this.#notificationContext = instance;
 			}).asPromise(),
 		]);

--- a/src/packages/search/examine-management-dashboard/views/section-view-examine-indexers.ts
+++ b/src/packages/search/examine-management-dashboard/views/section-view-examine-indexers.ts
@@ -1,10 +1,6 @@
 import { UUIButtonState } from '@umbraco-cms/backoffice/external/uui';
 import { css, html, nothing, customElement, property, state } from '@umbraco-cms/backoffice/external/lit';
-import {
-	UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
-	UMB_CONFIRM_MODAL,
-} from '@umbraco-cms/backoffice/modal';
+import { UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT, UMB_CONFIRM_MODAL } from '@umbraco-cms/backoffice/modal';
 import { HealthStatusModel, IndexResponseModel, IndexerResource } from '@umbraco-cms/backoffice/backend-api';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 import { tryExecuteAndNotify } from '@umbraco-cms/backoffice/resources';
@@ -31,7 +27,7 @@ export class UmbDashboardExamineIndexElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (_instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (_instance) => {
 			this._modalContext = _instance;
 		});
 	}

--- a/src/packages/search/examine-management-dashboard/views/section-view-examine-searchers.ts
+++ b/src/packages/search/examine-management-dashboard/views/section-view-examine-searchers.ts
@@ -2,7 +2,7 @@ import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { css, html, nothing, customElement, state, query, property } from '@umbraco-cms/backoffice/external/lit';
 import {
 	UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UMB_EXAMINE_FIELDS_SETTINGS_MODAL,
 } from '@umbraco-cms/backoffice/modal';
 import {
@@ -42,7 +42,7 @@ export class UmbDashboardExamineSearcherElement extends UmbLitElement {
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this._modalContext = instance;
 		});
 	}

--- a/src/packages/search/umb-search-header-app.element.ts
+++ b/src/packages/search/umb-search-header-app.element.ts
@@ -1,6 +1,6 @@
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { css, CSSResultGroup, html, customElement } from '@umbraco-cms/backoffice/external/lit';
-import { UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/modal';
+import { UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 
 @customElement('umb-search-header-app')
@@ -10,7 +10,7 @@ export class UmbSearchHeaderAppElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (_instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (_instance) => {
 			this._modalContext = _instance;
 		});
 	}

--- a/src/packages/settings/dashboards/published-status/dashboard-published-status.element.ts
+++ b/src/packages/settings/dashboards/published-status/dashboard-published-status.element.ts
@@ -1,10 +1,6 @@
 import { UUIButtonState } from '@umbraco-cms/backoffice/external/uui';
 import { css, html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
-import {
-	UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
-	UMB_CONFIRM_MODAL,
-} from '@umbraco-cms/backoffice/modal';
+import { UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT, UMB_CONFIRM_MODAL } from '@umbraco-cms/backoffice/modal';
 import { PublishedCacheResource } from '@umbraco-cms/backoffice/backend-api';
 import { tryExecuteAndNotify } from '@umbraco-cms/backoffice/resources';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
@@ -32,7 +28,7 @@ export class UmbDashboardPublishedStatusElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this._modalContext = instance;
 		});
 	}

--- a/src/packages/settings/extensions/workspace/extension-root-workspace.element.ts
+++ b/src/packages/settings/extensions/workspace/extension-root-workspace.element.ts
@@ -2,11 +2,7 @@ import { css, html, customElement, state } from '@umbraco-cms/backoffice/externa
 import { map } from '@umbraco-cms/backoffice/external/rxjs';
 import { ManifestTypes, umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
-import {
-	UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
-	UMB_CONFIRM_MODAL,
-} from '@umbraco-cms/backoffice/modal';
+import { UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT, UMB_CONFIRM_MODAL } from '@umbraco-cms/backoffice/modal';
 
 @customElement('umb-extension-root-workspace')
 export class UmbExtensionRootWorkspaceElement extends UmbLitElement {
@@ -19,7 +15,7 @@ export class UmbExtensionRootWorkspaceElement extends UmbLitElement {
 		super.connectedCallback();
 		this._observeExtensions();
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this._modalContext = instance;
 		});
 	}

--- a/src/packages/settings/languages/app-language-select/app-language-select.element.ts
+++ b/src/packages/settings/languages/app-language-select/app-language-select.element.ts
@@ -1,5 +1,5 @@
 import { UmbLanguageRepository } from '../repository/language.repository.js';
-import { UMB_APP_LANGUAGE_CONTEXT_TOKEN, UmbAppLanguageContext } from './app-language.context.js';
+import { UMB_APP_LANGUAGE_CONTEXT, UmbAppLanguageContext } from './app-language.context.js';
 import { UUIMenuItemEvent, UUIPopoverContainerElement } from '@umbraco-cms/backoffice/external/uui';
 import { css, html, customElement, state, repeat, ifDefined, query } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
@@ -26,7 +26,7 @@ export class UmbAppLanguageSelectElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_APP_LANGUAGE_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_APP_LANGUAGE_CONTEXT, (instance) => {
 			this.#appLanguageContext = instance;
 			this.#observeAppLanguage();
 		});

--- a/src/packages/settings/languages/app-language-select/app-language.context.ts
+++ b/src/packages/settings/languages/app-language-select/app-language.context.ts
@@ -17,7 +17,7 @@ export class UmbAppLanguageContext extends UmbBaseController implements UmbApi {
 	constructor(host: UmbControllerHost) {
 		super(host);
 
-		this.provideContext(UMB_APP_LANGUAGE_CONTEXT_TOKEN, this);
+		this.provideContext(UMB_APP_LANGUAGE_CONTEXT, this);
 
 		this.#languageRepository = new UmbLanguageRepository(this);
 		this.#observeLanguages();
@@ -58,4 +58,4 @@ export class UmbAppLanguageContext extends UmbBaseController implements UmbApi {
 // Default export to enable this as a globalContext extension js:
 export default UmbAppLanguageContext;
 
-export const UMB_APP_LANGUAGE_CONTEXT_TOKEN = new UmbContextToken<UmbAppLanguageContext>('UmbAppLanguageContext');
+export const UMB_APP_LANGUAGE_CONTEXT = new UmbContextToken<UmbAppLanguageContext>('UmbAppLanguageContext');

--- a/src/packages/settings/languages/repository/language-item.store.ts
+++ b/src/packages/settings/languages/repository/language-item.store.ts
@@ -5,7 +5,7 @@ import { UmbArrayState } from '@umbraco-cms/backoffice/observable-api';
 import { LanguageResponseModel } from '@umbraco-cms/backoffice/backend-api';
 import type { UmbItemStore } from '@umbraco-cms/backoffice/store';
 
-export const UMB_LANGUAGE_ITEM_STORE_CONTEXT_TOKEN = new UmbContextToken<UmbLanguageItemStore>('UmbLanguageItemStore');
+export const UMB_LANGUAGE_ITEM_STORE_CONTEXT = new UmbContextToken<UmbLanguageItemStore>('UmbLanguageItemStore');
 
 /**
  * @export
@@ -17,7 +17,7 @@ export class UmbLanguageItemStore extends UmbStoreBase<LanguageResponseModel> {
 	constructor(host: UmbControllerHostElement) {
 		super(
 			host,
-			UMB_LANGUAGE_ITEM_STORE_CONTEXT_TOKEN.toString(),
+			UMB_LANGUAGE_ITEM_STORE_CONTEXT.toString(),
 			new UmbArrayState<LanguageResponseModel>([], (x) => x.isoCode),
 		);
 	}

--- a/src/packages/settings/languages/repository/language.repository.ts
+++ b/src/packages/settings/languages/repository/language.repository.ts
@@ -1,10 +1,10 @@
 import { UmbLanguageServerDataSource } from './sources/language.server.data.js';
-import { UmbLanguageStore, UMB_LANGUAGE_STORE_CONTEXT_TOKEN } from './language.store.js';
+import { UmbLanguageStore, UMB_LANGUAGE_STORE_CONTEXT } from './language.store.js';
 import { UmbLanguageItemServerDataSource } from './sources/language-item.server.data.js';
-import { UMB_LANGUAGE_ITEM_STORE_CONTEXT_TOKEN, UmbLanguageItemStore } from './language-item.store.js';
+import { UMB_LANGUAGE_ITEM_STORE_CONTEXT, UmbLanguageItemStore } from './language-item.store.js';
 import { type UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbBaseController } from '@umbraco-cms/backoffice/class-api';
-import { UmbNotificationContext, UMB_NOTIFICATION_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/notification';
+import { UmbNotificationContext, UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
 import { LanguageItemResponseModel, LanguageResponseModel } from '@umbraco-cms/backoffice/backend-api';
 import { UmbItemRepository } from '@umbraco-cms/backoffice/repository';
 
@@ -25,15 +25,15 @@ export class UmbLanguageRepository extends UmbBaseController implements UmbItemR
 		this.#itemDataSource = new UmbLanguageItemServerDataSource(this);
 
 		this.#init = Promise.all([
-			this.consumeContext(UMB_NOTIFICATION_CONTEXT_TOKEN, (instance) => {
+			this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => {
 				this.#notificationContext = instance;
 			}).asPromise(),
 
-			this.consumeContext(UMB_LANGUAGE_STORE_CONTEXT_TOKEN, (instance) => {
+			this.consumeContext(UMB_LANGUAGE_STORE_CONTEXT, (instance) => {
 				this.#languageStore = instance;
 			}).asPromise(),
 
-			this.consumeContext(UMB_LANGUAGE_ITEM_STORE_CONTEXT_TOKEN, (instance) => {
+			this.consumeContext(UMB_LANGUAGE_ITEM_STORE_CONTEXT, (instance) => {
 				this.#languageItemStore = instance;
 			}).asPromise(),
 		]);

--- a/src/packages/settings/languages/repository/language.store.ts
+++ b/src/packages/settings/languages/repository/language.store.ts
@@ -4,7 +4,7 @@ import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api
 import { UmbArrayState } from '@umbraco-cms/backoffice/observable-api';
 import { LanguageResponseModel } from '@umbraco-cms/backoffice/backend-api';
 
-export const UMB_LANGUAGE_STORE_CONTEXT_TOKEN = new UmbContextToken<UmbLanguageStore>('UmbLanguageStore');
+export const UMB_LANGUAGE_STORE_CONTEXT = new UmbContextToken<UmbLanguageStore>('UmbLanguageStore');
 
 /**
  * @export
@@ -16,11 +16,7 @@ export class UmbLanguageStore extends UmbStoreBase {
 	public readonly data = this._data.asObservable();
 
 	constructor(host: UmbControllerHostElement) {
-		super(
-			host,
-			UMB_LANGUAGE_STORE_CONTEXT_TOKEN.toString(),
-			new UmbArrayState<LanguageResponseModel>([], (x) => x.isoCode),
-		);
+		super(host, UMB_LANGUAGE_STORE_CONTEXT.toString(), new UmbArrayState<LanguageResponseModel>([], (x) => x.isoCode));
 	}
 
 	append(language: LanguageResponseModel) {

--- a/src/packages/tags/repository/tag.repository.ts
+++ b/src/packages/tags/repository/tag.repository.ts
@@ -1,5 +1,5 @@
 import { UmbTagServerDataSource } from './sources/tag.server.data.js';
-import { UmbTagStore, UMB_TAG_STORE_CONTEXT_TOKEN } from './tag.store.js';
+import { UmbTagStore, UMB_TAG_STORE_CONTEXT } from './tag.store.js';
 import { type UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbBaseController } from '@umbraco-cms/backoffice/class-api';
 import { UmbApi } from '@umbraco-cms/backoffice/extension-api';
@@ -15,7 +15,7 @@ export class UmbTagRepository extends UmbBaseController implements UmbApi {
 
 		this.#dataSource = new UmbTagServerDataSource(this);
 
-		this.#init = this.consumeContext(UMB_TAG_STORE_CONTEXT_TOKEN, (instance) => {
+		this.#init = this.consumeContext(UMB_TAG_STORE_CONTEXT, (instance) => {
 			this.#tagStore = instance;
 		}).asPromise();
 	}

--- a/src/packages/tags/repository/tag.store.ts
+++ b/src/packages/tags/repository/tag.store.ts
@@ -4,7 +4,7 @@ import { UmbArrayState } from '@umbraco-cms/backoffice/observable-api';
 import { UmbStoreBase } from '@umbraco-cms/backoffice/store';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
 
-export const UMB_TAG_STORE_CONTEXT_TOKEN = new UmbContextToken<UmbTagStore>('UmbTagStore');
+export const UMB_TAG_STORE_CONTEXT = new UmbContextToken<UmbTagStore>('UmbTagStore');
 /**
  * @export
  * @class UmbTagStore
@@ -20,7 +20,7 @@ export class UmbTagStore extends UmbStoreBase {
 	 * @memberof UmbTagStore
 	 */
 	constructor(host: UmbControllerHostElement) {
-		super(host, UMB_TAG_STORE_CONTEXT_TOKEN.toString(), new UmbArrayState<TagResponseModel>([], (x) => x.id));
+		super(host, UMB_TAG_STORE_CONTEXT.toString(), new UmbArrayState<TagResponseModel>([], (x) => x.id));
 	}
 
 	/**

--- a/src/packages/templating/code-editor/code-editor.element.ts
+++ b/src/packages/templating/code-editor/code-editor.element.ts
@@ -1,7 +1,7 @@
 import { UmbCodeEditorController } from './code-editor.controller.js';
 import type { CodeEditorLanguage, CodeEditorSearchOptions, UmbCodeEditorHost } from './code-editor.model.js';
 import { CodeEditorTheme } from './code-editor.model.js';
-import { UMB_THEME_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/themes';
+import { UMB_THEME_CONTEXT } from '@umbraco-cms/backoffice/themes';
 import { monacoEditorStyles, monacoJumpingCursorHack } from '@umbraco-cms/backoffice/external/monaco-editor';
 import {
 	css,
@@ -98,7 +98,7 @@ export class UmbCodeEditorElement extends UmbLitElement implements UmbCodeEditor
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_THEME_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_THEME_CONTEXT, (instance) => {
 			this.observe(
 				instance.theme,
 				(themeAlias) => {

--- a/src/packages/templating/components/insert-menu/templating-insert-menu.element.ts
+++ b/src/packages/templating/components/insert-menu/templating-insert-menu.element.ts
@@ -6,7 +6,7 @@ import { customElement, property, css, html } from '@umbraco-cms/backoffice/exte
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import {
 	UMB_DICTIONARY_ITEM_PICKER_MODAL,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UMB_PARTIAL_VIEW_PICKER_MODAL,
 	UmbDictionaryItemPickerModalValue,
 	UmbModalManagerContext,
@@ -39,7 +39,7 @@ export class UmbTemplatingInsertMenuElement extends UmbLitElement {
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this._modalContext = instance;
 		});
 	}

--- a/src/packages/templating/modals/insert-choose-type-sidebar.element.ts
+++ b/src/packages/templating/modals/insert-choose-type-sidebar.element.ts
@@ -1,7 +1,7 @@
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { css, html, customElement } from '@umbraco-cms/backoffice/external/lit';
 import {
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UmbModalManagerContext,
 	UMB_PARTIAL_VIEW_PICKER_MODAL,
 	UmbModalContext,
@@ -37,7 +37,7 @@ export default class UmbChooseInsertTypeModalElement extends UmbModalBaseElement
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this._modalContext = instance;
 		});
 	}

--- a/src/packages/templating/partial-views/entity-actions/create/create.action.ts
+++ b/src/packages/templating/partial-views/entity-actions/create/create.action.ts
@@ -1,7 +1,7 @@
 import { UMB_PARTIAL_VIEW_CREATE_OPTIONS_MODAL } from './options-modal/index.js';
 import { UmbEntityActionBase } from '@umbraco-cms/backoffice/entity-action';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
-import { UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/modal';
+import { UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
 
 export class UmbPartialViewCreateOptionsEntityAction extends UmbEntityActionBase<never> {
 	#modalManagerContext?: UmbModalManagerContext;
@@ -9,7 +9,7 @@ export class UmbPartialViewCreateOptionsEntityAction extends UmbEntityActionBase
 	constructor(host: UmbControllerHostElement, repositoryAlias: string, unique: string) {
 		super(host, repositoryAlias, unique);
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalManagerContext = instance;
 		});
 	}

--- a/src/packages/templating/partial-views/entity-actions/create/options-modal/partial-view-create-options-modal.element.ts
+++ b/src/packages/templating/partial-views/entity-actions/create/options-modal/partial-view-create-options-modal.element.ts
@@ -3,11 +3,7 @@ import { UMB_PARTIAL_VIEW_FROM_SNIPPET_MODAL } from '../snippet-modal/create-fro
 import { UmbPartialViewCreateOptionsModalData } from './index.js';
 import { html, customElement } from '@umbraco-cms/backoffice/external/lit';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
-import {
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
-	UmbModalManagerContext,
-	UmbModalBaseElement,
-} from '@umbraco-cms/backoffice/modal';
+import { UMB_MODAL_MANAGER_CONTEXT, UmbModalManagerContext, UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 import { UmbCreateFolderEntityAction } from '@umbraco-cms/backoffice/tree';
 
 @customElement('umb-partial-view-create-options-modal')
@@ -21,7 +17,7 @@ export class UmbPartialViewCreateOptionsModalElement extends UmbModalBaseElement
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalManager = instance;
 		});
 	}

--- a/src/packages/templating/partial-views/workspace/partial-view-workspace-editor.element.ts
+++ b/src/packages/templating/partial-views/workspace/partial-view-workspace-editor.element.ts
@@ -6,7 +6,7 @@ import type { UmbCodeEditorElement } from '@umbraco-cms/backoffice/code-editor';
 import { UUIInputElement } from '@umbraco-cms/backoffice/external/uui';
 import { css, html, customElement, query, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
-import { UMB_MODAL_MANAGER_CONTEXT_TOKEN, UmbModalManagerContext } from '@umbraco-cms/backoffice/modal';
+import { UMB_MODAL_MANAGER_CONTEXT, UmbModalManagerContext } from '@umbraco-cms/backoffice/modal';
 
 @customElement('umb-partial-view-workspace-editor')
 export class UmbPartialViewWorkspaceEditorElement extends UmbLitElement {
@@ -34,7 +34,7 @@ export class UmbPartialViewWorkspaceEditorElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this._modalContext = instance;
 		});
 

--- a/src/packages/templating/scripts/entity-actions/create/create.action.ts
+++ b/src/packages/templating/scripts/entity-actions/create/create.action.ts
@@ -1,7 +1,7 @@
 import { UMB_SCRIPT_CREATE_OPTIONS_MODAL } from './options-modal/index.js';
 import { UmbEntityActionBase } from '@umbraco-cms/backoffice/entity-action';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
-import { UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/modal';
+import { UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
 
 export class UmbScriptCreateOptionsEntityAction extends UmbEntityActionBase<never> {
 	#modalManagerContext?: UmbModalManagerContext;
@@ -9,7 +9,7 @@ export class UmbScriptCreateOptionsEntityAction extends UmbEntityActionBase<neve
 	constructor(host: UmbControllerHostElement, repositoryAlias: string, unique: string) {
 		super(host, repositoryAlias, unique);
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalManagerContext = instance;
 		});
 	}

--- a/src/packages/templating/scripts/entity-actions/create/options-modal/script-create-options-modal.element.ts
+++ b/src/packages/templating/scripts/entity-actions/create/options-modal/script-create-options-modal.element.ts
@@ -2,11 +2,7 @@ import { UMB_SCRIPT_FOLDER_REPOSITORY_ALIAS } from '../../../tree/folder/index.j
 import { UmbScriptCreateOptionsModalData } from './index.js';
 import { html, customElement } from '@umbraco-cms/backoffice/external/lit';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
-import {
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
-	UmbModalManagerContext,
-	UmbModalBaseElement,
-} from '@umbraco-cms/backoffice/modal';
+import { UMB_MODAL_MANAGER_CONTEXT, UmbModalManagerContext, UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 import { UmbCreateFolderEntityAction } from '@umbraco-cms/backoffice/tree';
 
 @customElement('umb-script-create-options-modal')
@@ -17,7 +13,7 @@ export class UmbScriptCreateOptionsModalElement extends UmbModalBaseElement<UmbS
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalManager = instance;
 		});
 	}

--- a/src/packages/templating/stylesheets/components/stylesheet-rule-input/stylesheet-rule-input.element.ts
+++ b/src/packages/templating/stylesheets/components/stylesheet-rule-input/stylesheet-rule-input.element.ts
@@ -3,7 +3,7 @@ import { UMB_STYLESHEET_RULE_SETTINGS_MODAL } from './stylesheet-rule-settings-m
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { css, html, customElement, repeat, property } from '@umbraco-cms/backoffice/external/lit';
 import { FormControlMixin } from '@umbraco-cms/backoffice/external/uui';
-import { UMB_MODAL_MANAGER_CONTEXT_TOKEN, UmbModalManagerContext } from '@umbraco-cms/backoffice/modal';
+import { UMB_MODAL_MANAGER_CONTEXT, UmbModalManagerContext } from '@umbraco-cms/backoffice/modal';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 
 // TODO: add sorting when we have a generic sorting component/functionality for ref lists
@@ -18,7 +18,7 @@ export class UmbStylesheetRuleInputElement extends FormControlMixin(UmbLitElemen
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (modalContext) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (modalContext) => {
 			this.#modalManager = modalContext;
 		});
 	}

--- a/src/packages/templating/stylesheets/entity-actions/create/create.action.ts
+++ b/src/packages/templating/stylesheets/entity-actions/create/create.action.ts
@@ -1,7 +1,7 @@
 import { UMB_STYLESHEET_CREATE_OPTIONS_MODAL } from './options-modal/index.js';
 import { UmbEntityActionBase } from '@umbraco-cms/backoffice/entity-action';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
-import { UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/modal';
+import { UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
 
 export class UmbStylesheetCreateOptionsEntityAction extends UmbEntityActionBase<never> {
 	#modalManagerContext?: UmbModalManagerContext;
@@ -9,7 +9,7 @@ export class UmbStylesheetCreateOptionsEntityAction extends UmbEntityActionBase<
 	constructor(host: UmbControllerHostElement, repositoryAlias: string, unique: string) {
 		super(host, repositoryAlias, unique);
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalManagerContext = instance;
 		});
 	}

--- a/src/packages/templating/stylesheets/entity-actions/create/options-modal/stylesheet-create-options-modal.element.ts
+++ b/src/packages/templating/stylesheets/entity-actions/create/options-modal/stylesheet-create-options-modal.element.ts
@@ -2,11 +2,7 @@ import { UMB_STYLESHEET_FOLDER_REPOSITORY_ALIAS } from '../../../tree/folder/ind
 import { UmbStylesheetCreateOptionsModalData } from './index.js';
 import { html, customElement } from '@umbraco-cms/backoffice/external/lit';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
-import {
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
-	UmbModalManagerContext,
-	UmbModalBaseElement,
-} from '@umbraco-cms/backoffice/modal';
+import { UMB_MODAL_MANAGER_CONTEXT, UmbModalManagerContext, UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 import { UmbCreateFolderEntityAction } from '@umbraco-cms/backoffice/tree';
 
 @customElement('umb-stylesheet-create-options-modal')
@@ -20,7 +16,7 @@ export class UmbStylesheetCreateOptionsModalElement extends UmbModalBaseElement<
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalManager = instance;
 		});
 	}

--- a/src/packages/templating/templates/components/input-template/input-template.element.ts
+++ b/src/packages/templating/templates/components/input-template/input-template.element.ts
@@ -8,7 +8,7 @@ import {
 	UMB_TEMPLATE_PICKER_MODAL,
 	UMB_TEMPLATE_MODAL,
 	UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 } from '@umbraco-cms/backoffice/modal';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 import { ItemResponseModelBaseModel, TemplateResponseModel } from '@umbraco-cms/backoffice/backend-api';
@@ -81,7 +81,7 @@ export class UmbInputTemplateElement extends FormControlMixin(UmbLitElement) {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this._modalContext = instance;
 		});
 	}

--- a/src/packages/templating/templates/modals/query-builder/query-builder.element.ts
+++ b/src/packages/templating/templates/modals/query-builder/query-builder.element.ts
@@ -6,7 +6,7 @@ import { css, html, customElement, state, query, queryAll, ifDefined } from '@um
 import {
 	UmbModalBaseElement,
 	UMB_DOCUMENT_PICKER_MODAL,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UmbModalManagerContext,
 } from '@umbraco-cms/backoffice/modal';
 import {
@@ -65,7 +65,7 @@ export default class UmbChooseInsertTypeModalElement extends UmbModalBaseElement
 		this.#templateRepository = new UmbTemplateRepository(this);
 		this.#documentRepository = new UmbDocumentRepository(this);
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalManagerContext = instance;
 		});
 		this.#init();

--- a/src/packages/templating/templates/repository/template.repository.ts
+++ b/src/packages/templating/templates/repository/template.repository.ts
@@ -7,7 +7,7 @@ import { UmbTemplateQueryBuilderServerDataSource } from './sources/template.quer
 import type { UmbItemDataSource, UmbItemRepository } from '@umbraco-cms/backoffice/repository';
 import { UmbBaseController } from '@umbraco-cms/backoffice/class-api';
 import { type UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
-import { UmbNotificationContext, UMB_NOTIFICATION_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/notification';
+import { UmbNotificationContext, UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
 import type {
 	CreateTemplateRequestModel,
 	TemplateItemResponseModel,
@@ -52,7 +52,7 @@ export class UmbTemplateRepository
 				this.#store = instance;
 			}),
 
-			this.consumeContext(UMB_NOTIFICATION_CONTEXT_TOKEN, (instance) => {
+			this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => {
 				this.#notificationContext = instance;
 			}),
 		]);

--- a/src/packages/templating/templates/workspace/template-workspace-editor.element.ts
+++ b/src/packages/templating/templates/workspace/template-workspace-editor.element.ts
@@ -8,7 +8,7 @@ import { camelCase } from '@umbraco-cms/backoffice/external/lodash';
 import { UUIInputElement } from '@umbraco-cms/backoffice/external/uui';
 import { css, html, customElement, query, state, nothing, ifDefined } from '@umbraco-cms/backoffice/external/lit';
 import {
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UMB_TEMPLATE_PICKER_MODAL,
 	UmbModalManagerContext,
 } from '@umbraco-cms/backoffice/modal';
@@ -45,7 +45,7 @@ export class UmbTemplateWorkspaceEditorElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this._modalContext = instance;
 		});
 

--- a/src/packages/user/current-user/current-user-header-app.element.ts
+++ b/src/packages/user/current-user/current-user-header-app.element.ts
@@ -2,7 +2,7 @@ import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { css, CSSResultGroup, html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
 import {
 	UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UMB_CURRENT_USER_MODAL,
 } from '@umbraco-cms/backoffice/modal';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
@@ -19,7 +19,7 @@ export class UmbCurrentUserHeaderAppElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalManagerContext = instance;
 		});
 

--- a/src/packages/user/current-user/current-user-history.store.ts
+++ b/src/packages/user/current-user/current-user-history.store.ts
@@ -20,7 +20,7 @@ export class UmbCurrentUserHistoryStore extends UmbStoreBase<UmbCurrentUserHisto
 	constructor(host: UmbControllerHost) {
 		super(
 			host,
-			UMB_CURRENT_USER_HISTORY_STORE_CONTEXT_TOKEN.toString(),
+			UMB_CURRENT_USER_HISTORY_STORE_CONTEXT.toString(),
 			new UmbArrayState<UmbCurrentUserHistoryItem>([], (x) => x.unique),
 		);
 		if (!('navigation' in window)) return;
@@ -61,7 +61,7 @@ export class UmbCurrentUserHistoryStore extends UmbStoreBase<UmbCurrentUserHisto
 	}
 }
 
-export const UMB_CURRENT_USER_HISTORY_STORE_CONTEXT_TOKEN = new UmbContextToken<UmbCurrentUserHistoryStore>(
+export const UMB_CURRENT_USER_HISTORY_STORE_CONTEXT = new UmbContextToken<UmbCurrentUserHistoryStore>(
 	'UmbCurrentUserHistoryStore',
 );
 

--- a/src/packages/user/current-user/user-profile-apps/user-profile-app-history.element.ts
+++ b/src/packages/user/current-user/user-profile-apps/user-profile-app-history.element.ts
@@ -1,7 +1,7 @@
 import {
 	UmbCurrentUserHistoryItem,
 	UmbCurrentUserHistoryStore,
-	UMB_CURRENT_USER_HISTORY_STORE_CONTEXT_TOKEN,
+	UMB_CURRENT_USER_HISTORY_STORE_CONTEXT,
 } from '../current-user-history.store.js';
 import { css, html, nothing, customElement, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
@@ -17,7 +17,7 @@ export class UmbUserProfileAppHistoryElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_CURRENT_USER_HISTORY_STORE_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_CURRENT_USER_HISTORY_STORE_CONTEXT, (instance) => {
 			this.#currentUserHistoryStore = instance;
 			this.#observeHistory();
 		});

--- a/src/packages/user/current-user/user-profile-apps/user-profile-app-profile.element.ts
+++ b/src/packages/user/current-user/user-profile-apps/user-profile-app-profile.element.ts
@@ -4,7 +4,7 @@ import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 import {
 	UmbModalManagerContext,
 	UMB_CHANGE_PASSWORD_MODAL,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 } from '@umbraco-cms/backoffice/modal';
 import { UMB_CURRENT_USER_CONTEXT, type UmbCurrentUser } from '@umbraco-cms/backoffice/current-user';
 
@@ -19,7 +19,7 @@ export class UmbUserProfileAppProfileElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalManagerContext = instance;
 		});
 

--- a/src/packages/user/current-user/user-profile-apps/user-profile-app-themes.element.ts
+++ b/src/packages/user/current-user/user-profile-apps/user-profile-app-themes.element.ts
@@ -1,4 +1,4 @@
-import { UmbThemeContext, UMB_THEME_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/themes';
+import { UmbThemeContext, UMB_THEME_CONTEXT } from '@umbraco-cms/backoffice/themes';
 import { css, html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
 import { UUISelectEvent } from '@umbraco-cms/backoffice/external/uui';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
@@ -16,7 +16,7 @@ export class UmbUserProfileAppThemesElement extends UmbLitElement {
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_THEME_CONTEXT_TOKEN, (context) => {
+		this.consumeContext(UMB_THEME_CONTEXT, (context) => {
 			this.#themeContext = context;
 			this.observe(
 				context.theme,

--- a/src/packages/user/user-group/collection/repository/user-group-collection.repository.ts
+++ b/src/packages/user/user-group/collection/repository/user-group-collection.repository.ts
@@ -1,5 +1,5 @@
 import { UmbUserGroupCollectionFilterModel } from '../../types.js';
-import { UMB_USER_GROUP_STORE_CONTEXT_TOKEN, UmbUserGroupStore } from '../../repository/user-group.store.js';
+import { UMB_USER_GROUP_STORE_CONTEXT, UmbUserGroupStore } from '../../repository/user-group.store.js';
 import { UmbUserGroupCollectionServerDataSource } from './user-group-collection.server.data-source.js';
 import { UserGroupResponseModel } from '@umbraco-cms/backoffice/backend-api';
 import { UmbCollectionDataSource, UmbCollectionRepository } from '@umbraco-cms/backoffice/repository';
@@ -16,7 +16,7 @@ export class UmbUserGroupCollectionRepository extends UmbBaseController implemen
 		super(host);
 		this.#collectionSource = new UmbUserGroupCollectionServerDataSource(this._host);
 
-		this.#init = this.consumeContext(UMB_USER_GROUP_STORE_CONTEXT_TOKEN, (instance) => {
+		this.#init = this.consumeContext(UMB_USER_GROUP_STORE_CONTEXT, (instance) => {
 			this.#detailStore = instance;
 		}).asPromise();
 	}

--- a/src/packages/user/user-group/entity-bulk-actions/delete/delete.action.ts
+++ b/src/packages/user/user-group/entity-bulk-actions/delete/delete.action.ts
@@ -3,11 +3,7 @@ import { html } from '@umbraco-cms/backoffice/external/lit';
 import { UmbEntityBulkActionBase } from '@umbraco-cms/backoffice/entity-bulk-action';
 import type { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
 import { UmbContextConsumerController } from '@umbraco-cms/backoffice/context-api';
-import {
-	UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
-	UMB_CONFIRM_MODAL,
-} from '@umbraco-cms/backoffice/modal';
+import { UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT, UMB_CONFIRM_MODAL } from '@umbraco-cms/backoffice/modal';
 
 export class UmbDeleteUserGroupEntityBulkAction extends UmbEntityBulkActionBase<UmbUserGroupRepository> {
 	#modalContext?: UmbModalManagerContext;
@@ -15,7 +11,7 @@ export class UmbDeleteUserGroupEntityBulkAction extends UmbEntityBulkActionBase<
 	constructor(host: UmbControllerHostElement, repositoryAlias: string, selection: Array<string>) {
 		super(host, repositoryAlias, selection);
 
-		new UmbContextConsumerController(host, UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		new UmbContextConsumerController(host, UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalContext = instance;
 		});
 	}

--- a/src/packages/user/user-group/repository/user-group-item.store.ts
+++ b/src/packages/user/user-group/repository/user-group-item.store.ts
@@ -17,10 +17,8 @@ export class UmbUserGroupItemStore extends UmbEntityItemStore<UserGroupItemRespo
 	 * @memberof UmbUserGroupItemStore
 	 */
 	constructor(host: UmbControllerHostElement) {
-		super(host, UMB_USER_GROUP_ITEM_STORE_CONTEXT_TOKEN.toString());
+		super(host, UMB_USER_GROUP_ITEM_STORE_CONTEXT.toString());
 	}
 }
 
-export const UMB_USER_GROUP_ITEM_STORE_CONTEXT_TOKEN = new UmbContextToken<UmbUserGroupItemStore>(
-	'UmbUserGroupItemStore',
-);
+export const UMB_USER_GROUP_ITEM_STORE_CONTEXT = new UmbContextToken<UmbUserGroupItemStore>('UmbUserGroupItemStore');

--- a/src/packages/user/user-group/repository/user-group.repository.ts
+++ b/src/packages/user/user-group/repository/user-group.repository.ts
@@ -1,6 +1,6 @@
 import { UmbUserGroupDetailDataSource } from '../types.js';
 import { UmbUserGroupServerDataSource } from './sources/user-group.server.data-source.js';
-import { UMB_USER_GROUP_ITEM_STORE_CONTEXT_TOKEN, UmbUserGroupItemStore } from './user-group-item.store.js';
+import { UMB_USER_GROUP_ITEM_STORE_CONTEXT, UmbUserGroupItemStore } from './user-group-item.store.js';
 import { UmbUserGroupItemServerDataSource } from './sources/user-group-item.server.data-source.js';
 import { Observable } from '@umbraco-cms/backoffice/external/rxjs';
 import { UserGroupItemResponseModel, UserGroupResponseModel } from '@umbraco-cms/backoffice/backend-api';
@@ -10,7 +10,7 @@ import {
 	UmbDataSourceErrorResponse,
 	DataSourceResponse,
 } from '@umbraco-cms/backoffice/repository';
-import { UMB_NOTIFICATION_CONTEXT_TOKEN, UmbNotificationContext } from '@umbraco-cms/backoffice/notification';
+import { UMB_NOTIFICATION_CONTEXT, UmbNotificationContext } from '@umbraco-cms/backoffice/notification';
 import { type UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbBaseController } from '@umbraco-cms/backoffice/class-api';
 import { UmbApi } from '@umbraco-cms/backoffice/extension-api';
@@ -37,16 +37,16 @@ export class UmbUserGroupRepository
 
 		this.#init = Promise.all([
 			/*
-			this.consumeContext(UMB_USER_GROUP_STORE_CONTEXT_TOKEN, (instance) => {
+			this.consumeContext(UMB_USER_GROUP_STORE_CONTEXT, (instance) => {
 				this.#detailStore = instance;
 			}).asPromise(),
 			*/
 
-			this.consumeContext(UMB_USER_GROUP_ITEM_STORE_CONTEXT_TOKEN, (instance) => {
+			this.consumeContext(UMB_USER_GROUP_ITEM_STORE_CONTEXT, (instance) => {
 				this.#itemStore = instance;
 			}).asPromise(),
 
-			this.consumeContext(UMB_NOTIFICATION_CONTEXT_TOKEN, (instance) => {
+			this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => {
 				this.#notificationContext = instance;
 			}).asPromise(),
 		]);

--- a/src/packages/user/user-group/repository/user-group.store.ts
+++ b/src/packages/user/user-group/repository/user-group.store.ts
@@ -4,7 +4,7 @@ import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api
 import { UmbArrayState } from '@umbraco-cms/backoffice/observable-api';
 import { UmbStoreBase } from '@umbraco-cms/backoffice/store';
 
-export const UMB_USER_GROUP_STORE_CONTEXT_TOKEN = new UmbContextToken<UmbUserGroupStore>('UmbUserGroupStore');
+export const UMB_USER_GROUP_STORE_CONTEXT = new UmbContextToken<UmbUserGroupStore>('UmbUserGroupStore');
 
 /**
  * @export
@@ -14,6 +14,6 @@ export const UMB_USER_GROUP_STORE_CONTEXT_TOKEN = new UmbContextToken<UmbUserGro
  */
 export class UmbUserGroupStore extends UmbStoreBase {
 	constructor(host: UmbControllerHostElement) {
-		super(host, UMB_USER_GROUP_STORE_CONTEXT_TOKEN.toString(), new UmbArrayState<UserGroupDetails>([], (x) => x.id));
+		super(host, UMB_USER_GROUP_STORE_CONTEXT.toString(), new UmbArrayState<UserGroupDetails>([], (x) => x.id));
 	}
 }

--- a/src/packages/user/user/collection/action/create-user.collection-action.ts
+++ b/src/packages/user/user/collection/action/create-user.collection-action.ts
@@ -2,7 +2,7 @@ import { UmbCollectionActionBase } from '@umbraco-cms/backoffice/collection';
 import { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import {
 	UMB_CREATE_USER_MODAL,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UmbModalManagerContext,
 } from '@umbraco-cms/backoffice/modal';
 
@@ -12,7 +12,7 @@ export class UmbCreateUserCollectionAction extends UmbCollectionActionBase {
 	constructor(host: UmbControllerHost) {
 		super(host);
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalManagerContext = instance;
 		});
 	}

--- a/src/packages/user/user/entity-actions/change-password/change-user-password.action.ts
+++ b/src/packages/user/user/entity-actions/change-password/change-user-password.action.ts
@@ -3,7 +3,7 @@ import { UmbEntityActionBase } from '@umbraco-cms/backoffice/entity-action';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
 import {
 	type UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UMB_CHANGE_PASSWORD_MODAL,
 } from '@umbraco-cms/backoffice/modal';
 
@@ -13,7 +13,7 @@ export class UmbChangeUserPasswordEntityAction extends UmbEntityActionBase<UmbCh
 	constructor(host: UmbControllerHostElement, repositoryAlias: string, unique: string) {
 		super(host, repositoryAlias, unique);
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalManager = instance;
 		});
 	}

--- a/src/packages/user/user/entity-actions/disable/disable-user.action.ts
+++ b/src/packages/user/user/entity-actions/disable/disable-user.action.ts
@@ -4,7 +4,7 @@ import { UmbEntityActionBase } from '@umbraco-cms/backoffice/entity-action';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
 import {
 	type UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UMB_CONFIRM_MODAL,
 } from '@umbraco-cms/backoffice/modal';
 
@@ -17,7 +17,7 @@ export class UmbDisableUserEntityAction extends UmbEntityActionBase<UmbDisableUs
 
 		this.#itemRepository = new UmbUserItemRepository(this);
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalManager = instance;
 		});
 	}

--- a/src/packages/user/user/entity-actions/enable/enable-user.action.ts
+++ b/src/packages/user/user/entity-actions/enable/enable-user.action.ts
@@ -4,7 +4,7 @@ import { UmbEntityActionBase } from '@umbraco-cms/backoffice/entity-action';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
 import {
 	type UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UMB_CONFIRM_MODAL,
 } from '@umbraco-cms/backoffice/modal';
 
@@ -17,7 +17,7 @@ export class UmbEnableUserEntityAction extends UmbEntityActionBase<UmbEnableUser
 
 		this.#itemRepository = new UmbUserItemRepository(this);
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalManager = instance;
 		});
 	}

--- a/src/packages/user/user/entity-actions/unlock/unlock-user.action.ts
+++ b/src/packages/user/user/entity-actions/unlock/unlock-user.action.ts
@@ -4,7 +4,7 @@ import { UmbEntityActionBase } from '@umbraco-cms/backoffice/entity-action';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
 import {
 	type UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UMB_CONFIRM_MODAL,
 } from '@umbraco-cms/backoffice/modal';
 
@@ -17,7 +17,7 @@ export class UmbUnlockUserEntityAction extends UmbEntityActionBase<UmbUnlockUser
 
 		this.#itemRepository = new UmbUserItemRepository(this);
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalManager = instance;
 		});
 	}

--- a/src/packages/user/user/entity-bulk-actions/delete/delete.action.ts
+++ b/src/packages/user/user/entity-bulk-actions/delete/delete.action.ts
@@ -3,11 +3,7 @@ import { html } from '@umbraco-cms/backoffice/external/lit';
 import { UmbEntityBulkActionBase } from '@umbraco-cms/backoffice/entity-bulk-action';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
 import { UmbContextConsumerController } from '@umbraco-cms/backoffice/context-api';
-import {
-	UmbModalManagerContext,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
-	UMB_CONFIRM_MODAL,
-} from '@umbraco-cms/backoffice/modal';
+import { UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT, UMB_CONFIRM_MODAL } from '@umbraco-cms/backoffice/modal';
 
 export class UmbUserDeleteEntityBulkAction extends UmbEntityBulkActionBase<UmbUserDetailRepository> {
 	#modalContext?: UmbModalManagerContext;
@@ -15,7 +11,7 @@ export class UmbUserDeleteEntityBulkAction extends UmbEntityBulkActionBase<UmbUs
 	constructor(host: UmbControllerHostElement, repositoryAlias: string, selection: Array<string>) {
 		super(host, repositoryAlias, selection);
 
-		new UmbContextConsumerController(host, UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		new UmbContextConsumerController(host, UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalContext = instance;
 		});
 	}

--- a/src/packages/user/user/entity-bulk-actions/set-group/set-group.action.ts
+++ b/src/packages/user/user/entity-bulk-actions/set-group/set-group.action.ts
@@ -2,7 +2,7 @@ import { UmbUserRepository } from '../../repository/user.repository.js';
 import { UmbEntityBulkActionBase } from '@umbraco-cms/backoffice/entity-bulk-action';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
 import { UmbContextConsumerController } from '@umbraco-cms/backoffice/context-api';
-import { UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/modal';
+import { UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
 
 export class UmbSetGroupUserEntityBulkAction extends UmbEntityBulkActionBase<UmbUserRepository> {
 	#modalContext?: UmbModalManagerContext;
@@ -10,7 +10,7 @@ export class UmbSetGroupUserEntityBulkAction extends UmbEntityBulkActionBase<Umb
 	constructor(host: UmbControllerHostElement, repositoryAlias: string, selection: Array<string>) {
 		super(host, repositoryAlias, selection);
 
-		new UmbContextConsumerController(host, UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		new UmbContextConsumerController(host, UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalContext = instance;
 
 			//TODO: add user group picker modal

--- a/src/packages/user/user/invite/collection-action/invite-user.collection-action.ts
+++ b/src/packages/user/user/invite/collection-action/invite-user.collection-action.ts
@@ -1,7 +1,7 @@
 import { UMB_INVITE_USER_MODAL } from '../modal/index.js';
 import { UmbCollectionActionBase } from '@umbraco-cms/backoffice/collection';
 import { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
-import { UMB_MODAL_MANAGER_CONTEXT_TOKEN, UmbModalManagerContext } from '@umbraco-cms/backoffice/modal';
+import { UMB_MODAL_MANAGER_CONTEXT, UmbModalManagerContext } from '@umbraco-cms/backoffice/modal';
 
 export class UmbInviteUserCollectionAction extends UmbCollectionActionBase {
 	#modalManagerContext: UmbModalManagerContext | undefined;
@@ -9,7 +9,7 @@ export class UmbInviteUserCollectionAction extends UmbCollectionActionBase {
 	constructor(host: UmbControllerHost) {
 		super(host);
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalManagerContext = instance;
 		});
 	}

--- a/src/packages/user/user/invite/entity-action/resend-invite/resend-invite.action.ts
+++ b/src/packages/user/user/invite/entity-action/resend-invite/resend-invite.action.ts
@@ -2,7 +2,7 @@ import { type UmbEnableUserRepository } from '../../../repository/enable/enable-
 import { UMB_RESEND_INVITE_TO_USER_MODAL } from '../../index.js';
 import { UmbEntityActionBase } from '@umbraco-cms/backoffice/entity-action';
 import { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
-import { type UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/modal';
+import { type UmbModalManagerContext, UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
 
 export class UmbResendInviteToUserEntityAction extends UmbEntityActionBase<UmbEnableUserRepository> {
 	#modalManager?: UmbModalManagerContext;
@@ -10,7 +10,7 @@ export class UmbResendInviteToUserEntityAction extends UmbEntityActionBase<UmbEn
 	constructor(host: UmbControllerHostElement, repositoryAlias: string, unique: string) {
 		super(host, repositoryAlias, unique);
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this.#modalManager = instance;
 		});
 	}

--- a/src/packages/user/user/modals/create/user-create-modal.element.ts
+++ b/src/packages/user/user/modals/create/user-create-modal.element.ts
@@ -4,7 +4,7 @@ import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { css, html, customElement, query } from '@umbraco-cms/backoffice/external/lit';
 import {
 	UmbModalBaseElement,
-	UMB_MODAL_MANAGER_CONTEXT_TOKEN,
+	UMB_MODAL_MANAGER_CONTEXT,
 	UMB_CREATE_USER_SUCCESS_MODAL,
 	UmbModalManagerContext,
 } from '@umbraco-cms/backoffice/modal';
@@ -20,7 +20,7 @@ export class UmbUserCreateModalElement extends UmbModalBaseElement {
 	connectedCallback(): void {
 		super.connectedCallback();
 
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (_instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (_instance) => {
 			this.#modalManagerContext = _instance;
 		});
 	}

--- a/src/packages/user/user/modals/create/user-create-success-modal.element.ts
+++ b/src/packages/user/user/modals/create/user-create-success-modal.element.ts
@@ -5,7 +5,7 @@ import { UUIInputPasswordElement } from '@umbraco-cms/backoffice/external/uui';
 import {
 	UmbNotificationDefaultData,
 	UmbNotificationContext,
-	UMB_NOTIFICATION_CONTEXT_TOKEN,
+	UMB_NOTIFICATION_CONTEXT,
 } from '@umbraco-cms/backoffice/notification';
 import {
 	UmbCreateUserSuccessModalData,
@@ -28,7 +28,7 @@ export class UmbUserCreateSuccessModalElement extends UmbModalBaseElement<
 	connectedCallback(): void {
 		super.connectedCallback();
 
-		this.consumeContext(UMB_NOTIFICATION_CONTEXT_TOKEN, (instance) => (this.#notificationContext = instance));
+		this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => (this.#notificationContext = instance));
 	}
 
 	protected async firstUpdated(): Promise<void> {

--- a/src/packages/user/user/repository/user-repository-base.ts
+++ b/src/packages/user/user/repository/user-repository-base.ts
@@ -1,7 +1,7 @@
-import { UMB_USER_STORE_CONTEXT_TOKEN, UmbUserStore } from './user.store.js';
+import { UMB_USER_STORE_CONTEXT, UmbUserStore } from './user.store.js';
 import { UMB_USER_ITEM_STORE_CONTEXT, UmbUserItemStore } from './item/user-item.store.js';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
-import { UMB_NOTIFICATION_CONTEXT_TOKEN, UmbNotificationContext } from '@umbraco-cms/backoffice/notification';
+import { UMB_NOTIFICATION_CONTEXT, UmbNotificationContext } from '@umbraco-cms/backoffice/notification';
 import { UmbRepositoryBase } from '@umbraco-cms/backoffice/repository';
 
 export class UmbUserRepositoryBase extends UmbRepositoryBase {
@@ -15,7 +15,7 @@ export class UmbUserRepositoryBase extends UmbRepositoryBase {
 		super(host);
 
 		this.init = Promise.all([
-			this.consumeContext(UMB_USER_STORE_CONTEXT_TOKEN, (instance) => {
+			this.consumeContext(UMB_USER_STORE_CONTEXT, (instance) => {
 				this.detailStore = instance;
 			}).asPromise(),
 
@@ -23,7 +23,7 @@ export class UmbUserRepositoryBase extends UmbRepositoryBase {
 				this.itemStore = instance;
 			}).asPromise(),
 
-			this.consumeContext(UMB_NOTIFICATION_CONTEXT_TOKEN, (instance) => {
+			this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => {
 				this.notificationContext = instance;
 			}).asPromise(),
 		]);

--- a/src/packages/user/user/repository/user.store.ts
+++ b/src/packages/user/user/repository/user.store.ts
@@ -4,7 +4,7 @@ import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
 import { UmbStoreBase } from '@umbraco-cms/backoffice/store';
 import { type UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
 
-export const UMB_USER_STORE_CONTEXT_TOKEN = new UmbContextToken<UmbUserStore>('UmbUserStore');
+export const UMB_USER_STORE_CONTEXT = new UmbContextToken<UmbUserStore>('UmbUserStore');
 
 /**
  * @export
@@ -14,7 +14,7 @@ export const UMB_USER_STORE_CONTEXT_TOKEN = new UmbContextToken<UmbUserStore>('U
  */
 export class UmbUserStore extends UmbStoreBase {
 	constructor(host: UmbControllerHostElement) {
-		super(host, UMB_USER_STORE_CONTEXT_TOKEN.toString(), new UmbArrayState<UmbUserDetailModel>([], (x) => x.id));
+		super(host, UMB_USER_STORE_CONTEXT.toString(), new UmbArrayState<UmbUserDetailModel>([], (x) => x.id));
 	}
 
 	/**

--- a/src/shared/resources/resource.controller.ts
+++ b/src/shared/resources/resource.controller.ts
@@ -2,7 +2,7 @@
 import { isApiError, isCancelError, isCancelablePromise } from './apiTypeValidators.function.js';
 import {
 	UmbNotificationContext,
-	UMB_NOTIFICATION_CONTEXT_TOKEN,
+	UMB_NOTIFICATION_CONTEXT,
 	UmbNotificationOptions,
 } from '@umbraco-cms/backoffice/notification';
 import { type UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
@@ -20,7 +20,7 @@ export class UmbResourceController extends UmbBaseController {
 
 		this.#promise = promise;
 
-		new UmbContextConsumerController(host, UMB_NOTIFICATION_CONTEXT_TOKEN, (_instance) => {
+		new UmbContextConsumerController(host, UMB_NOTIFICATION_CONTEXT, (_instance) => {
 			this.#notificationContext = _instance;
 		});
 	}

--- a/src/shared/router/route.context.ts
+++ b/src/shared/router/route.context.ts
@@ -4,7 +4,7 @@ import type { IRoutingInfo, IRouterSlot } from '@umbraco-cms/backoffice/external
 import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
 import { type UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
 import { UmbBaseController } from '@umbraco-cms/backoffice/class-api';
-import { UMB_MODAL_MANAGER_CONTEXT_TOKEN, UmbModalRouteRegistration } from '@umbraco-cms/backoffice/modal';
+import { UMB_MODAL_MANAGER_CONTEXT, UmbModalRouteRegistration } from '@umbraco-cms/backoffice/modal';
 
 const EmptyDiv = document.createElement('div');
 
@@ -14,7 +14,7 @@ export class UmbRouteContext extends UmbBaseController {
 	#mainRouter: IRouterSlot;
 	#modalRouter: IRouterSlot;
 	#modalRegistrations: UmbModalRouteRegistration[] = [];
-	#modalContext?: typeof UMB_MODAL_MANAGER_CONTEXT_TOKEN.TYPE;
+	#modalContext?: typeof UMB_MODAL_MANAGER_CONTEXT.TYPE;
 	#modalRoutes: UmbRoutePlusModalKey[] = [];
 	#routerBasePath?: string;
 	#routerActiveLocalPath?: string;
@@ -24,8 +24,8 @@ export class UmbRouteContext extends UmbBaseController {
 		super(host);
 		this.#mainRouter = mainRouter;
 		this.#modalRouter = modalRouter;
-		this.provideContext(UMB_ROUTE_CONTEXT_TOKEN, this);
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (context) => {
+		this.provideContext(UMB_ROUTE_CONTEXT, this);
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (context) => {
 			this.#modalContext = context;
 			this.#generateModalRoutes();
 		});
@@ -154,4 +154,4 @@ export class UmbRouteContext extends UmbBaseController {
 	};
 }
 
-export const UMB_ROUTE_CONTEXT_TOKEN = new UmbContextToken<UmbRouteContext>('UmbRouterContext');
+export const UMB_ROUTE_CONTEXT = new UmbContextToken<UmbRouteContext>('UmbRouterContext');

--- a/storybook/stories/context-api.mdx
+++ b/storybook/stories/context-api.mdx
@@ -32,9 +32,9 @@ new UmbContextConsumerController(host, 'requestThisContextAlias', (context) => {
 Using a Context Token gives you a typed context:
 
 ```ts
-import { UMB_NOTIFICATION_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/notification';
+import { UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
 
-this.consumeContext(UMB_NOTIFICATION_CONTEXT_TOKEN, (context) => {
+this.consumeContext(UMB_NOTIFICATION_CONTEXT, (context) => {
 	// Notice this is a subscription, as context might change or a new one appears, but the value is strongly typed
 	console.log("I've got the context of the right type", context);
 });
@@ -52,7 +52,7 @@ type MyContext = {
 	bar: number;
 };
 
-const MY_CONTEXT_TOKEN = new ContextToken<MyContext>('My.Context.Token');
+const MY_CONTEXT = new ContextToken<MyContext>('My.Context.Token');
 ```
 
 #### Context Token with discriminator.
@@ -79,38 +79,37 @@ import { ContextToken } from '@umbraco-cms/backoffice/context';
 interface MyBaseContext {
 	foo: string;
 	bar: number;
-};
+}
 
 interface MyPublishableContext extends MyBaseContext {
-	publish()
-};
+	publish();
+}
 
-const MY_PUBLISHABLE_CONTEXT_TOKEN = new ContextToken<MyContext, MyPublishableContext>('My.Context.Token', (context): context is MyPublishableContext => {
-	return 'publish' in context;
-});
+const MY_PUBLISHABLE_CONTEXT = new ContextToken<MyContext, MyPublishableContext>(
+	'My.Context.Token',
+	(context): context is MyPublishableContext => {
+		return 'publish' in context;
+	},
+);
 ```
 
 Implementation of context token example:
 
 ```ts
-
 const contextElement = new UmbLitElement();
-contextElement.provideContext(MY_PUBLISHABLE_CONTEXT_TOKEN, new MyPublishableContext());
-
+contextElement.provideContext(MY_PUBLISHABLE_CONTEXT, new MyPublishableContext());
 
 const consumerElement = new UmbLitElement();
 contextElement.appendChild(contextElement);
-consumerElement.consumeContext(MY_PUBLISHABLE_CONTEXT_TOKEN, (context) => {
+consumerElement.consumeContext(MY_PUBLISHABLE_CONTEXT, (context) => {
 	// context is of type 'MyPublishableContext'
 	console.log("I've got the context of the right type", context);
 });
-
 ```
 
 This enables implementors to request a publishable context, without the knowledge about how do identify such, neither they need to know about the Type.
 
 In details, the Context API will find the first API matching alias 'My.Context.Token', and never look furhter. If that API does live up to the type discriminator, it will be returned. If not the consumer will never reply.
-
 
 ### Provide a Context API.
 

--- a/storybook/stories/extending/entity-actions.mdx
+++ b/storybook/stories/extending/entity-actions.mdx
@@ -131,14 +131,14 @@ If any additional contexts are needed, these can be consumed from the host eleme
 ```ts
 import { UmbEntityActionBase } from '@umbraco-cms/entity-action';
 import { UmbContextConsumerController } from '@umbraco-cms/controller';
-import { UMB_MODAL_SERVICE_CONTEXT_TOKEN } from '@umbraco-cms/modal';
+import { UMB_MODAL_SERVICE_CONTEXT } from '@umbraco-cms/modal';
 import { MyRepository } from './my-repository';
 
 export class MyEntityAction extends UmbEntityActionBase<MyRepository> {
 	constructor(host: UmbControllerHostElement, repositoryAlias: string, unique: string) {
 		super(host, repositoryAlias, unique);
 
-		new UmbContextConsumerController(this.host, UMB_MODAL_SERVICE_CONTEXT_TOKEN, (instance) => {
+		new UmbContextConsumerController(this.host, UMB_MODAL_SERVICE_CONTEXT, (instance) => {
 			this.#modalService = instance;
 		});
 	}
@@ -184,10 +184,12 @@ const manifest = {
 		label: 'My Entity Bulk Action',
 		repositoryAlias: 'My.Repository',
 	},
-	conditions: [{
-		alias: 'Umb.Condition.CollectionAlias',
-		match: 'my-collection-alias',
-	}],
+	conditions: [
+		{
+			alias: 'Umb.Condition.CollectionAlias',
+			match: 'my-collection-alias',
+		},
+	],
 };
 
 extensionRegistry.register(manifest);

--- a/storybook/stories/extending/registration/conditions.mdx
+++ b/storybook/stories/extending/registration/conditions.mdx
@@ -58,7 +58,7 @@ import {
 	UmbConditionControllerArguments,
 	UmbExtensionCondition,
 } from '@umbraco-cms/backoffice/extension-api';
-import { UMB_SECTION_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/section';
+import { UMB_SECTION_CONTEXT } from '@umbraco-cms/backoffice/section';
 
 type MyConditionConfig = UmbConditionConfigBase & {
 	match: string;

--- a/storybook/stories/modal/modal.mdx
+++ b/storybook/stories/modal/modal.mdx
@@ -181,7 +181,7 @@ class MyElement extends UmbElementMixin(LitElement) {
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_MODAL_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_CONTEXT, (instance) => {
 			this.#modalManagerContext = instance;
 			// modalManagerContext is now ready to be used
 		});

--- a/storybook/stories/modal/story-modal-service-example.element.ts
+++ b/storybook/stories/modal/story-modal-service-example.element.ts
@@ -1,6 +1,6 @@
 import { html, customElement, property, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
-import { UMB_MODAL_MANAGER_CONTEXT_TOKEN, UmbModalManagerContext } from '@umbraco-cms/backoffice/modal';
+import { UMB_MODAL_MANAGER_CONTEXT, UmbModalManagerContext } from '@umbraco-cms/backoffice/modal';
 
 @customElement('umb-story-modal-context-example')
 export class UmbStoryModalContextExampleElement extends UmbLitElement {
@@ -14,7 +14,7 @@ export class UmbStoryModalContextExampleElement extends UmbLitElement {
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT_TOKEN, (instance) => {
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
 			this._modalContext = instance;
 		});
 	}

--- a/storybook/stories/umb-element.mdx
+++ b/storybook/stories/umb-element.mdx
@@ -27,9 +27,9 @@ this.consumeContext('requestThisContextAlias', (context) => {
 Or use the a Context Token to get a typed context:
 
 ```ts
-import { UMB_NOTIFICATION_CONTEXT_TOKEN } from '@umbraco-cms/backoffice/notification';
+import { UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
 
-this.consumeContext(UMB_NOTIFICATION_CONTEXT_TOKEN, (context) => {
+this.consumeContext(UMB_NOTIFICATION_CONTEXT, (context) => {
 	// Notice this is a subscription, as context might change or a new one appears, but the value is strongly typed
 	console.log("I've got the context", context);
 });


### PR DESCRIPTION
Most of the early Context Tokens was named UMB_MYNAME_CONTEXT_TOKEN.

But we god away from using the _TOKEN part for new tokens. Mainly cause it seems unnecessary in a consumption perspective. (also we dont use Token when naming Modal Tokens)

Like in this example:

`
		this.consumeContext(UMB_NOTIFICATION_CONTEXT, (_instance) => {
			this._notificationContext = _instance;
		});
`

it does not matter much to the reader that its a TOKEN, that is part of its type and we dont spell out types in general.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
