### PR TITLE
Document Collection: Document Workspace Collection Condition

### DIFF
--- a/src/packages/documents/documents/conditions/document-workspace-has-collection.condition.ts
+++ b/src/packages/documents/documents/conditions/document-workspace-has-collection.condition.ts
@@ -1,0 +1,32 @@
+import { UMB_DOCUMENT_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/document';
+import { UmbBaseController } from '@umbraco-cms/backoffice/class-api';
+import type {
+	UmbConditionConfigBase,
+	UmbConditionControllerArguments,
+	UmbExtensionCondition,
+} from '@umbraco-cms/backoffice/extension-api';
+
+export class UmbDocumentWorkspaceHasCollectionCondition extends UmbBaseController implements UmbExtensionCondition {
+	config: DocumentWorkspaceHasCollectionConditionConfig;
+	permitted = false;
+	#onChange: () => void;
+
+	constructor(args: UmbConditionControllerArguments<DocumentWorkspaceHasCollectionConditionConfig>) {
+		super(args.host);
+		this.config = args.config;
+		this.#onChange = args.onChange;
+
+		this.consumeContext(UMB_DOCUMENT_WORKSPACE_CONTEXT, (context) => {
+			this.observe(context.structure.ownerContentType(), (contentType) => {
+				// TODO: [LK] Replace this check once the `.collection` is available from the Management API.
+				if (contentType?.unique === 'simple-document-type-id') {
+					this.permitted = true;
+					this.#onChange();
+				}
+			});
+		});
+	}
+}
+
+export type DocumentWorkspaceHasCollectionConditionConfig =
+	UmbConditionConfigBase<'Umb.Condition.DocumentWorkspaceHasCollection'>;

--- a/src/packages/documents/documents/conditions/index.ts
+++ b/src/packages/documents/documents/conditions/index.ts
@@ -1,0 +1,1 @@
+export * from './document-workspace-has-collection.condition.js';

--- a/src/packages/documents/documents/conditions/manifests.ts
+++ b/src/packages/documents/documents/conditions/manifests.ts
@@ -1,0 +1,11 @@
+import { UmbDocumentWorkspaceHasCollectionCondition } from './document-workspace-has-collection.condition.js';
+import type { ManifestCondition } from '@umbraco-cms/backoffice/extension-api';
+
+const documentWorkspaceHasCollectionManifest: ManifestCondition = {
+	type: 'condition',
+	name: 'Document Workspace Has Collection Condition',
+	alias: 'Umb.Condition.DocumentWorkspaceHasCollection',
+	api: UmbDocumentWorkspaceHasCollectionCondition,
+};
+
+export const manifests = [documentWorkspaceHasCollectionManifest];

--- a/src/packages/documents/documents/index.ts
+++ b/src/packages/documents/documents/index.ts
@@ -8,6 +8,7 @@ export * from './user-permissions/index.js';
 export * from './components/index.js';
 export * from './entity.js';
 export * from './entity-actions/index.js';
+export * from './conditions/index.js';
 
 export { UMB_DOCUMENT_TREE_ALIAS } from './tree/index.js';
 export { UMB_CONTENT_MENU_ALIAS } from './menu.manifests.js';

--- a/src/packages/documents/documents/manifests.ts
+++ b/src/packages/documents/documents/manifests.ts
@@ -1,4 +1,5 @@
 import { manifests as collectionManifests } from './collection/manifests.js';
+import { manifests as conditionManifests } from './conditions/manifests.js';
 import { manifests as menuItemManifests } from './menu-item/manifests.js';
 import { manifests as repositoryManifests } from './repository/manifests.js';
 import { manifests as treeManifests } from './tree/manifests.js';
@@ -12,6 +13,7 @@ import { manifests as trackedReferenceManifests } from './tracked-reference/mani
 
 export const manifests = [
 	...collectionManifests,
+	...conditionManifests,
 	...menuItemManifests,
 	...treeManifests,
 	...repositoryManifests,

--- a/src/packages/documents/documents/workspace/manifests.ts
+++ b/src/packages/documents/documents/workspace/manifests.ts
@@ -7,7 +7,6 @@ import type {
 	ManifestWorkspace,
 	ManifestWorkspaceAction,
 	ManifestWorkspaceView,
-	ManifestWorkspaceViewCollection,
 } from '@umbraco-cms/backoffice/extension-registry';
 
 const workspace: ManifestWorkspace = {
@@ -24,9 +23,26 @@ const workspace: ManifestWorkspace = {
 const workspaceViews: Array<ManifestWorkspaceView> = [
 	{
 		type: 'workspaceView',
+		alias: 'Umb.WorkspaceView.Document.Collection',
+		name: 'Document Workspace Collection View',
+		element: () => import('./views/collection/document-workspace-view-collection.element.js'),
+		weight: 300,
+		meta: {
+			label: 'Documents',
+			pathname: 'collection',
+			icon: 'icon-grid',
+		},
+		conditions: [
+			{
+				alias: 'Umb.Condition.DocumentWorkspaceHasCollection',
+			},
+		],
+	},
+	{
+		type: 'workspaceView',
 		alias: 'Umb.WorkspaceView.Document.Edit',
 		name: 'Document Workspace Edit View',
-		js: () => import('./views/edit/document-workspace-view-edit.element.js'),
+		element: () => import('./views/edit/document-workspace-view-edit.element.js'),
 		weight: 200,
 		meta: {
 			label: 'Content',
@@ -44,7 +60,7 @@ const workspaceViews: Array<ManifestWorkspaceView> = [
 		type: 'workspaceView',
 		alias: 'Umb.WorkspaceView.Document.Info',
 		name: 'Document Workspace Info View',
-		js: () => import('./views/info/document-workspace-view-info.element.js'),
+		element: () => import('./views/info/document-workspace-view-info.element.js'),
 		weight: 100,
 		meta: {
 			label: 'Info',
@@ -58,25 +74,6 @@ const workspaceViews: Array<ManifestWorkspaceView> = [
 			},
 		],
 	},
-];
-
-const workspaceViewCollections: Array<ManifestWorkspaceViewCollection> = [
-	/*
-	// TODO: Reenable this:
-	{
-		type: 'workspaceViewCollection',
-		alias: 'Umb.WorkspaceView.Document.Collection',
-		name: 'Document Workspace Collection View',
-		weight: 300,
-		meta: {
-			label: 'Documents',
-			pathname: 'collection',
-			icon: 'icon-grid',
-			entityType: UMB_DOCUMENT_ENTITY_TYPE,
-			repositoryAlias: DOCUMENT_REPOSITORY_ALIAS,
-		}
-	},
-	*/
 ];
 
 const workspaceActions: Array<ManifestWorkspaceAction> = [
@@ -152,4 +149,4 @@ const workspaceActions: Array<ManifestWorkspaceAction> = [
 	*/
 ];
 
-export const manifests = [workspace, ...workspaceViews, ...workspaceViewCollections, ...workspaceActions];
+export const manifests = [workspace, ...workspaceViews, ...workspaceActions];

--- a/src/packages/documents/documents/workspace/views/collection/document-workspace-view-collection.element.ts
+++ b/src/packages/documents/documents/workspace/views/collection/document-workspace-view-collection.element.ts
@@ -1,0 +1,34 @@
+import { css, customElement, html } from '@umbraco-cms/backoffice/external/lit';
+import { UmbLitElement } from '@umbraco-cms/internal/lit-element';
+import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
+import { UMB_DOCUMENT_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/document';
+import type { UmbWorkspaceViewElement } from '@umbraco-cms/backoffice/extension-registry';
+
+@customElement('umb-document-workspace-view-collection')
+export class UmbDocumentWorkspaceViewCollectionElement extends UmbLitElement implements UmbWorkspaceViewElement {
+	#workspaceContext?: typeof UMB_DOCUMENT_WORKSPACE_CONTEXT.TYPE;
+
+	constructor() {
+		super();
+
+		this.consumeContext(UMB_DOCUMENT_WORKSPACE_CONTEXT, (workspaceContext) => {
+			this.#workspaceContext = workspaceContext;
+
+			// TODO: [LK] Get the `dataTypeId` and get the configuration for the collection view.
+		});
+	}
+
+	render() {
+		return html`<umb-collection alias="Umb.Collection.Document"></umb-collection>`;
+	}
+
+	static styles = [UmbTextStyles, css``];
+}
+
+export default UmbDocumentWorkspaceViewCollectionElement;
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-document-workspace-view-collection': UmbDocumentWorkspaceViewCollectionElement;
+	}
+}


### PR DESCRIPTION
This PR adds a Manifest Condition for the Document Workspace, to check if the Document Type is configured as a Collection (container) and display the Collection workspace view.

Note, this isn't fully wired up yet, as we are awaiting the relevant Management API endpoints, hence the TODO comments.
This PR contains the rest of the boilerplate code.