### PR TITLE
Feature: Document Type Modal Routing Identify

### DIFF
--- a/src/packages/core/content-type/content-type-container-structure-helper.class.ts
+++ b/src/packages/core/content-type/content-type-container-structure-helper.class.ts
@@ -217,7 +217,7 @@ export class UmbContentTypeContainerStructureHelper<T extends UmbContentTypeMode
 	async addContainer(parentContainerId?: string | null, sortOrder?: number) {
 		if (!this.#structure) return;
 
-		await this.#structure.createContainer(null, parentContainerId, this._childType, sortOrder);
+		return await this.#structure.createContainer(null, parentContainerId, this._childType, sortOrder);
 	}
 
 	async removeContainer(groupId: string) {

--- a/src/packages/core/data-type/components/data-type-flow-input/data-type-flow-input.element.ts
+++ b/src/packages/core/data-type/components/data-type-flow-input/data-type-flow-input.element.ts
@@ -15,6 +15,7 @@ import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
  */
 @customElement('umb-data-type-flow-input')
 export class UmbInputDataTypeElement extends FormControlMixin(UmbLitElement) {
+	#modalRegistration;
 	protected getFormElement() {
 		return undefined;
 	}
@@ -38,6 +39,17 @@ export class UmbInputDataTypeElement extends FormControlMixin(UmbLitElement) {
 			.filter((id) => id.length !== 0);
 	}
 
+	private _propertyId = '';
+	@property({ type: String })
+	set propertyId(value: string) {
+		if (!value) return;
+		this._propertyId = value;
+		this.#modalRegistration.setUniquePathValue('propertyId', value);
+	}
+	get propertyId(): string {
+		return this._propertyId;
+	}
+
 	#editDataTypeModal?: UmbModalRouteRegistrationController;
 
 	@state()
@@ -48,7 +60,8 @@ export class UmbInputDataTypeElement extends FormControlMixin(UmbLitElement) {
 
 		this.#editDataTypeModal = new UmbModalRouteRegistrationController(this, UMB_DATATYPE_WORKSPACE_MODAL);
 
-		new UmbModalRouteRegistrationController(this, UMB_DATA_TYPE_PICKER_FLOW_MODAL)
+		this.#modalRegistration = new UmbModalRouteRegistrationController(this, UMB_DATA_TYPE_PICKER_FLOW_MODAL)
+			.addUniquePaths(['propertyId'])
 			.onSetup(() => {
 				return {
 					data: {

--- a/src/packages/core/data-type/components/data-type-flow-input/data-type-flow-input.element.ts
+++ b/src/packages/core/data-type/components/data-type-flow-input/data-type-flow-input.element.ts
@@ -38,18 +38,6 @@ export class UmbInputDataTypeElement extends FormControlMixin(UmbLitElement) {
 			.map((tag) => tag.trim())
 			.filter((id) => id.length !== 0);
 	}
-
-	private _propertyId = '';
-	@property({ type: String })
-	set propertyId(value: string) {
-		if (!value) return;
-		this._propertyId = value;
-		this.#modalRegistration.setUniquePathValue('propertyId', value);
-	}
-	get propertyId(): string {
-		return this._propertyId;
-	}
-
 	#editDataTypeModal?: UmbModalRouteRegistrationController;
 
 	@state()
@@ -61,7 +49,6 @@ export class UmbInputDataTypeElement extends FormControlMixin(UmbLitElement) {
 		this.#editDataTypeModal = new UmbModalRouteRegistrationController(this, UMB_DATATYPE_WORKSPACE_MODAL);
 
 		this.#modalRegistration = new UmbModalRouteRegistrationController(this, UMB_DATA_TYPE_PICKER_FLOW_MODAL)
-			.addUniquePaths(['propertyId'])
 			.onSetup(() => {
 				return {
 					data: {

--- a/src/packages/core/modal/common/property-settings/property-settings-modal.element.ts
+++ b/src/packages/core/modal/common/property-settings/property-settings-modal.element.ts
@@ -6,7 +6,7 @@ import { UMB_DOCUMENT_TYPE_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/doc
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import type { UUIBooleanInputEvent, UUIInputEvent, UUISelectEvent } from '@umbraco-cms/backoffice/external/uui';
 import type { PropertyValueMap } from '@umbraco-cms/backoffice/external/lit';
-import { css, html, nothing, customElement, state } from '@umbraco-cms/backoffice/external/lit';
+import { css, html, nothing, customElement, state, ifDefined } from '@umbraco-cms/backoffice/external/lit';
 import type { UmbPropertySettingsModalValue, UmbPropertySettingsModalData } from '@umbraco-cms/backoffice/modal';
 import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 import { generateAlias } from '@umbraco-cms/backoffice/utils';
@@ -259,7 +259,8 @@ export class UmbPropertySettingsModalElement extends UmbModalBaseElement<
 										.value=${this.value.description}></uui-textarea>
 								</div>
 								<umb-data-type-flow-input
-									.value=${this.value.dataType?.unique}
+									propertyId=${this.value.id}
+									value=${ifDefined(this.value.dataType?.unique)}
 									@change=${this.#onDataTypeIdChange}></umb-data-type-flow-input>
 								<hr />
 								<div class="container">

--- a/src/packages/core/modal/common/property-settings/property-settings-modal.element.ts
+++ b/src/packages/core/modal/common/property-settings/property-settings-modal.element.ts
@@ -259,7 +259,6 @@ export class UmbPropertySettingsModalElement extends UmbModalBaseElement<
 										.value=${this.value.description}></uui-textarea>
 								</div>
 								<umb-data-type-flow-input
-									propertyId=${this.value.id}
 									value=${ifDefined(this.value.dataType?.unique)}
 									@change=${this.#onDataTypeIdChange}></umb-data-type-flow-input>
 								<hr />

--- a/src/packages/documents/document-types/workspace/views/design/document-type-workspace-view-edit-properties.element.ts
+++ b/src/packages/documents/document-types/workspace/views/design/document-type-workspace-view-edit-properties.element.ts
@@ -13,6 +13,7 @@ import { UMB_PROPERTY_SETTINGS_MODAL, UmbModalRouteRegistrationController } from
 
 @customElement('umb-document-type-workspace-view-edit-properties')
 export class UmbDocumentTypeWorkspaceViewEditPropertiesElement extends UmbLitElement {
+	#modalRegistration;
 	#model: Array<UmbPropertyTypeModel> = [];
 	#sorter = new UmbSorterController<UmbPropertyTypeModel, UmbDocumentTypeWorkspacePropertyElement>(this, {
 		getUniqueOfElement: (element) => {
@@ -87,6 +88,7 @@ export class UmbDocumentTypeWorkspaceViewEditPropertiesElement extends UmbLitEle
 		if (value === this._containerId) return;
 		const oldValue = this._containerId;
 		this._containerId = value;
+		this.#modalRegistration.setUniquePathValue('containerId', value);
 		this.requestUpdate('containerId', oldValue);
 	}
 
@@ -159,8 +161,10 @@ export class UmbDocumentTypeWorkspaceViewEditPropertiesElement extends UmbLitEle
 		});
 
 		// Note: Route for adding a new property
-		new UmbModalRouteRegistrationController(this, UMB_PROPERTY_SETTINGS_MODAL)
+		this.#modalRegistration = new UmbModalRouteRegistrationController(this, UMB_PROPERTY_SETTINGS_MODAL)
+			//Is there a way to make new-property BEFORE containerId in the URL? right now it shows as .../containerId/new-property/...
 			.addAdditionalPath('new-property')
+			.addUniquePaths(['containerId'])
 			.onSetup(async () => {
 				const documentTypeId = this._ownerDocumentTypes?.find(
 					(types) => types.containers?.find((containers) => containers.id === this.containerId),

--- a/src/packages/documents/document-types/workspace/views/design/document-type-workspace-view-edit-tab.element.ts
+++ b/src/packages/documents/document-types/workspace/views/design/document-type-workspace-view-edit-tab.element.ts
@@ -155,9 +155,16 @@ export class UmbDocumentTypeWorkspaceViewEditTabElement extends UmbLitElement {
 		});
 	}
 
-	#onAddGroup = () => {
+	#onAddGroup = async () => {
 		// Idea, maybe we can gather the sortOrder from the last group rendered and add 1 to it?
-		this._groupStructureHelper.addContainer(this._ownerTabId);
+		const newContainer = await this._groupStructureHelper.addContainer(this._ownerTabId);
+
+		requestAnimationFrame(() => {
+			this.shadowRoot
+				?.querySelector(`[container-id="${newContainer?.id}"]`)
+				?.parentElement?.querySelector('uui-input')
+				?.focus();
+		});
 	};
 
 	render() {


### PR DESCRIPTION
CHANGES:
- Sets the container id in the URL when creating a new property editor in a document type - this way we know which group we are trying to insert a property into.
- Sets focus on the group name when creating a new group

BUGS:
- Changing a group name causes an issue where a property editor cannot be picked (issue on main branch).

