### PR TITLE
Feature: Media Collection Entity Bulk Action Conditions

### DIFF
--- a/src/packages/media/media/entity-bulk-actions/delete/delete.action.ts
+++ b/src/packages/media/media/entity-bulk-actions/delete/delete.action.ts
@@ -5,7 +5,7 @@ import { UmbContextConsumerController } from '@umbraco-cms/backoffice/context-ap
 import type { UmbModalManagerContext } from '@umbraco-cms/backoffice/modal';
 import { UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
 
-export class UmbMediaTrashEntityBulkAction extends UmbEntityBulkActionBase<UmbMediaDetailRepository> {
+export class UmbMediaDeleteEntityBulkAction extends UmbEntityBulkActionBase<UmbMediaDetailRepository> {
 	#modalContext?: UmbModalManagerContext;
 
 	constructor(host: UmbControllerHostElement, repositoryAlias: string, selection: Array<string>) {
@@ -17,7 +17,8 @@ export class UmbMediaTrashEntityBulkAction extends UmbEntityBulkActionBase<UmbMe
 	}
 
 	async execute() {
-		alert('not implemented');
+		console.log(`execute delete for: ${this.selection}`);
+
 		// TODO: show error
 		if (!this.#modalContext || !this.repository) return;
 

--- a/src/packages/media/media/entity-bulk-actions/manifests.ts
+++ b/src/packages/media/media/entity-bulk-actions/manifests.ts
@@ -1,35 +1,21 @@
+import type { UmbCollectionBulkActionPermissions } from '../../../core/collection/types.js';
 import { UMB_MEDIA_DETAIL_REPOSITORY_ALIAS } from '../repository/index.js';
 import { UMB_MEDIA_COLLECTION_ALIAS } from '../collection/index.js';
 import { UmbMediaMoveEntityBulkAction } from './move/move.action.js';
 import { UmbMediaCopyEntityBulkAction } from './copy/copy.action.js';
-import { UmbMediaTrashEntityBulkAction } from './trash/trash.action.js';
+import { UmbMediaDeleteEntityBulkAction } from './delete/delete.action.js';
 import type { ManifestEntityBulkAction } from '@umbraco-cms/backoffice/extension-registry';
-import { UMB_COLLECTION_ALIAS_CONDITION } from '@umbraco-cms/backoffice/collection';
+import {
+	UMB_COLLECTION_ALIAS_CONDITION,
+	UMB_COLLECTION_BULK_ACTION_PERMISSION_CONDITION,
+} from '@umbraco-cms/backoffice/collection';
 
-const entityActions: Array<ManifestEntityBulkAction> = [
-	{
-		type: 'entityBulkAction',
-		alias: 'Umb.EntityBulkAction.Media.Move',
-		name: 'Move Media Entity Bulk Action',
-		weight: 100,
-		api: UmbMediaMoveEntityBulkAction,
-		meta: {
-			label: 'Move',
-			repositoryAlias: UMB_MEDIA_DETAIL_REPOSITORY_ALIAS,
-		},
-		conditions: [
-			{
-				// TODO: this condition should be based on entity types in the selection
-				alias: UMB_COLLECTION_ALIAS_CONDITION,
-				match: UMB_MEDIA_COLLECTION_ALIAS,
-			},
-		],
-	},
+export const manifests: Array<ManifestEntityBulkAction> = [
 	{
 		type: 'entityBulkAction',
 		alias: 'Umb.EntityBulkAction.Media.Copy',
 		name: 'Copy Media Entity Bulk Action',
-		weight: 90,
+		weight: 30,
 		api: UmbMediaCopyEntityBulkAction,
 		meta: {
 			label: 'Copy',
@@ -37,30 +23,55 @@ const entityActions: Array<ManifestEntityBulkAction> = [
 		},
 		conditions: [
 			{
-				// TODO: this condition should be based on entity types in the selection
 				alias: UMB_COLLECTION_ALIAS_CONDITION,
 				match: UMB_MEDIA_COLLECTION_ALIAS,
+			},
+			{
+				alias: UMB_COLLECTION_BULK_ACTION_PERMISSION_CONDITION,
+				match: (permissions: UmbCollectionBulkActionPermissions) => permissions.allowBulkCopy,
 			},
 		],
 	},
 	{
 		type: 'entityBulkAction',
-		alias: 'Umb.EntityBulkAction.Media.Trash',
-		name: 'Trash Media Entity Bulk Action',
-		weight: 80,
-		api: UmbMediaTrashEntityBulkAction,
+		alias: 'Umb.EntityBulkAction.Media.Move',
+		name: 'Move Media Entity Bulk Action',
+		weight: 20,
+		api: UmbMediaMoveEntityBulkAction,
 		meta: {
-			label: 'Trash',
+			label: 'Move',
 			repositoryAlias: UMB_MEDIA_DETAIL_REPOSITORY_ALIAS,
 		},
 		conditions: [
 			{
-				// TODO: this condition should be based on entity types in the selection
 				alias: UMB_COLLECTION_ALIAS_CONDITION,
 				match: UMB_MEDIA_COLLECTION_ALIAS,
+			},
+			{
+				alias: UMB_COLLECTION_BULK_ACTION_PERMISSION_CONDITION,
+				match: (permissions: UmbCollectionBulkActionPermissions) => permissions.allowBulkMove,
+			},
+		],
+	},
+	{
+		type: 'entityBulkAction',
+		alias: 'Umb.EntityBulkAction.Media.Delete',
+		name: 'Delete Media Entity Bulk Action',
+		weight: 10,
+		api: UmbMediaDeleteEntityBulkAction,
+		meta: {
+			label: 'Delete',
+			repositoryAlias: UMB_MEDIA_DETAIL_REPOSITORY_ALIAS,
+		},
+		conditions: [
+			{
+				alias: UMB_COLLECTION_ALIAS_CONDITION,
+				match: UMB_MEDIA_COLLECTION_ALIAS,
+			},
+			{
+				alias: UMB_COLLECTION_BULK_ACTION_PERMISSION_CONDITION,
+				match: (permissions: UmbCollectionBulkActionPermissions) => permissions.allowBulkDelete,
 			},
 		],
 	},
 ];
-
-export const manifests = [...entityActions];

--- a/src/packages/media/media/entity-bulk-actions/move/move.action.ts
+++ b/src/packages/media/media/entity-bulk-actions/move/move.action.ts
@@ -17,6 +17,8 @@ export class UmbMediaMoveEntityBulkAction extends UmbEntityBulkActionBase<UmbMed
 	}
 
 	async execute() {
+		console.log(`execute move for: ${this.selection}`);
+
 		// TODO: the picker should be single picker by default
 		const modalContext = this.#modalContext?.open(UMB_MEDIA_TREE_PICKER_MODAL, {
 			data: {


### PR DESCRIPTION
Added "Collection Bulk Action Permission Condition" to Media's Entity Bulk Action manifests.

Also renamed the "Trash" action to "Delete", for consistency with the action name in the Documents package.
