### PR TITLE
Multi-URL Picker: Removing UDI support

### DIFF
--- a/src/mocks/data/document/document.data.ts
+++ b/src/mocks/data/document/document.data.ts
@@ -40,7 +40,7 @@ export const data: Array<UmbMockDocumentModel> = [
 					blocks: {},
 					markup: `
 						<p>
-							Some value for the RTE with an <a href="https://google.com">external link</a> and an <a href="/{localLink:umb://document/c05da24d7740447b9cdcbd8ce2172e38}">internal link</a> foo foo
+							Some value for the RTE with an <a href="https://google.com">external link</a> and an <a type="document" href="/{localLink:c05da24d-7740-447b-9cdc-bd8ce2172e38}">internal link</a> foo foo
 						</p>
 						<div class="umb-macro-holder TestMacro umb-macro-mce_1 mceNonEditable"><!-- <?UMBRACO_MACRO macroAlias="TestMacro" /> --><ins>Macro alias: <strong>TestMacro</strong></ins></div>
 						<p>The following tests the embed plugin:</p>

--- a/src/packages/core/components/input-multi-url/input-multi-url.element.ts
+++ b/src/packages/core/components/input-multi-url/input-multi-url.element.ts
@@ -3,12 +3,8 @@ import { FormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import type { UUIModalSidebarSize } from '@umbraco-cms/backoffice/external/uui';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
 import type { UmbVariantId } from '@umbraco-cms/backoffice/variant';
-import {
-	UMB_LINK_PICKER_MODAL,
-	UmbModalRouteRegistrationController,
-} from '@umbraco-cms/backoffice/modal';
-import type { UmbModalRouteBuilder ,
-	UmbLinkPickerLink} from '@umbraco-cms/backoffice/modal';
+import { UMB_LINK_PICKER_MODAL, UmbModalRouteRegistrationController } from '@umbraco-cms/backoffice/modal';
+import type { UmbModalRouteBuilder, UmbLinkPickerLink } from '@umbraco-cms/backoffice/modal';
 
 /**
  * @element umb-input-multi-url
@@ -109,6 +105,7 @@ export class UmbInputMultiUrlElement extends FormControlMixin(UmbLitElement) {
 
 	constructor() {
 		super();
+
 		this.addValidator(
 			'rangeUnderflow',
 			() => this.minMessage,
@@ -155,7 +152,8 @@ export class UmbInputMultiUrlElement extends FormControlMixin(UmbLitElement) {
 							queryString: data?.queryString,
 							target: data?.target,
 							trashed: data?.trashed,
-							udi: data?.udi,
+							type: data?.type,
+							unique: data?.unique,
 							url: data?.url,
 						},
 					},

--- a/src/packages/core/modal/common/link-picker/link-picker-modal.element.ts
+++ b/src/packages/core/modal/common/link-picker/link-picker-modal.element.ts
@@ -4,11 +4,11 @@ import type { UUIBooleanInputEvent, UUIInputElement } from '@umbraco-cms/backoff
 import type {
 	UmbLinkPickerConfig,
 	UmbLinkPickerLink,
+	UmbLinkPickerLinkType,
 	UmbLinkPickerModalData,
 	UmbLinkPickerModalValue,
 } from '@umbraco-cms/backoffice/modal';
 import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
-import { buildUdi, getKeyFromUdi } from '@umbraco-cms/backoffice/utils';
 import { UMB_DOCUMENT_TREE_ALIAS } from '@umbraco-cms/backoffice/document';
 
 @customElement('umb-link-picker-modal')
@@ -57,7 +57,7 @@ export class UmbLinkPickerModalElement extends UmbModalBaseElement<UmbLinkPicker
 		if (this.modalContext) {
 			this.observe(this.modalContext.value, (value) => {
 				(this._link as any) = value.link;
-				this._selectedKey = this._link?.udi ? getKeyFromUdi(this._link.udi) : undefined;
+				this._selectedKey = this._link?.unique ?? undefined;
 				this._selectionConfiguration.selection = this._selectedKey ? [this._selectedKey] : [];
 			});
 		}
@@ -88,18 +88,18 @@ export class UmbLinkPickerModalElement extends UmbModalBaseElement<UmbLinkPicker
 		const selectedKey = selection[selection.length - 1];
 
 		if (!selectedKey) {
-			this.#partialUpdateLink({ udi: '', url: undefined });
+			this.#partialUpdateLink({ type: undefined, unique: '', url: undefined });
 			this._selectedKey = undefined;
 			this._selectionConfiguration.selection = [];
 			this.requestUpdate();
 			return;
 		}
 
-		const udi = buildUdi(entityType, selectedKey);
+		const linkType = (entityType as UmbLinkPickerLinkType) ?? 'external';
 
 		this._selectedKey = selectedKey;
 		this._selectionConfiguration.selection = [this._selectedKey];
-		this.#partialUpdateLink({ udi: udi, url: udi });
+		this.#partialUpdateLink({ type: linkType, unique: selectedKey, url: selectedKey });
 		this.requestUpdate();
 	}
 
@@ -154,9 +154,9 @@ export class UmbLinkPickerModalElement extends UmbModalBaseElement<UmbLinkPicker
 				id="link-input"
 				placeholder=${this.localize.term('general_url')}
 				label=${this.localize.term('general_url')}
-				.value="${this._link.udi ?? this._link.url ?? ''}"
-				@input=${() => this.#partialUpdateLink({ url: this._linkInput.value as string })}
-				?disabled="${this._link.udi ? true : false}"></uui-input>
+				.value="${this._link.unique ?? this._link.url ?? ''}"
+				@input=${() => this.#partialUpdateLink({ type: 'external', url: this._linkInput.value as string })}
+				?disabled="${this._link.unique ? true : false}"></uui-input>
 		</span>`;
 	}
 

--- a/src/packages/core/modal/token/link-picker-modal.token.ts
+++ b/src/packages/core/modal/token/link-picker-modal.token.ts
@@ -15,9 +15,12 @@ export interface UmbLinkPickerLink {
 	queryString?: string | null;
 	target?: string | null;
 	trashed?: boolean | null;
-	udi?: string | null;
+	type?: UmbLinkPickerLinkType | null;
+	unique?: string | null;
 	url?: string | null;
 }
+
+export type UmbLinkPickerLinkType = 'document' | 'external' | 'media';
 
 // TODO: investigate: this looks more like a property editor configuration. Is this used in the correct way?
 export interface UmbLinkPickerConfig {

--- a/src/packages/core/property-editor/uis/tiny-mce/plugins/tiny-mce-linkpicker.plugin.ts
+++ b/src/packages/core/property-editor/uis/tiny-mce/plugins/tiny-mce-linkpicker.plugin.ts
@@ -85,7 +85,7 @@ export default class UmbTinyMceLinkPickerPlugin extends UmbTinyMcePluginBase {
 
 		if (this.#anchorElement.href.includes('localLink:')) {
 			const href = this.#anchorElement.getAttribute('href')!;
-			currentTarget.udi = href.split('localLink:')[1].slice(0, -1);
+			currentTarget.unique = href.split('localLink:')[1].slice(0, -1);
 		} else if (this.#anchorElement.host.length) {
 			currentTarget.url = this.#anchorElement.protocol ? this.#anchorElement.protocol + '//' : undefined;
 			currentTarget.url += this.#anchorElement.host + this.#anchorElement.pathname;
@@ -193,14 +193,14 @@ export default class UmbTinyMceLinkPickerPlugin extends UmbTinyMcePluginBase {
 			}
 		}
 
-		if (!this.#linkPickerData?.link.url && !this.#linkPickerData?.link.queryString && !this.#linkPickerData?.link.udi) {
+		if (!this.#linkPickerData?.link.url && !this.#linkPickerData?.link.queryString && !this.#linkPickerData?.link.unique) {
 			this.editor.execCommand('unlink');
 			return;
 		}
 
 		//if we have an id, it must be a locallink:id
-		if (this.#linkPickerData?.link.udi) {
-			this.#linkPickerData.link.url = '/{localLink:' + this.#linkPickerData.link.udi + '}';
+		if (this.#linkPickerData?.link.unique) {
+			this.#linkPickerData.link.url = '/{localLink:' + this.#linkPickerData.link.unique + '}';
 			this.#insertLink();
 			return;
 		}


### PR DESCRIPTION
As part of the process to remove UDI support from the client UI, the Multi-URL Picker has re-introduced a "Link Type" property (of either `document`, `external` or `media`).

The Management API will support this change in due course.

