### PR TITLE
Make data type picker modal medium

### DIFF
--- a/src/packages/core/modal/token/data-type-picker-flow-modal.token.ts
+++ b/src/packages/core/modal/token/data-type-picker-flow-modal.token.ts
@@ -14,6 +14,6 @@ export const UMB_DATA_TYPE_PICKER_FLOW_MODAL = new UmbModalToken<
 >('Umb.Modal.DataTypePickerFlow', {
 	modal: {
 		type: 'sidebar',
-		size: 'small',
+		size: 'medium',
 	},
 });


### PR DESCRIPTION
Fix for the data type picker modal size: https://github.com/umbraco/Umbraco.CMS.Backoffice/issues/846

