### PR TITLE
Entity Action: Adds the `getHref` inteface method

### DIFF
--- a/src/packages/core/action/repository-action.ts
+++ b/src/packages/core/action/repository-action.ts
@@ -1,4 +1,4 @@
-import type { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbBaseController } from '@umbraco-cms/backoffice/class-api';
 import { type UmbApi, UmbExtensionApiInitializer } from '@umbraco-cms/backoffice/extension-api';
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
@@ -6,7 +6,7 @@ import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registr
 export class UmbActionBase<RepositoryType> extends UmbBaseController implements UmbApi {
 	repository?: RepositoryType;
 
-	constructor(host: UmbControllerHostElement, repositoryAlias: string) {
+	constructor(host: UmbControllerHost, repositoryAlias: string) {
 		super(host);
 
 		new UmbExtensionApiInitializer(this, umbExtensionsRegistry, repositoryAlias, [this._host], (permitted, ctrl) => {

--- a/src/packages/core/entity-action/entity-action.ts
+++ b/src/packages/core/entity-action/entity-action.ts
@@ -4,6 +4,7 @@ import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
 export interface UmbEntityAction<RepositoryType> extends UmbAction<RepositoryType> {
 	unique: string;
+	getHref(): Promise<string | null | undefined>;
 	execute(): Promise<void>;
 }
 
@@ -22,5 +23,10 @@ export abstract class UmbEntityActionBase<RepositoryType>
 		this.repositoryAlias = repositoryAlias;
 	}
 
-	abstract execute(): Promise<void>;
+	public getHref(): Promise<string | null | undefined> {
+		return Promise.resolve(undefined);
+	}
+	public execute(): Promise<void> {
+		return Promise.resolve();
+	}
 }

--- a/src/packages/core/entity-action/entity-action.ts
+++ b/src/packages/core/entity-action/entity-action.ts
@@ -1,6 +1,6 @@
 import type { UmbAction } from '../action/index.js';
 import { UmbActionBase } from '../action/index.js';
-import type { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
 export interface UmbEntityAction<RepositoryType> extends UmbAction<RepositoryType> {
 	unique: string;
@@ -15,7 +15,7 @@ export abstract class UmbEntityActionBase<RepositoryType>
 	unique: string;
 	repositoryAlias: string;
 
-	constructor(host: UmbControllerHostElement, repositoryAlias: string, unique: string, entityType: string) {
+	constructor(host: UmbControllerHost, repositoryAlias: string, unique: string, entityType: string) {
 		super(host, repositoryAlias);
 		this.entityType = entityType;
 		this.unique = unique;

--- a/src/packages/core/entity-action/entity-action.ts
+++ b/src/packages/core/entity-action/entity-action.ts
@@ -2,12 +2,42 @@ import type { UmbAction } from '../action/index.js';
 import { UmbActionBase } from '../action/index.js';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
+/**
+ * Interface for an entity action.
+ * @export
+ * @interface UmbEntityAction<RepositoryType>
+ * @extends {UmbAction<RepositoryType>}
+ * @template RepositoryType
+ */
 export interface UmbEntityAction<RepositoryType> extends UmbAction<RepositoryType> {
+	/**
+	 * The unique identifier of the entity.
+	 * @type {string}
+	 */
 	unique: string;
+
+	/**
+	 * The href location, the action will act as a link.
+	 * @returns {Promise<string | null | undefined>}
+	 */
 	getHref(): Promise<string | null | undefined>;
+
+	/**
+	 * The `execute` method, the action will act as a button.
+	 * @returns {Promise<void>}
+	 */
 	execute(): Promise<void>;
 }
 
+/**
+ * Base class for an entity action.
+ * @export
+ * @abstract
+ * @class UmbEntityActionBase<RepositoryType>
+ * @extends {UmbActionBase<RepositoryType>}
+ * @implements {UmbEntityAction<RepositoryType>}
+ * @template RepositoryType
+ */
 export abstract class UmbEntityActionBase<RepositoryType>
 	extends UmbActionBase<RepositoryType>
 	implements UmbEntityAction<RepositoryType>
@@ -16,6 +46,14 @@ export abstract class UmbEntityActionBase<RepositoryType>
 	unique: string;
 	repositoryAlias: string;
 
+	/**
+	 * Creates an instance of UmbEntityActionBase<RepositoryType>.
+	 * @param {UmbControllerHost} host
+	 * @param {string} repositoryAlias
+	 * @param {string} unique
+	 * @param {string} entityType
+	 * @memberof UmbEntityActionBase<RepositoryType>
+	 */
 	constructor(host: UmbControllerHost, repositoryAlias: string, unique: string, entityType: string) {
 		super(host, repositoryAlias);
 		this.entityType = entityType;
@@ -23,9 +61,21 @@ export abstract class UmbEntityActionBase<RepositoryType>
 		this.repositoryAlias = repositoryAlias;
 	}
 
+	/**
+	 * By specifying the href, the action will act as a link.
+	 * The `execute` method will not be called.
+	 * @abstract
+	 * @returns {string | null | undefined}
+	 */
 	public getHref(): Promise<string | null | undefined> {
 		return Promise.resolve(undefined);
 	}
+
+	/**
+	 * By specifying the `execute` method, the action will act as a button.
+	 * @abstract
+	 * @returns {Promise<void>}
+	 */
 	public execute(): Promise<void> {
 		return Promise.resolve();
 	}


### PR DESCRIPTION
Follow up to #1288 and #1291.

Adds the `getHref` method to the `UmbEntityAction<>` interface. The `UmbEntityActionBase` base class implements both the `getHref` and `execute` methods, and marks them with JSDocs `@abstract` to define them as overridable.
