### PR TITLE
Bugfix: Reference by unique instead of id

### DIFF
--- a/src/packages/core/models/index.ts
+++ b/src/packages/core/models/index.ts
@@ -20,6 +20,6 @@ export interface NumberRangeValueType {
 	max?: number;
 }
 
-export interface UmbReferenceById {
-	id: string;
+export interface UmbReferenceByUnique {
+	unique: string;
 }

--- a/src/packages/documents/documents/conditions/document-workspace-has-collection.condition.ts
+++ b/src/packages/documents/documents/conditions/document-workspace-has-collection.condition.ts
@@ -21,7 +21,7 @@ export class UmbDocumentWorkspaceHasCollectionCondition extends UmbBaseControlle
 			this.observe(
 				context.contentTypeCollection,
 				(collection) => {
-					this.permitted = !!collection?.id;
+					this.permitted = !!collection?.unique;
 					this.#onChange();
 				},
 				'observeCollection',

--- a/src/packages/documents/documents/repository/detail/document-detail.server.data-source.ts
+++ b/src/packages/documents/documents/repository/detail/document-detail.server.data-source.ts
@@ -43,6 +43,7 @@ export class UmbDocumentServerDataSource implements UmbDetailDataSource<UmbDocum
 			template: null,
 			documentType: {
 				unique: '',
+				collection: null,
 			},
 			isTrashed: false,
 			values: [],
@@ -113,7 +114,7 @@ export class UmbDocumentServerDataSource implements UmbDetailDataSource<UmbDocum
 			template: data.template ? { unique: data.template.id } : null,
 			documentType: {
 				unique: data.documentType.id,
-				collection: data.documentType.collection ?? undefined,
+				collection: data.documentType.collection ? { unique: data.documentType.collection.id } : null,
 			},
 			isTrashed: data.isTrashed,
 		};

--- a/src/packages/documents/documents/repository/item/document-item.server.data-source.ts
+++ b/src/packages/documents/documents/repository/item/document-item.server.data-source.ts
@@ -38,7 +38,7 @@ const mapper = (item: DocumentItemResponseModel): UmbDocumentItemModel => {
 		documentType: {
 			unique: item.documentType.id,
 			icon: item.documentType.icon,
-			collection: item.documentType.collection ?? undefined,
+			collection: item.documentType.collection ? { unique: item.documentType.collection.id } : null,
 		},
 		variants: item.variants.map((variant) => {
 			return {

--- a/src/packages/documents/documents/repository/item/types.ts
+++ b/src/packages/documents/documents/repository/item/types.ts
@@ -1,5 +1,5 @@
 import type { DocumentVariantStateModel } from '@umbraco-cms/backoffice/external/backend-api';
-import type { UmbReferenceById } from '@umbraco-cms/backoffice/models';
+import type { UmbReferenceByUnique } from '@umbraco-cms/backoffice/models';
 
 export interface UmbDocumentItemModel {
 	name: string; // TODO: this is not correct. We need to get it from the variants. This is a temp solution.
@@ -9,7 +9,7 @@ export interface UmbDocumentItemModel {
 	documentType: {
 		unique: string;
 		icon: string;
-		collection?: UmbReferenceById;
+		collection?: UmbReferenceByUnique;
 	};
 	variants: Array<UmbDocumentItemVariantModel>;
 }

--- a/src/packages/documents/documents/repository/item/types.ts
+++ b/src/packages/documents/documents/repository/item/types.ts
@@ -9,7 +9,7 @@ export interface UmbDocumentItemModel {
 	documentType: {
 		unique: string;
 		icon: string;
-		collection?: UmbReferenceByUnique;
+		collection: UmbReferenceByUnique | null;
 	};
 	variants: Array<UmbDocumentItemVariantModel>;
 }

--- a/src/packages/documents/documents/tree/document-tree.server.data-source.ts
+++ b/src/packages/documents/documents/tree/document-tree.server.data-source.ts
@@ -55,7 +55,7 @@ const mapper = (item: DocumentTreeItemResponseModel): UmbDocumentTreeItemModel =
 		documentType: {
 			unique: item.documentType.id,
 			icon: item.documentType.icon,
-			collection: item.documentType.collection ?? undefined,
+			collection: item.documentType.collection ? { unique: item.documentType.collection.id } : null,
 		},
 		variants: item.variants.map((variant) => {
 			return {

--- a/src/packages/documents/documents/tree/types.ts
+++ b/src/packages/documents/documents/tree/types.ts
@@ -1,7 +1,7 @@
 import type { UmbDocumentEntityType, UmbDocumentRootEntityType } from '../entity.js';
 import type { UmbUniqueTreeItemModel, UmbUniqueTreeRootModel } from '@umbraco-cms/backoffice/tree';
 import type { DocumentVariantStateModel } from '@umbraco-cms/backoffice/external/backend-api';
-import type { UmbReferenceById } from '@umbraco-cms/backoffice/models';
+import type { UmbReferenceByUnique } from '@umbraco-cms/backoffice/models';
 
 export interface UmbDocumentTreeItemModel extends UmbUniqueTreeItemModel {
 	entityType: UmbDocumentEntityType;
@@ -11,7 +11,7 @@ export interface UmbDocumentTreeItemModel extends UmbUniqueTreeItemModel {
 	documentType: {
 		unique: string;
 		icon: string;
-		collection?: UmbReferenceById;
+		collection?: UmbReferenceByUnique;
 	};
 	variants: Array<UmbDocumentTreeItemVariantModel>;
 }

--- a/src/packages/documents/documents/tree/types.ts
+++ b/src/packages/documents/documents/tree/types.ts
@@ -11,7 +11,7 @@ export interface UmbDocumentTreeItemModel extends UmbUniqueTreeItemModel {
 	documentType: {
 		unique: string;
 		icon: string;
-		collection?: UmbReferenceByUnique;
+		collection: UmbReferenceByUnique | null;
 	};
 	variants: Array<UmbDocumentTreeItemVariantModel>;
 }

--- a/src/packages/documents/documents/types.ts
+++ b/src/packages/documents/documents/types.ts
@@ -7,7 +7,7 @@ export { UmbDocumentVariantState };
 export interface UmbDocumentDetailModel {
 	documentType: {
 		unique: string;
-		collection?: UmbReferenceByUnique;
+		collection: UmbReferenceByUnique | null;
 	};
 	entityType: UmbDocumentEntityType;
 	isTrashed: boolean;

--- a/src/packages/documents/documents/types.ts
+++ b/src/packages/documents/documents/types.ts
@@ -1,13 +1,13 @@
 import type { UmbDocumentEntityType } from './entity.js';
 import type { UmbVariantModel } from '@umbraco-cms/backoffice/variant';
-import type { UmbReferenceById } from '@umbraco-cms/backoffice/models';
+import type { UmbReferenceByUnique } from '@umbraco-cms/backoffice/models';
 import { DocumentVariantStateModel as UmbDocumentVariantState } from '@umbraco-cms/backoffice/external/backend-api';
 export { UmbDocumentVariantState };
 
 export interface UmbDocumentDetailModel {
 	documentType: {
 		unique: string;
-		collection?: UmbReferenceById;
+		collection?: UmbReferenceByUnique;
 	};
 	entityType: UmbDocumentEntityType;
 	isTrashed: boolean;

--- a/src/packages/documents/documents/workspace/document-workspace.context.ts
+++ b/src/packages/documents/documents/workspace/document-workspace.context.ts
@@ -79,6 +79,7 @@ export class UmbDocumentWorkspaceContext
 		this.#getDataPromise = this.repository.createScaffold(parentUnique, {
 			documentType: {
 				unique: documentTypeUnique,
+				collection: null,
 			},
 		});
 		const { data } = await this.#getDataPromise;

--- a/src/packages/media/media/conditions/media-workspace-has-collection.condition.ts
+++ b/src/packages/media/media/conditions/media-workspace-has-collection.condition.ts
@@ -21,7 +21,7 @@ export class UmbMediaWorkspaceHasCollectionCondition extends UmbBaseController i
 			this.observe(
 				context.contentTypeCollection,
 				(collection) => {
-					this.permitted = !!collection?.id;
+					this.permitted = !!collection?.unique;
 					this.#onChange();
 				},
 				'observeCollection',

--- a/src/packages/media/media/repository/detail/media-detail.server.data-source.ts
+++ b/src/packages/media/media/repository/detail/media-detail.server.data-source.ts
@@ -92,7 +92,7 @@ export class UmbMediaServerDataSource implements UmbDetailDataSource<UmbMediaDet
 			urls: data.urls,
 			mediaType: {
 				unique: data.mediaType.id,
-				collection: data.mediaType.collection || null,
+				collection: data.mediaType.collection ? { unique: data.mediaType.collection.id } : null,
 			},
 			isTrashed: data.isTrashed,
 		};

--- a/src/packages/media/media/repository/item/media-item.server.data-source.ts
+++ b/src/packages/media/media/repository/item/media-item.server.data-source.ts
@@ -37,7 +37,7 @@ const mapper = (item: MediaItemResponseModel): UmbMediaItemModel => {
 		mediaType: {
 			unique: item.mediaType.id,
 			icon: item.mediaType.icon,
-			collection: item.mediaType.collection ?? undefined,
+			collection: item.mediaType.collection ? { unique: item.mediaType.collection.id } : null,
 		},
 		variants: item.variants.map((variant) => {
 			return {

--- a/src/packages/media/media/repository/item/types.ts
+++ b/src/packages/media/media/repository/item/types.ts
@@ -6,7 +6,7 @@ export interface UmbMediaItemModel {
 	mediaType: {
 		unique: string;
 		icon: string;
-		collection?: UmbReferenceByUnique;
+		collection: UmbReferenceByUnique | null;
 	};
 	variants: Array<UmbMediaItemVariantModel>;
 	name: string; // TODO: get correct variant name

--- a/src/packages/media/media/repository/item/types.ts
+++ b/src/packages/media/media/repository/item/types.ts
@@ -1,4 +1,4 @@
-import type { UmbReferenceById } from '@umbraco-cms/backoffice/models';
+import type { UmbReferenceByUnique } from '@umbraco-cms/backoffice/models';
 
 export interface UmbMediaItemModel {
 	unique: string;
@@ -6,7 +6,7 @@ export interface UmbMediaItemModel {
 	mediaType: {
 		unique: string;
 		icon: string;
-		collection?: UmbReferenceById;
+		collection?: UmbReferenceByUnique;
 	};
 	variants: Array<UmbMediaItemVariantModel>;
 	name: string; // TODO: get correct variant name

--- a/src/packages/media/media/tree/media-tree.server.data-source.ts
+++ b/src/packages/media/media/tree/media-tree.server.data-source.ts
@@ -54,7 +54,7 @@ const mapper = (item: MediaTreeItemResponseModel): UmbMediaTreeItemModel => {
 		mediaType: {
 			unique: item.mediaType.id,
 			icon: item.mediaType.icon,
-			collection: item.mediaType.collection ?? undefined,
+			collection: item.mediaType.collection ? { unique: item.mediaType.collection.id } : null,
 		},
 		name: item.variants[0]?.name, // TODO: this is not correct. We need to get it from the variants. This is a temp solution.
 		variants: item.variants.map((variant) => {

--- a/src/packages/media/media/tree/media-tree.store.ts
+++ b/src/packages/media/media/tree/media-tree.store.ts
@@ -42,7 +42,7 @@ export class UmbMediaTreeStore extends UmbUniqueTreeStore {
 			hasChildren: false,
 			variants: item.variants,
 			isTrashed: item.isTrashed,
-			mediaType: { unique: item.mediaType.unique, icon: '' },
+			mediaType: { unique: item.mediaType.unique, icon: '', collection: null },
 			noAccess: false,
 		};
 

--- a/src/packages/media/media/tree/types.ts
+++ b/src/packages/media/media/tree/types.ts
@@ -1,5 +1,5 @@
 import type { UmbMediaEntityType, UmbMediaRootEntityType } from '../entity.js';
-import type { UmbReferenceById } from '@umbraco-cms/backoffice/models';
+import type { UmbReferenceByUnique } from '@umbraco-cms/backoffice/models';
 import type { UmbUniqueTreeItemModel, UmbUniqueTreeRootModel } from '@umbraco-cms/backoffice/tree';
 
 export interface UmbMediaTreeItemModel extends UmbUniqueTreeItemModel {
@@ -9,7 +9,7 @@ export interface UmbMediaTreeItemModel extends UmbUniqueTreeItemModel {
 	mediaType: {
 		unique: string;
 		icon: string;
-		collection?: UmbReferenceById;
+		collection?: UmbReferenceByUnique;
 	};
 	variants: Array<UmbMediaTreeItemVariantModel>;
 }

--- a/src/packages/media/media/tree/types.ts
+++ b/src/packages/media/media/tree/types.ts
@@ -9,7 +9,7 @@ export interface UmbMediaTreeItemModel extends UmbUniqueTreeItemModel {
 	mediaType: {
 		unique: string;
 		icon: string;
-		collection?: UmbReferenceByUnique;
+		collection: UmbReferenceByUnique | null;
 	};
 	variants: Array<UmbMediaTreeItemVariantModel>;
 }

--- a/src/packages/media/media/types.ts
+++ b/src/packages/media/media/types.ts
@@ -1,12 +1,12 @@
 import type { UmbMediaEntityType } from './entity.js';
-import type { UmbReferenceById } from '@umbraco-cms/backoffice/models';
+import type { UmbReferenceByUnique } from '@umbraco-cms/backoffice/models';
 import type { UmbVariantModel } from '@umbraco-cms/backoffice/variant';
 import type { MediaUrlInfoModel, MediaValueModel } from '@umbraco-cms/backoffice/external/backend-api';
 
 export interface UmbMediaDetailModel {
 	mediaType: {
 		unique: string;
-		collection: UmbReferenceById | null;
+		collection: UmbReferenceByUnique | null;
 	};
 	entityType: UmbMediaEntityType;
 	isTrashed: boolean;

--- a/src/packages/members/member/repository/item/member-item.server.data-source.ts
+++ b/src/packages/members/member/repository/item/member-item.server.data-source.ts
@@ -36,7 +36,7 @@ const mapper = (item: MemberItemResponseModel): UmbMemberItemModel => {
 		memberType: {
 			unique: item.memberType.id,
 			icon: item.memberType.icon,
-			collection: item.memberType.collection ?? undefined,
+			collection: item.memberType.collection ? { unique: item.memberType.collection.id } : null,
 		},
 		variants: item.variants.map((variant) => {
 			return {

--- a/src/packages/members/member/repository/item/types.ts
+++ b/src/packages/members/member/repository/item/types.ts
@@ -5,7 +5,7 @@ export interface UmbMemberItemModel {
 	memberType: {
 		unique: string;
 		icon: string;
-		collection?: UmbReferenceByUnique;
+		collection: UmbReferenceByUnique | null;
 	};
 	variants: Array<UmbMemberVariantItemModel>;
 }

--- a/src/packages/members/member/repository/item/types.ts
+++ b/src/packages/members/member/repository/item/types.ts
@@ -1,11 +1,11 @@
-import type { UmbReferenceById } from '@umbraco-cms/backoffice/models';
+import type { UmbReferenceByUnique } from '@umbraco-cms/backoffice/models';
 
 export interface UmbMemberItemModel {
 	unique: string;
 	memberType: {
 		unique: string;
 		icon: string;
-		collection?: UmbReferenceById;
+		collection?: UmbReferenceByUnique;
 	};
 	variants: Array<UmbMemberVariantItemModel>;
 }


### PR DESCRIPTION
We shouldn't reference by id as most models are mapped to a unique identifier.

This PR updates the models and the implementations to keep are models aligned.