### PR TITLE
Entity Action: Adds the `execute` abstract method

### DIFF
--- a/src/packages/core/entity-action/entity-action.ts
+++ b/src/packages/core/entity-action/entity-action.ts
@@ -1,12 +1,16 @@
-import type { UmbAction} from '../action/index.js';
+import type { UmbAction } from '../action/index.js';
 import { UmbActionBase } from '../action/index.js';
 import type { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
 
 export interface UmbEntityAction<RepositoryType> extends UmbAction<RepositoryType> {
 	unique: string;
+	execute(): Promise<void>;
 }
 
-export class UmbEntityActionBase<RepositoryType> extends UmbActionBase<RepositoryType> {
+export abstract class UmbEntityActionBase<RepositoryType>
+	extends UmbActionBase<RepositoryType>
+	implements UmbEntityAction<RepositoryType>
+{
 	entityType: string;
 	unique: string;
 	repositoryAlias: string;
@@ -17,4 +21,6 @@ export class UmbEntityActionBase<RepositoryType> extends UmbActionBase<Repositor
 		this.unique = unique;
 		this.repositoryAlias = repositoryAlias;
 	}
+
+	abstract execute(): Promise<void>;
 }

--- a/src/packages/core/entity-bulk-action/entity-bulk-action.ts
+++ b/src/packages/core/entity-bulk-action/entity-bulk-action.ts
@@ -5,6 +5,7 @@ import type { UmbControllerHostElement } from '@umbraco-cms/backoffice/controlle
 export interface UmbEntityBulkAction<RepositoryType = unknown> extends UmbAction<RepositoryType> {
 	selection: Array<string>;
 	setSelection(selection: Array<string>): void;
+	execute(): Promise<void>;
 }
 
 export abstract class UmbEntityBulkActionBase<RepositoryType = unknown>


### PR DESCRIPTION
Ensures the `execute` method is on the base interface for both `UmbEntityAction` and `UmbEntityBulkAction`.

Resolves #1288.