### PR TITLE
Bugfix/workspace modals closing

### DIFF
--- a/src/mocks/data/document/document.data.ts
+++ b/src/mocks/data/document/document.data.ts
@@ -97,7 +97,8 @@ export const data: Array<UmbMockDocumentModel> = [
 				alias: 'multiNodeTreePicker',
 				culture: null,
 				segment: null,
-				value: null,
+				value:
+					'all-property-editors-document-id,c05da24d-7740-447b-9cdc-bd8ce2172e38,fd56a0b5-01a0-4da2-b428-52773bfa9cc4',
 			},
 			{
 				alias: 'datePicker',

--- a/src/packages/block/block-list/components/inline-list-block/inline-list-block.element.ts
+++ b/src/packages/block/block-list/components/inline-list-block/inline-list-block.element.ts
@@ -37,7 +37,7 @@ export class UmbInlineListBlockElement extends UmbLitElement {
 				'observeContentUdi',
 			);
 		});
-		this.observe(umbExtensionsRegistry.getByTypeAndAlias('workspace', UMB_BLOCK_WORKSPACE_ALIAS), (manifest) => {
+		this.observe(umbExtensionsRegistry.byTypeAndAlias('workspace', UMB_BLOCK_WORKSPACE_ALIAS), (manifest) => {
 			if (manifest) {
 				createExtensionApi(manifest, [this, { manifest: manifest }]).then((context) => {
 					if (context) {

--- a/src/packages/core/collection/collection.element.ts
+++ b/src/packages/core/collection/collection.element.ts
@@ -1,7 +1,7 @@
 import type { UmbCollectionContext } from './types.js';
 import { customElement, html, property, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
-import type { ManifestCollection} from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestCollection } from '@umbraco-cms/backoffice/extension-registry';
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { createExtensionApi, createExtensionElement } from '@umbraco-cms/backoffice/extension-api';
 
@@ -25,7 +25,7 @@ export class UmbCollectionElement extends UmbLitElement {
 	#observeManifest() {
 		if (!this._alias) return;
 		this.observe(
-			umbExtensionsRegistry.getByTypeAndAlias('collection', this._alias),
+			umbExtensionsRegistry.byTypeAndAlias('collection', this._alias),
 			async (manifest) => {
 				if (!manifest) return;
 				this.#manifest = manifest;

--- a/src/packages/core/components/backoffice-modal-container/backoffice-modal-container.element.ts
+++ b/src/packages/core/components/backoffice-modal-container/backoffice-modal-container.element.ts
@@ -46,7 +46,7 @@ export class UmbBackofficeModalContainerElement extends UmbLitElement {
 		});
 
 		if (this._modals.length === 0) {
-			this._modalElementMap.clear();
+			//this._modalElementMap.clear(); // should not make a difference now that we clean it above. [NL]
 			return;
 		}
 

--- a/src/packages/core/content-type/components/property-type-based-property/property-type-based-property.element.ts
+++ b/src/packages/core/content-type/components/property-type-based-property/property-type-based-property.element.ts
@@ -45,7 +45,7 @@ export class UmbPropertyTypeBasedPropertyElement extends UmbLitElement {
 					if (!this._propertyEditorUiAlias && dataType?.editorAlias) {
 						//use 'dataType.editorAlias' to look up the extension in the registry:
 						this.observe(
-							umbExtensionsRegistry.getByTypeAndAlias('propertyEditorSchema', dataType.editorAlias),
+							umbExtensionsRegistry.byTypeAndAlias('propertyEditorSchema', dataType.editorAlias),
 							(extension) => {
 								if (!extension) return;
 								this._propertyEditorUiAlias = extension?.meta.defaultPropertyEditorUiAlias;

--- a/src/packages/core/data-type/workspace/data-type-workspace.context.ts
+++ b/src/packages/core/data-type/workspace/data-type-workspace.context.ts
@@ -1,8 +1,7 @@
 import { UmbDataTypeDetailRepository } from '../repository/detail/data-type-detail.repository.js';
 import type { UmbDataTypeDetailModel } from '../types.js';
 import type { UmbPropertyDatasetContext } from '@umbraco-cms/backoffice/property';
-import type {
-	UmbInvariantableWorkspaceContextInterface} from '@umbraco-cms/backoffice/workspace';
+import type { UmbInvariantableWorkspaceContextInterface } from '@umbraco-cms/backoffice/workspace';
 import {
 	UmbEditableWorkspaceContextBase,
 	UmbInvariantWorkspacePropertyDatasetContext,
@@ -17,10 +16,9 @@ import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { combineLatest, map } from '@umbraco-cms/backoffice/external/rxjs';
 import type {
 	PropertyEditorConfigDefaultData,
-	PropertyEditorConfigProperty} from '@umbraco-cms/backoffice/extension-registry';
-import {
-	umbExtensionsRegistry,
+	PropertyEditorConfigProperty,
 } from '@umbraco-cms/backoffice/extension-registry';
+import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { UMB_PROPERTY_EDITOR_SCHEMA_ALIAS_DEFAULT } from '@umbraco-cms/backoffice/property-editor';
 
 export class UmbDataTypeWorkspaceContext
@@ -102,7 +100,7 @@ export class UmbDataTypeWorkspaceContext
 
 	#setPropertyEditorSchemaConfig(propertyEditorSchemaAlias: string) {
 		return this.observe(
-			umbExtensionsRegistry.getByTypeAndAlias('propertyEditorSchema', propertyEditorSchemaAlias),
+			umbExtensionsRegistry.byTypeAndAlias('propertyEditorSchema', propertyEditorSchemaAlias),
 			(manifest) => {
 				this._propertyEditorSchemaConfigProperties = manifest?.meta.settings?.properties || [];
 				this._propertyEditorSchemaConfigDefaultData = manifest?.meta.settings?.defaultData || [];
@@ -112,17 +110,14 @@ export class UmbDataTypeWorkspaceContext
 	}
 
 	#setPropertyEditorUIConfig(propertyEditorUIAlias: string) {
-		return this.observe(
-			umbExtensionsRegistry.getByTypeAndAlias('propertyEditorUi', propertyEditorUIAlias),
-			(manifest) => {
-				this.#propertyEditorUiIcon.setValue(manifest?.meta.icon || null);
-				this.#propertyEditorUiName.setValue(manifest?.name || null);
+		return this.observe(umbExtensionsRegistry.byTypeAndAlias('propertyEditorUi', propertyEditorUIAlias), (manifest) => {
+			this.#propertyEditorUiIcon.setValue(manifest?.meta.icon || null);
+			this.#propertyEditorUiName.setValue(manifest?.name || null);
 
-				this._propertyEditorUISettingsSchemaAlias = manifest?.meta.propertyEditorSchemaAlias;
-				this._propertyEditorUISettingsProperties = manifest?.meta.settings?.properties || [];
-				this._propertyEditorUISettingsDefaultData = manifest?.meta.settings?.defaultData || [];
-			},
-		).asPromise();
+			this._propertyEditorUISettingsSchemaAlias = manifest?.meta.propertyEditorSchemaAlias;
+			this._propertyEditorUISettingsProperties = manifest?.meta.settings?.properties || [];
+			this._propertyEditorUISettingsDefaultData = manifest?.meta.settings?.defaultData || [];
+		}).asPromise();
 	}
 
 	private _mergeConfigProperties() {

--- a/src/packages/core/modal/modal.element.ts
+++ b/src/packages/core/modal/modal.element.ts
@@ -124,7 +124,7 @@ export class UmbModalElement extends UmbLitElement {
 	#observeModal(alias: string) {
 		this.#modalExtensionObserver?.destroy();
 
-		this.observe(umbExtensionsRegistry.getByTypeAndAlias('modal', alias), async (manifest) => {
+		this.observe(umbExtensionsRegistry.byTypeAndAlias('modal', alias), async (manifest) => {
 			this.#removeInnerElement();
 
 			if (manifest) {

--- a/src/packages/core/property/property/property.element.ts
+++ b/src/packages/core/property/property/property.element.ts
@@ -131,7 +131,7 @@ export class UmbPropertyElement extends UmbLitElement {
 
 	private _observePropertyEditorUI() {
 		this.observe(
-			umbExtensionsRegistry.getByTypeAndAlias('propertyEditorUi', this._propertyEditorUiAlias),
+			umbExtensionsRegistry.byTypeAndAlias('propertyEditorUi', this._propertyEditorUiAlias),
 			(manifest) => {
 				this._gotEditorUI(manifest);
 			},

--- a/src/packages/core/tree/tree.context.ts
+++ b/src/packages/core/tree/tree.context.ts
@@ -122,7 +122,7 @@ export class UmbTreeContextBase<TreeItemType extends UmbTreeItemModelBase>
 	#observeTreeManifest() {
 		if (this.#treeAlias) {
 			this.observe(
-				umbExtensionsRegistry.getByTypeAndAlias('tree', this.#treeAlias),
+				umbExtensionsRegistry.byTypeAndAlias('tree', this.#treeAlias),
 				async (treeManifest) => {
 					if (!treeManifest) return;
 					this.#observeRepository(treeManifest);

--- a/src/packages/documents/documents/components/input-document/input-document.element.ts
+++ b/src/packages/documents/documents/components/input-document/input-document.element.ts
@@ -150,7 +150,6 @@ export class UmbInputDocumentElement extends FormControlMixin(UmbLitElement) {
 
 	#openPicker() {
 		// TODO: Configure the content picker, with `startNodeId` and `ignoreUserStartNodes` [LK]
-		console.log('#openPicker', [this.startNodeId, this.ignoreUserStartNodes]);
 		this.#pickerContext.openPicker({
 			hideTreeRoot: true,
 			// eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/src/packages/media/media/components/input-media/input-media.element.ts
+++ b/src/packages/media/media/components/input-media/input-media.element.ts
@@ -149,7 +149,6 @@ export class UmbInputMediaElement extends FormControlMixin(UmbLitElement) {
 
 	#openPicker() {
 		// TODO: Configure the media picker, with `allowedContentTypeIds` and `ignoreUserStartNodes` [LK]
-		console.log('#openPicker', [this.allowedContentTypeIds, this.ignoreUserStartNodes]);
 		this.#pickerContext.openPicker({
 			hideTreeRoot: true,
 			pickableFilter: this.#pickableFilter,

--- a/src/shared/router/route.context.ts
+++ b/src/shared/router/route.context.ts
@@ -72,7 +72,7 @@ export class UmbRouteContext extends UmbBaseController {
 	}
 
 	#removeModalPath(info: IRoutingInfo) {
-		// Reset the URL to the routerBasePath
+		// Reset the URL to the routerBasePath + routerActiveLocalPath
 		const folderToRemove = info.match.match.input;
 		if (folderToRemove && window.location.href.includes(folderToRemove)) {
 			window.history.pushState({}, '', this.#routerBasePath + '/' + this.#routerActiveLocalPath);

--- a/src/shared/router/route.context.ts
+++ b/src/shared/router/route.context.ts
@@ -72,8 +72,17 @@ export class UmbRouteContext extends UmbBaseController {
 	}
 
 	#removeModalPath(info: IRoutingInfo) {
-		if (window.location.href.includes(info.match.fragments.consumed)) {
-			window.history.pushState({}, '', window.location.href.split(info.match.fragments.consumed)[0]);
+		/*
+		NOTICE:
+		This piece of code remove the last occurrence of the modal path from the current url.
+		This means if the same type of modal is opened multiple times, the url will be cleaned from the last opened modal.
+		This is okay for now as we do not have any situations where we close a parent modal before a child modal.
+		*/
+		const currentUrl = window.location.href;
+		const folderToRemove = info.match.fragments.consumed;
+		if (currentUrl.includes(folderToRemove)) {
+			const split = currentUrl.split(folderToRemove);
+			window.history.pushState({}, '', split[split.length - 1]);
 		}
 	}
 

--- a/src/shared/router/route.context.ts
+++ b/src/shared/router/route.context.ts
@@ -81,8 +81,8 @@ export class UmbRouteContext extends UmbBaseController {
 		const currentUrl = window.location.href;
 		const folderToRemove = info.match.fragments.consumed;
 		if (currentUrl.includes(folderToRemove)) {
-			const split = currentUrl.split(folderToRemove);
-			window.history.pushState({}, '', split[split.length - 1]);
+			const lastIndex = currentUrl.lastIndexOf(folderToRemove);
+			window.history.pushState({}, '', currentUrl.slice(0, lastIndex));
 		}
 	}
 

--- a/src/shared/router/route.context.ts
+++ b/src/shared/router/route.context.ts
@@ -72,15 +72,10 @@ export class UmbRouteContext extends UmbBaseController {
 	}
 
 	#removeModalPath(info: IRoutingInfo) {
-		/*
-		NOTICE:
-		This piece of code remove the last occurrence of the modal path from the current url.
-		This means if the same type of modal is opened multiple times, the url will be cleaned from the last opened modal.
-		This is okay for now as we do not have any situations where we close a parent modal before a child modal.
-		*/
+		// Reset the URL to the routerBasePath
 		const folderToRemove = info.match.match.input;
 		if (folderToRemove && window.location.href.includes(folderToRemove)) {
-			window.history.pushState({}, '', this.#routerBasePath);
+			window.history.pushState({}, '', this.#routerBasePath + '/' + this.#routerActiveLocalPath);
 		}
 	}
 

--- a/src/shared/router/route.context.ts
+++ b/src/shared/router/route.context.ts
@@ -78,11 +78,9 @@ export class UmbRouteContext extends UmbBaseController {
 		This means if the same type of modal is opened multiple times, the url will be cleaned from the last opened modal.
 		This is okay for now as we do not have any situations where we close a parent modal before a child modal.
 		*/
-		const currentUrl = window.location.href;
-		const folderToRemove = info.match.fragments.consumed;
-		if (currentUrl.includes(folderToRemove)) {
-			const lastIndex = currentUrl.lastIndexOf(folderToRemove);
-			window.history.pushState({}, '', currentUrl.slice(0, lastIndex));
+		const folderToRemove = info.match.match.input;
+		if (folderToRemove && window.location.href.includes(folderToRemove)) {
+			window.history.pushState({}, '', this.#routerBasePath);
 		}
 	}
 

--- a/src/shared/router/router-slot.element.ts
+++ b/src/shared/router/router-slot.element.ts
@@ -116,7 +116,6 @@ export class UmbRouterSlotElement extends UmbLitElement {
 			this.#routeContext._internal_routerGotActiveLocalPath(this._activeLocalPath);
 			this.dispatchEvent(new UmbRouterSlotChangeEvent());
 		} else if (event.detail.slot === this.#modalRouter) {
-			console.log('modal navigation change', event.detail.match.route.path);
 			const newActiveModalLocalPath = event.detail.match.route.path;
 			this.#routeContext._internal_modalRouterChanged(newActiveModalLocalPath);
 		}

--- a/src/shared/router/router-slot.element.ts
+++ b/src/shared/router/router-slot.element.ts
@@ -20,7 +20,7 @@ export class UmbRouterSlotElement extends UmbLitElement {
 	#modalRouter: IRouterSlot = document.createElement('router-slot') as IRouterSlot;
 	#listening = false;
 
-	@property()
+	@property({ attribute: false })
 	public get routes(): UmbRoute[] | undefined {
 		return this.#router.routes;
 	}
@@ -34,7 +34,7 @@ export class UmbRouterSlotElement extends UmbLitElement {
 		}
 	}
 
-	@property()
+	@property({ attribute: false })
 	public get parent(): IRouterSlot | null | undefined {
 		return this.#router.parent;
 	}
@@ -103,6 +103,7 @@ export class UmbRouterSlotElement extends UmbLitElement {
 
 			const newActiveLocalPath = this.#router.match?.route.path;
 			if (this._activeLocalPath !== newActiveLocalPath) {
+				console.log('update', newActiveLocalPath);
 				this._activeLocalPath = newActiveLocalPath;
 				this.#routeContext._internal_routerGotActiveLocalPath(this._activeLocalPath);
 				this.dispatchEvent(new UmbRouterSlotChangeEvent());
@@ -116,6 +117,7 @@ export class UmbRouterSlotElement extends UmbLitElement {
 			this.#routeContext._internal_routerGotActiveLocalPath(this._activeLocalPath);
 			this.dispatchEvent(new UmbRouterSlotChangeEvent());
 		} else if (event.detail.slot === this.#modalRouter) {
+			console.log('modal navigation change', event.detail.match.route.path);
 			const newActiveModalLocalPath = event.detail.match.route.path;
 			this.#routeContext._internal_modalRouterChanged(newActiveModalLocalPath);
 		}

--- a/src/shared/router/router-slot.element.ts
+++ b/src/shared/router/router-slot.element.ts
@@ -103,7 +103,6 @@ export class UmbRouterSlotElement extends UmbLitElement {
 
 			const newActiveLocalPath = this.#router.match?.route.path;
 			if (this._activeLocalPath !== newActiveLocalPath) {
-				console.log('update', newActiveLocalPath);
 				this._activeLocalPath = newActiveLocalPath;
 				this.#routeContext._internal_routerGotActiveLocalPath(this._activeLocalPath);
 				this.dispatchEvent(new UmbRouterSlotChangeEvent());


### PR DESCRIPTION
Fixes having multiple routed modals of the same type(alias), so if multiple is present we make sure that the URL that stays back is what was left of that specific modal and not the other one.

There is also a few minor other changes.

The noticable change is in (the rest is just usual corrections)
router.context.ts

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
