### PR TITLE
Generate umbraco package

### DIFF
--- a/devops/build/create-umbraco-package.js
+++ b/devops/build/create-umbraco-package.js
@@ -1,0 +1,23 @@
+import { createImportMap } from "../importmap/index.js";
+import { writeFileSync, rmSync } from "fs";
+import { packageJsonName, packageJsonVersion } from "../package/index.js";
+
+const srcDir = './dist-cms';
+const outputModuleList = `${srcDir}/umbraco-package.json`;
+const importmap = createImportMap({ rootDir: '/umbraco/backoffice', additionalImports: {} });
+
+const umbracoPackageJson = {
+	name: packageJsonName,
+	version: packageJsonVersion,
+	extensions: [],
+	importmap
+};
+
+try {
+	rmSync(outputModuleList, { force: true });
+	writeFileSync(outputModuleList, JSON.stringify(umbracoPackageJson));
+	console.log(`Wrote manifest to ${outputModuleList}`);
+} catch (e) {
+	console.error(`Failed to write manifest to ${outputModuleList}`, e);
+	process.exit(1);
+}

--- a/devops/importmap/index.js
+++ b/devops/importmap/index.js
@@ -12,7 +12,9 @@ export const createImportMap = (args) => {
 			const moduleName = key.replace(/^\.\//, '');
 
 			// replace ./dist-cms with src and remove /index.js
-			const modulePath = value.replace(/^\.\/dist-cms/, args.rootDir).replace('.js', '.ts');
+			let modulePath = value;
+			if (typeof args.rootDir !== 'undefined') modulePath = modulePath.replace(/^\.\/dist-cms/, args.rootDir);
+			if (args.replaceModuleExtensions) modulePath = modulePath.replace('.js', '.ts');
 			console.log('replacing', value, 'with', modulePath)
 			const importAlias = `${packageJsonName}/${moduleName}`;
 

--- a/devops/package/meta.js
+++ b/devops/package/meta.js
@@ -3,4 +3,5 @@ import { readFileSync } from 'fs';
 export const packageJsonPath = 'package.json';
 export const packageJsonData = JSON.parse(readFileSync(packageJsonPath).toString());
 export const packageJsonName = packageJsonData.name;
+export const packageJsonVersion = packageJsonData.version;
 export const packageJsonExports = packageJsonData.exports;

--- a/devops/tsconfig/index.js
+++ b/devops/tsconfig/index.js
@@ -42,6 +42,7 @@ const importmap = createImportMap({
 	additionalImports: {
 		'@umbraco-cms/internal/test-utils': './utils/test-utils.ts',
 	},
+	replaceModuleExtensions: true,
 });
 
 const paths = {};

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
 		"build:for:cms": "npm run build && node ./devops/build/copy-to-cms.js",
 		"build:for:static": "vite build",
 		"build:vite": "tsc && vite build --mode staging",
-		"build": "tsc --project ./src/tsconfig.build.json && rollup -c ./src/rollup.config.js && npm run package:validate",
+		"build": "tsc --project ./src/tsconfig.build.json && rollup -c ./src/rollup.config.js && npm run package:validate && npm run generate:manifest",
 		"check": "npm run lint:errors && npm run compile && npm run build-storybook && npm run generate:jsonschema:dist",
 		"compile": "tsc",
 		"dev": "vite",
@@ -143,6 +143,7 @@
 		"wc-analyze:vscode": "wca **/*.element.ts --format vscode --outFile dist-cms/vscode-html-custom-data.json",
 		"wc-analyze": "wca **/*.element.ts --outFile dist-cms/custom-elements.json",
 		"generate:tsconfig": "node ./devops/tsconfig/index.js",
+		"generate:manifest": "node ./devops/build/create-umbraco-package.js",
 		"package:validate": "node ./devops/package/validate-exports.js"
 	},
 	"engines": {

--- a/src/packages/core/extension-registry/umbraco-package.ts
+++ b/src/packages/core/extension-registry/umbraco-package.ts
@@ -51,6 +51,6 @@ export interface UmbracoPackage {
 		 * @title The scopes for the package
 		 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap#scopes
 		 */
-		scopes?: Record<string, object>;
-	}
+		scopes?: Record<string, Record<string, string>>;
+	};
 }

--- a/src/packages/core/extension-registry/umbraco-package.ts
+++ b/src/packages/core/extension-registry/umbraco-package.ts
@@ -38,19 +38,38 @@ export interface UmbracoPackage {
 	 * @description This is used to define the imports and the scopes for the package to be used in the browser. It will be combined with the global importmap.
 	 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap
 	 */
-	importmap?: {
-		/**
-		 * @title The imports for the package
-		 * @required
-		 * @minProperties 1
-		 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap#imports
-		 */
-		imports: Record<string, string>;
+	importmap?: UmbracoPackageImportmap;
+}
 
-		/**
-		 * @title The scopes for the package
-		 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap#scopes
-		 */
-		scopes?: Record<string, Record<string, string>>;
-	};
+export interface UmbracoPackageImportmap {
+	/**
+	 * @title A module specifier with a path for the importmap
+	 * @description This is used to define the module specifiers and their respective paths for the package to be used in the browser.
+	 * @examples [{
+	 * 		"library": "./path/to/library.js",
+	 * 		"library/*": "./path/to/library/*"
+	 * }]
+	 * @required
+	 * @minProperties 1
+	 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap#imports
+	 */
+	imports: UmbracoPackageImportmapValue;
+
+	/**
+	 * @title The importmap scopes for the package
+	 * @description This is used to define the scopes for the package to be used in the browser. It has to specify a path and a value that is an object with module specifiers and their respective paths.
+	 * @examples [{
+	 * 		"/path/to/library": { "library": "./path/to/some/other/library.js" }
+	 * }]
+	 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap#scopes
+	 */
+	scopes?: UmbracoPackageImportmapScopes;
+}
+
+export interface UmbracoPackageImportmapScopes {
+	[key: string]: UmbracoPackageImportmapValue;
+}
+
+export interface UmbracoPackageImportmapValue {
+	[key: string]: string;
 }

--- a/src/packages/core/extension-registry/umbraco-package.ts
+++ b/src/packages/core/extension-registry/umbraco-package.ts
@@ -32,4 +32,25 @@ export interface UmbracoPackage {
 	 * @required
 	 */
 	extensions: ManifestTypes[];
+
+	/**
+	 * @title The importmap for the package
+	 * @description This is used to define the imports and the scopes for the package to be used in the browser. It will be combined with the global importmap.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap
+	 */
+	importmap?: {
+		/**
+		 * @title The imports for the package
+		 * @required
+		 * @minProperties 1
+		 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap#imports
+		 */
+		imports: Record<string, string>;
+
+		/**
+		 * @title The scopes for the package
+		 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap#scopes
+		 */
+		scopes?: Record<string, object>;
+	}
 }

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -30,6 +30,7 @@ export default {
 					additionalImports: {
 						'@umbraco-cms/internal/test-utils': './utils/test-utils.ts',
 					},
+					replaceModuleExtensions: true,
 				}),
 			},
 		}),


### PR DESCRIPTION
Generate an umbraco-package.json file for the backoffice containing data useful to serve the backoffice such as the importmap.

There is now also a new definition added to the UmbracoPackage type to allow to define an importmap.

Fixes #1178

Note: When this is merged, we can also merge https://github.com/umbraco/Umbraco-CMS/pull/15710 to generate the importmap dynamically on the server.