### PR TITLE
Adds mock API for Media Type structure

### DIFF
--- a/src/mocks/data/media-type/media-type.data.ts
+++ b/src/mocks/data/media-type/media-type.data.ts
@@ -67,7 +67,7 @@ export const data: Array<UmbMockMediaTypeModel> = [
 				sortOrder: 0,
 			},
 		],
-		allowedAsRoot: false,
+		allowedAsRoot: true,
 		variesByCulture: false,
 		variesBySegment: false,
 		isElement: false,

--- a/src/mocks/data/media-type/media-type.db.ts
+++ b/src/mocks/data/media-type/media-type.db.ts
@@ -7,11 +7,14 @@ import type { UmbMockMediaTypeModel } from './media-type.data.js';
 import { data } from './media-type.data.js';
 import { UmbId } from '@umbraco-cms/backoffice/id';
 import type {
+	AllowedMediaTypeModel,
 	CreateFolderRequestModel,
 	CreateMediaTypeRequestModel,
 	MediaTypeItemResponseModel,
 	MediaTypeResponseModel,
+	MediaTypeSortModel,
 	MediaTypeTreeItemResponseModel,
+	PagedAllowedMediaTypeModel,
 } from '@umbraco-cms/backoffice/external/backend-api';
 
 class UmbMediaTypeMockDB extends UmbEntityMockDbBase<UmbMockMediaTypeModel> {
@@ -26,6 +29,21 @@ class UmbMediaTypeMockDB extends UmbEntityMockDbBase<UmbMockMediaTypeModel> {
 
 	constructor(data: Array<UmbMockMediaTypeModel>) {
 		super(data);
+	}
+
+	getAllowedChildren(id: string): PagedAllowedMediaTypeModel {
+		const mediaType = this.detail.read(id);
+		const allowedMediaTypes = mediaType.allowedMediaTypes.map((sortModel: MediaTypeSortModel) =>
+			this.detail.read(sortModel.mediaType.id),
+		);
+		const mappedItems = allowedMediaTypes.map((item: UmbMockMediaTypeModel) => allowedMediaTypeMapper(item));
+		return { items: mappedItems, total: mappedItems.length };
+	}
+
+	getAllowedAtRoot(): PagedAllowedMediaTypeModel {
+		const mockItems = this.data.filter((item) => item.allowedAsRoot);
+		const mappedItems = mockItems.map((item) => allowedMediaTypeMapper(item));
+		return { items: mappedItems, total: mappedItems.length };
 	}
 }
 
@@ -104,6 +122,15 @@ const mediaTypeItemMapper = (item: UmbMockMediaTypeModel): MediaTypeItemResponse
 	return {
 		id: item.id,
 		name: item.name,
+		icon: item.icon,
+	};
+};
+
+const allowedMediaTypeMapper = (item: UmbMockMediaTypeModel): AllowedMediaTypeModel => {
+	return {
+		id: item.id,
+		name: item.name,
+		description: item.description,
 		icon: item.icon,
 	};
 };

--- a/src/mocks/handlers/media-type/index.ts
+++ b/src/mocks/handlers/media-type/index.ts
@@ -1,6 +1,7 @@
 import { treeHandlers } from './tree.handlers.js';
-import { itemHandlers } from './item.handlers.js';
 import { detailHandlers } from './detail.handlers.js';
+import { itemHandlers } from './item.handlers.js';
 import { folderHandlers } from './folder.handlers.js';
+import { structureHandlers } from './structure.handlers.js';
 
-export const handlers = [...treeHandlers, ...itemHandlers, ...folderHandlers, ...detailHandlers];
+export const handlers = [...treeHandlers, ...itemHandlers, ...folderHandlers, ...structureHandlers, ...detailHandlers];

--- a/src/mocks/handlers/media-type/structure.handlers.ts
+++ b/src/mocks/handlers/media-type/structure.handlers.ts
@@ -1,0 +1,18 @@
+const { rest } = window.MockServiceWorker;
+import { umbMediaTypeMockDb } from '../../data/media-type/media-type.db.js';
+import { UMB_SLUG } from './slug.js';
+import { umbracoPath } from '@umbraco-cms/backoffice/utils';
+
+export const structureHandlers = [
+	rest.get(umbracoPath(`${UMB_SLUG}/:id/allowed-children`), (req, res, ctx) => {
+		const id = req.params.id as string;
+		if (!id) return res(ctx.status(400));
+		const response = umbMediaTypeMockDb.getAllowedChildren(id);
+		return res(ctx.status(200), ctx.json(response));
+	}),
+
+	rest.get(umbracoPath(`${UMB_SLUG}/allowed-at-root`), (req, res, ctx) => {
+		const response = umbMediaTypeMockDb.getAllowedAtRoot();
+		return res(ctx.status(200), ctx.json(response));
+	}),
+];


### PR DESCRIPTION
Adds mock API for Media Type structure, e.g. `getAllowedAtRoot` and `getAllowedChildren`

This is to add mock data support for PR #1263.