### PR TITLE
Exports types for `UmbCollectionBulkActionPermissions` and `UmbCollectionConfiguration`

### DIFF
--- a/src/packages/core/collection/index.ts
+++ b/src/packages/core/collection/index.ts
@@ -14,3 +14,4 @@ export { UMB_COLLECTION_BULK_ACTION_PERMISSION_CONDITION } from './collection-bu
 
 export { UmbCollectionActionElement, UmbCollectionActionBase } from './action/index.js';
 export type { UmbCollectionDataSource, UmbCollectionRepository } from './repository/index.js';
+export type { UmbCollectionBulkActionPermissions, UmbCollectionConfiguration } from './types.js';


### PR DESCRIPTION
I wasn't sure whether to be specific with the exports or do a generic `export type * from './types.js';`?

---

Once this is merged in, I can mark PRs #1275 and #1277 as ready for re-review.