### PR TITLE
Feature: Media Collection UI (workspace and property-editor)

### DIFF
--- a/src/mocks/data/media-type/media-type.data.ts
+++ b/src/mocks/data/media-type/media-type.data.ts
@@ -57,6 +57,26 @@ export const data: Array<UmbMockMediaTypeModel> = [
 					labelOnTop: false,
 				},
 			},
+			{
+				id: '7',
+				container: { id: 'c3cd2f12-b7c4-4206-8d8b-27c061589f75' },
+				alias: 'listView',
+				name: 'List View',
+				description: '',
+				dataType: { id: 'dt-collectionView' },
+				variesByCulture: false,
+				variesBySegment: false,
+				sortOrder: 2,
+				validation: {
+					mandatory: false,
+					mandatoryMessage: null,
+					regEx: null,
+					regExMessage: null,
+				},
+				appearance: {
+					labelOnTop: false,
+				},
+			},
 		],
 		containers: [
 			{
@@ -71,9 +91,12 @@ export const data: Array<UmbMockMediaTypeModel> = [
 		variesByCulture: false,
 		variesBySegment: false,
 		isElement: false,
-		allowedMediaTypes: [],
+		allowedMediaTypes: [
+			{ mediaType: { id: 'media-type-1-id' }, sortOrder: 0 },
+		],
 		compositions: [],
 		isFolder: false,
 		hasChildren: false,
+		collection: { id: 'dt-collectionView' },
 	},
 ];

--- a/src/mocks/data/media-type/media-type.db.ts
+++ b/src/mocks/data/media-type/media-type.db.ts
@@ -65,6 +65,7 @@ const createMockMediaTypeFolderMapper = (request: CreateFolderRequestModel): Umb
 		compositions: [],
 		isFolder: true,
 		hasChildren: false,
+		collection: null,
 	};
 };
 
@@ -86,6 +87,7 @@ const createMockMediaTypeMapper = (request: CreateMediaTypeRequestModel): UmbMoc
 		parent: request.folder ? { id: request.folder.id } : null,
 		isFolder: false,
 		hasChildren: false,
+		collection: null,
 	};
 };
 
@@ -104,6 +106,7 @@ const mediaTypeDetailMapper = (item: UmbMockMediaTypeModel): MediaTypeResponseMo
 		isElement: item.isElement,
 		allowedMediaTypes: item.allowedMediaTypes,
 		compositions: item.compositions,
+		collection: item.collection,
 	};
 };
 

--- a/src/mocks/data/media/media.data.ts
+++ b/src/mocks/data/media/media.data.ts
@@ -74,6 +74,7 @@ export const data: Array<UmbMockMediaModel> = [
 		mediaType: {
 			id: 'media-type-1-id',
 			icon: 'icon-bug',
+			collection: { id: 'dt-collectionView' },
 		},
 		values: [],
 		variants: [
@@ -97,6 +98,7 @@ export const data: Array<UmbMockMediaModel> = [
 		mediaType: {
 			id: 'media-type-1-id',
 			icon: 'icon-bug',
+			collection: { id: 'dt-collectionView' },
 		},
 		values: [],
 		variants: [

--- a/src/packages/media/media/conditions/index.ts
+++ b/src/packages/media/media/conditions/index.ts
@@ -1,0 +1,1 @@
+export { UMB_MEDIA_WORKSPACE_HAS_COLLECTION_CONDITION } from './media-workspace-has-collection.condition.js';

--- a/src/packages/media/media/conditions/manifests.ts
+++ b/src/packages/media/media/conditions/manifests.ts
@@ -1,0 +1,3 @@
+import { manifest as mediaWorkspaceHasCollectionCondition } from './media-workspace-has-collection.condition.js';
+
+export const manifests = [mediaWorkspaceHasCollectionCondition];

--- a/src/packages/media/media/conditions/media-workspace-has-collection.condition.ts
+++ b/src/packages/media/media/conditions/media-workspace-has-collection.condition.ts
@@ -1,0 +1,44 @@
+import { UMB_MEDIA_WORKSPACE_CONTEXT } from '../workspace/media-workspace.context-token.js';
+import { UmbBaseController } from '@umbraco-cms/backoffice/class-api';
+import type {
+	ManifestCondition,
+	UmbConditionConfigBase,
+	UmbConditionControllerArguments,
+	UmbExtensionCondition,
+} from '@umbraco-cms/backoffice/extension-api';
+
+export class UmbMediaWorkspaceHasCollectionCondition extends UmbBaseController implements UmbExtensionCondition {
+	config: MediaWorkspaceHasCollectionConditionConfig;
+	permitted = false;
+	#onChange: () => void;
+
+	constructor(args: UmbConditionControllerArguments<MediaWorkspaceHasCollectionConditionConfig>) {
+		super(args.host);
+		this.config = args.config;
+		this.#onChange = args.onChange;
+
+		this.consumeContext(UMB_MEDIA_WORKSPACE_CONTEXT, (context) => {
+			this.observe(
+				context.contentTypeCollection,
+				(collection) => {
+					this.permitted = !!collection?.id;
+					this.#onChange();
+				},
+				'observeCollection',
+			);
+		});
+	}
+}
+
+export type MediaWorkspaceHasCollectionConditionConfig = UmbConditionConfigBase<
+	typeof UMB_MEDIA_WORKSPACE_HAS_COLLECTION_CONDITION
+>;
+
+export const UMB_MEDIA_WORKSPACE_HAS_COLLECTION_CONDITION = 'Umb.Condition.MediaWorkspaceHasCollection';
+
+export const manifest: ManifestCondition = {
+	type: 'condition',
+	name: 'Media Workspace Has Collection Condition',
+	alias: UMB_MEDIA_WORKSPACE_HAS_COLLECTION_CONDITION,
+	api: UmbMediaWorkspaceHasCollectionCondition,
+};

--- a/src/packages/media/media/index.ts
+++ b/src/packages/media/media/index.ts
@@ -7,6 +7,7 @@ export * from './tracked-reference/index.js';
 export * from './user-permissions/index.js';
 export * from './utils/index.js';
 export * from './workspace/index.js';
+export * from './conditions/index.js';
 
 export { UMB_MEDIA_TREE_ALIAS } from './tree/index.js';
 export { UMB_MEDIA_COLLECTION_ALIAS } from './collection/index.js';

--- a/src/packages/media/media/manifests.ts
+++ b/src/packages/media/media/manifests.ts
@@ -1,4 +1,5 @@
 import { manifests as collectionManifests } from './collection/manifests.js';
+import { manifests as conditionManifests } from './conditions/manifests.js';
 import { manifests as entityActionsManifests } from './entity-actions/manifests.js';
 import { manifests as entityBulkActionsManifests } from './entity-bulk-actions/manifests.js';
 import { manifests as menuItemManifests } from './menu-item/manifests.js';
@@ -11,6 +12,7 @@ import { manifests as workspaceManifests } from './workspace/manifests.js';
 
 export const manifests = [
 	...collectionManifests,
+	...conditionManifests,
 	...entityActionsManifests,
 	...entityBulkActionsManifests,
 	...menuItemManifests,

--- a/src/packages/media/media/repository/detail/media-detail.server.data-source.ts
+++ b/src/packages/media/media/repository/detail/media-detail.server.data-source.ts
@@ -40,6 +40,7 @@ export class UmbMediaServerDataSource implements UmbDetailDataSource<UmbMediaDet
 			urls: [],
 			mediaType: {
 				unique: mediaType.unique,
+				collection: mediaType.collection || null,
 			},
 			isTrashed: false,
 			values: [],
@@ -89,7 +90,10 @@ export class UmbMediaServerDataSource implements UmbDetailDataSource<UmbMediaDet
 				};
 			}),
 			urls: data.urls,
-			mediaType: { unique: data.mediaType.id },
+			mediaType: {
+				unique: data.mediaType.id,
+				collection: data.mediaType.collection || null,
+			},
 			isTrashed: data.isTrashed,
 		};
 

--- a/src/packages/media/media/types.ts
+++ b/src/packages/media/media/types.ts
@@ -1,9 +1,13 @@
 import type { UmbMediaEntityType } from './entity.js';
+import type { UmbReferenceById } from '@umbraco-cms/backoffice/models';
 import type { UmbVariantModel } from '@umbraco-cms/backoffice/variant';
 import type { MediaUrlInfoModel, MediaValueModel } from '@umbraco-cms/backoffice/external/backend-api';
 
 export interface UmbMediaDetailModel {
-	mediaType: { unique: string };
+	mediaType: {
+		unique: string;
+		collection: UmbReferenceById | null;
+	};
 	entityType: UmbMediaEntityType;
 	isTrashed: boolean;
 	unique: string;

--- a/src/packages/media/media/workspace/manifests.ts
+++ b/src/packages/media/media/workspace/manifests.ts
@@ -1,4 +1,4 @@
-import { UMB_MEDIA_DETAIL_REPOSITORY_ALIAS } from '../repository/index.js';
+import { UMB_MEDIA_WORKSPACE_HAS_COLLECTION_CONDITION } from '../conditions/media-workspace-has-collection.condition.js';
 import { UmbSaveWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
 import type {
 	ManifestWorkspace,
@@ -18,24 +18,23 @@ const workspace: ManifestWorkspace = {
 };
 
 const workspaceViews: Array<ManifestWorkspaceView> = [
-	// {
-	// 	type: 'workspaceView',
-	// 	alias: 'Umb.WorkspaceView.Media.Collection',
-	// 	name: 'Media Workspace Collection View',
-	// 	element: () => import('./views/collection/media-collection-workspace-view.element.js'),
-	// 	weight: 300,
-	// 	meta: {
-	// 		label: 'Media',
-	// 		pathname: 'collection',
-	// 		icon: 'icon-grid',
-	// 	},
-	// 	conditions: [
-	// 		{
-	// 			alias: 'Umb.Condition.WorkspaceAlias',
-	// 			match: workspace.alias,
-	// 		},
-	// 	],
-	// },
+	{
+		type: 'workspaceView',
+		alias: 'Umb.WorkspaceView.Media.Collection',
+		name: 'Media Workspace Collection View',
+		element: () => import('./views/collection/media-workspace-view-collection.element.js'),
+		weight: 300,
+		meta: {
+			label: 'Collection',
+			pathname: 'collection',
+			icon: 'icon-grid',
+		},
+		conditions: [
+			{
+				alias: UMB_MEDIA_WORKSPACE_HAS_COLLECTION_CONDITION,
+			},
+		],
+	},
 	{
 		type: 'workspaceView',
 		alias: 'Umb.WorkspaceView.Media.Edit',

--- a/src/packages/media/media/workspace/media-workspace.context.ts
+++ b/src/packages/media/media/workspace/media-workspace.context.ts
@@ -32,6 +32,7 @@ export class UmbMediaWorkspaceContext
 
 	readonly unique = this.#currentData.asObservablePart((data) => data?.unique);
 	readonly contentTypeUnique = this.#currentData.asObservablePart((data) => data?.mediaType.unique);
+	readonly contentTypeCollection = this.#currentData.asObservablePart((data) => data?.mediaType.collection);
 
 	readonly variants = this.#currentData.asObservablePart((data) => data?.variants || []);
 	readonly urls = this.#currentData.asObservablePart((data) => data?.urls || []);

--- a/src/packages/media/media/workspace/views/collection/media-workspace-view-collection.element.ts
+++ b/src/packages/media/media/workspace/views/collection/media-workspace-view-collection.element.ts
@@ -1,0 +1,83 @@
+import type {
+	UmbCollectionBulkActionPermissions,
+	UmbCollectionConfiguration,
+} from '../../../../../core/collection/types.js';
+import { customElement, html, state } from '@umbraco-cms/backoffice/external/lit';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { UmbDataTypeDetailRepository } from '@umbraco-cms/backoffice/data-type';
+import { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
+import { UMB_MEDIA_COLLECTION_ALIAS, UMB_MEDIA_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/media';
+import type { UmbDataTypeDetailModel } from '@umbraco-cms/backoffice/data-type';
+import type { UmbWorkspaceViewElement } from '@umbraco-cms/backoffice/extension-registry';
+
+@customElement('umb-media-workspace-view-collection')
+export class UmbMediaWorkspaceViewCollectionElement extends UmbLitElement implements UmbWorkspaceViewElement {
+	@state()
+	private _config?: UmbCollectionConfiguration;
+
+	@state()
+	private _mediaUnique?: string;
+
+	#dataTypeDetailRepository = new UmbDataTypeDetailRepository(this);
+
+	constructor() {
+		super();
+		this.#observeConfig();
+	}
+
+	async #observeConfig() {
+		this.consumeContext(UMB_MEDIA_WORKSPACE_CONTEXT, (workspaceContext) => {
+			this.observe(workspaceContext.unique, (unique) => {
+				this._mediaUnique = unique;
+			});
+			this.observe(
+				workspaceContext.structure.ownerContentType(),
+				async (mediaType) => {
+					if (!mediaType || !mediaType.collection) return;
+
+					const dataTypeUnique = mediaType.collection.unique;
+
+					if (dataTypeUnique) {
+						await this.#dataTypeDetailRepository.requestByUnique(dataTypeUnique);
+						this.observe(
+							await this.#dataTypeDetailRepository.byUnique(dataTypeUnique),
+							(dataType) => {
+								if (!dataType) return;
+								this._config = this.#mapDataTypeConfigToCollectionConfig(dataType);
+							},
+							'_observeConfigDataType',
+						);
+					}
+				},
+				'_observeConfigMediaType',
+			);
+		});
+	}
+
+	#mapDataTypeConfigToCollectionConfig(dataType: UmbDataTypeDetailModel): UmbCollectionConfiguration {
+		const config = new UmbPropertyEditorConfigCollection(dataType.values);
+		return {
+			unique: this._mediaUnique,
+			dataTypeId: dataType.unique,
+			allowedEntityBulkActions: config?.getValueByAlias<UmbCollectionBulkActionPermissions>('bulkActionPermissions'),
+			orderBy: config?.getValueByAlias('orderBy') ?? 'updateDate',
+			orderDirection: config?.getValueByAlias('orderDirection') ?? 'asc',
+			pageSize: Number(config?.getValueByAlias('pageSize')) ?? 50,
+			useInfiniteEditor: config?.getValueByAlias('useInfiniteEditor') ?? false,
+			userDefinedProperties: config?.getValueByAlias('includeProperties'),
+		};
+	}
+
+	render() {
+		if (!this._config?.unique || !this._config?.dataTypeId) return html`<uui-loader></uui-loader>`;
+		return html`<umb-collection .alias=${UMB_MEDIA_COLLECTION_ALIAS} .config=${this._config}></umb-collection>`;
+	}
+}
+
+export default UmbMediaWorkspaceViewCollectionElement;
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-media-workspace-view-collection': UmbMediaWorkspaceViewCollectionElement;
+	}
+}

--- a/src/packages/media/media/workspace/views/collection/media-workspace-view-collection.element.ts
+++ b/src/packages/media/media/workspace/views/collection/media-workspace-view-collection.element.ts
@@ -1,12 +1,12 @@
-import type {
-	UmbCollectionBulkActionPermissions,
-	UmbCollectionConfiguration,
-} from '../../../../../core/collection/types.js';
 import { customElement, html, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbDataTypeDetailRepository } from '@umbraco-cms/backoffice/data-type';
 import { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
 import { UMB_MEDIA_COLLECTION_ALIAS, UMB_MEDIA_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/media';
+import type {
+	UmbCollectionBulkActionPermissions,
+	UmbCollectionConfiguration,
+} from '@umbraco-cms/backoffice/collection';
 import type { UmbDataTypeDetailModel } from '@umbraco-cms/backoffice/data-type';
 import type { UmbWorkspaceViewElement } from '@umbraco-cms/backoffice/extension-registry';
 


### PR DESCRIPTION
- Adds mock data
- Adds Media workspace condition
- Adds Media workspace view for collection
- Updates existing Collection property-editor (to work with both Documents and Media)

> [!NOTE]
> We'll need to review how `<umb-property-editor-ui-collection-view>` is wired up, as it is currently hardcoded to be either Document or Media. Ideally, it should be abstracted to work with any Entity type that supports ContentType structures.
> To be discussed further...