### PR TITLE
Bugfix: Collection View Bulk Action Permissions - `allowBulkPublish` flag

### DIFF
--- a/src/packages/core/property-editor/uis/collection-view/config/bulk-action-permissions/property-editor-ui-collection-view-bulk-action-permissions.element.ts
+++ b/src/packages/core/property-editor/uis/collection-view/config/bulk-action-permissions/property-editor-ui-collection-view-bulk-action-permissions.element.ts
@@ -76,7 +76,7 @@ export class UmbPropertyEditorUICollectionViewBulkActionPermissionsElement
 
 	render() {
 		return html`<uui-toggle
-				?checked=${this.value.allowBulkUnpublish}
+				?checked=${this.value.allowBulkPublish}
 				@change=${(e: UUIBooleanInputEvent) => this.#onChange(e, 'allowBulkPublish')}
 				label="Allow bulk publish (content only)"></uui-toggle>
 			<uui-toggle
@@ -94,7 +94,7 @@ export class UmbPropertyEditorUICollectionViewBulkActionPermissionsElement
 			<uui-toggle
 				?checked=${this.value.allowBulkDelete}
 				@change=${(e: UUIBooleanInputEvent) => this.#onChange(e, 'allowBulkDelete')}
-				label="Allow bulk delete"></uui-toggle> `;
+				label="Allow bulk delete"></uui-toggle>`;
 	}
 
 	static styles = [


### PR DESCRIPTION
As part of reviewing the Collections (formerly List View) data-type configuration, I spotted a small bug in the bulk action permissions UI. The `allowBulkPublish` flag was checking the value of `allowBulkUnpublish`.


