### PR TITLE
Rename `input-document-picker-root` to `input-document-root-picker`

### DIFF
--- a/src/packages/core/components/input-tree-picker-source/input-tree-picker-source.element.ts
+++ b/src/packages/core/components/input-tree-picker-source/input-tree-picker-source.element.ts
@@ -1,4 +1,4 @@
-import type { UmbInputDocumentPickerRootElement } from '@umbraco-cms/backoffice/document';
+import type { UmbInputDocumentRootPickerElement } from '@umbraco-cms/backoffice/document';
 import { html, customElement, property, css, state, nothing } from '@umbraco-cms/backoffice/external/lit';
 import type { UUISelectEvent } from '@umbraco-cms/backoffice/external/uui';
 import { FormControlMixin } from '@umbraco-cms/backoffice/external/uui';
@@ -89,7 +89,7 @@ export class UmbInputTreePickerSourceElement extends FormControlMixin(UmbLitElem
 	#onDocumentRootChange(event: CustomEvent) {
 		switch (this.type) {
 			case 'content':
-				this.dynamicRoot = (event.target as UmbInputDocumentPickerRootElement).data;
+				this.dynamicRoot = (event.target as UmbInputDocumentRootPickerElement).data;
 
 				// HACK: Workaround consolidating the old content-picker and dynamic-root. [LK:2024-01-24]
 				if (this.dynamicRoot?.originAlias === 'ByKey') {
@@ -131,9 +131,9 @@ export class UmbInputTreePickerSourceElement extends FormControlMixin(UmbLitElem
 	}
 
 	#renderDocumentSourcePicker() {
-		return html`<umb-input-document-picker-root
+		return html`<umb-input-document-root-picker
 			@change=${this.#onDocumentRootChange}
-			.data=${this.dynamicRoot}></umb-input-document-picker-root>`;
+			.data=${this.dynamicRoot}></umb-input-document-root-picker>`;
 	}
 
 	static styles = [

--- a/src/packages/documents/documents/components/index.ts
+++ b/src/packages/documents/documents/components/index.ts
@@ -1,3 +1,3 @@
 export * from './input-document/input-document.element.js';
 export * from './input-document-granular-permission/input-document-granular-permission.element.js';
-export * from './input-document-picker-root/input-document-picker-root.element.js';
+export * from './input-document-root-picker/input-document-root-picker.element.js';

--- a/src/packages/documents/documents/components/input-document-root-picker/input-document-root-picker.element.ts
+++ b/src/packages/documents/documents/components/input-document-root-picker/input-document-root-picker.element.ts
@@ -17,8 +17,8 @@ import type {
 import type { UmbModalContext } from '@umbraco-cms/backoffice/modal';
 import type { UmbTreePickerDynamicRoot, UmbTreePickerDynamicRootQueryStep } from '@umbraco-cms/backoffice/components';
 
-@customElement('umb-input-document-picker-root')
-export class UmbInputDocumentPickerRootElement extends FormControlMixin(UmbLitElement) {
+@customElement('umb-input-document-root-picker')
+export class UmbInputDocumentRootPickerElement extends FormControlMixin(UmbLitElement) {
 	protected getFormElement() {
 		return undefined;
 	}
@@ -257,10 +257,10 @@ export class UmbInputDocumentPickerRootElement extends FormControlMixin(UmbLitEl
 	];
 }
 
-export default UmbInputDocumentPickerRootElement;
+export default UmbInputDocumentRootPickerElement;
 
 declare global {
 	interface HTMLElementTagNameMap {
-		'umb-input-document-picker-root': UmbInputDocumentPickerRootElement;
+		'umb-input-document-root-picker': UmbInputDocumentRootPickerElement;
 	}
 }


### PR DESCRIPTION
A small follow up chore to PR #1164 (Dynamic Root), I wasn't happy with the naming of `input-document-picker-root`, as the editor is a picker of the "document root", not the root of the document picker, (a la "the cart before the horse").

I'm suggesting this as a separate change as I didn't want to pollute PR #1164.