### PR TITLE
rename the workspace action menu

### DIFF
--- a/src/packages/core/property-action/shared/property-action-menu/property-action-menu.element.ts
+++ b/src/packages/core/property-action/shared/property-action-menu/property-action-menu.element.ts
@@ -24,8 +24,11 @@ export class UmbPropertyActionMenuElement extends UmbLitElement {
 
 	private _value?: unknown;
 
+	#propertyEditorUiAlias = '';
+
 	@property()
 	set propertyEditorUiAlias(alias: string) {
+		this.#propertyEditorUiAlias = alias;
 		// TODO: Stop using string for 'propertyAction', we need to start using Const.
 		// TODO: Align property actions with entity actions.
 		this.#actionsInitializer = new UmbExtensionsElementInitializer(
@@ -39,6 +42,10 @@ export class UmbPropertyActionMenuElement extends UmbLitElement {
 			'extensionsInitializer',
 		);
 	}
+	get propertyEditorUiAlias() {
+		return this.#propertyEditorUiAlias;
+	}
+
 	@state()
 	private _actions: Array<UmbExtensionElementInitializer<ManifestPropertyAction, any>> = [];
 

--- a/src/packages/core/property-action/shared/property-action-menu/property-action-menu.element.ts
+++ b/src/packages/core/property-action/shared/property-action-menu/property-action-menu.element.ts
@@ -12,15 +12,16 @@ export class UmbPropertyActionMenuElement extends UmbLitElement {
 	#actionsInitializer?: UmbExtensionsElementInitializer<ManifestTypes, 'propertyAction'>;
 
 	@property({ attribute: false })
-	public get value(): unknown {
-		return this._value;
-	}
 	public set value(value: unknown) {
 		this._value = value;
 		if (this.#actionsInitializer) {
 			this.#actionsInitializer.properties = { value };
 		}
 	}
+	public get value(): unknown {
+		return this._value;
+	}
+
 	private _value?: unknown;
 
 	@property()
@@ -79,4 +80,10 @@ export class UmbPropertyActionMenuElement extends UmbLitElement {
 			}
 		`,
 	];
+}
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-property-action-menu': UmbPropertyActionMenuElement;
+	}
 }

--- a/src/packages/core/workspace/components/index.ts
+++ b/src/packages/core/workspace/components/index.ts
@@ -1,4 +1,4 @@
-export * from './workspace-action-menu/index.js';
+export * from './workspace-entity-action-menu/index.js';
 export * from './workspace-action/index.js';
 export * from './workspace-editor/index.js';
 export * from './workspace-footer/index.js';

--- a/src/packages/core/workspace/components/workspace-action-menu/index.ts
+++ b/src/packages/core/workspace/components/workspace-action-menu/index.ts
@@ -1,1 +1,0 @@
-export * from './workspace-action-menu.element.js';

--- a/src/packages/core/workspace/components/workspace-entity-action-menu/index.ts
+++ b/src/packages/core/workspace/components/workspace-entity-action-menu/index.ts
@@ -1,0 +1,1 @@
+export * from './workspace-entity-action-menu.element.js';

--- a/src/packages/core/workspace/components/workspace-entity-action-menu/workspace-entity-action-menu.element.ts
+++ b/src/packages/core/workspace/components/workspace-entity-action-menu/workspace-entity-action-menu.element.ts
@@ -3,8 +3,8 @@ import { css, html, customElement, state, nothing } from '@umbraco-cms/backoffic
 import type { UmbActionExecutedEvent } from '@umbraco-cms/backoffice/event';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UMB_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/workspace';
-@customElement('umb-workspace-action-menu')
-export class UmbWorkspaceActionMenuElement extends UmbLitElement {
+@customElement('umb-workspace-entity-action-menu')
+export class UmbWorkspaceEntityActionMenuElement extends UmbLitElement {
 	private _workspaceContext?: typeof UMB_WORKSPACE_CONTEXT.TYPE;
 
 	@state()
@@ -49,12 +49,12 @@ export class UmbWorkspaceActionMenuElement extends UmbLitElement {
 	#renderActionsMenu() {
 		return this._entityId && this._entityType
 			? html`
-					<uui-button popovertarget="workspace-action-menu-popover" label="Actions">
+					<uui-button popovertarget="workspace-entity-action-menu-popover" label="Actions">
 						Actions
 						<uui-symbol-expand .open=${this._popoverOpen}></uui-symbol-expand>
 					</uui-button>
 					<uui-popover-container
-						id="workspace-action-menu-popover"
+						id="workspace-entity-action-menu-popover"
 						placement="bottom-end"
 						@toggle=${this.#onPopoverToggle}>
 						<umb-popover-layout>
@@ -87,6 +87,6 @@ export class UmbWorkspaceActionMenuElement extends UmbLitElement {
 
 declare global {
 	interface HTMLElementTagNameMap {
-		'umb-workspace-action-menu': UmbWorkspaceActionMenuElement;
+		'umb-workspace-entity-action-menu': UmbWorkspaceEntityActionMenuElement;
 	}
 }

--- a/src/packages/core/workspace/components/workspace-split-view/workspace-split-view.element.ts
+++ b/src/packages/core/workspace/components/workspace-split-view/workspace-split-view.element.ts
@@ -31,7 +31,7 @@ export class UmbWorkspaceSplitViewElement extends UmbLitElement {
 					<umb-variant-selector></umb-variant-selector>
 				</div>
 				${this.displayNavigation
-					? html`<umb-workspace-action-menu slot="action-menu"></umb-workspace-action-menu>`
+					? html`<umb-workspace-entity-action-menu slot="action-menu"></umb-workspace-entity-action-menu>`
 					: ''}
 				<slot name="action-menu" slot="action-menu"></slot>
 			</umb-workspace-editor>

--- a/storybook/stories/extending/entity-actions.mdx
+++ b/storybook/stories/extending/entity-actions.mdx
@@ -28,7 +28,7 @@ TODO: introduction to actions
 			</td>
 			<td>
 				<div>
-					<strong>Workspace Action Menu</strong>
+					<strong>Workspace Entity Action Menu</strong>
 				</div>
 				<img src="docs/entity-action-workspace-menu.svg" width="400" />
 			</td>


### PR DESCRIPTION
it is now called "workspace-entity-action-menu" which is more befitting for its placement and also allows us to re-use the name "workspace-action-menu" for the upcoming popover menu on workspace actions

![entity-action-workspace-menu](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/752371/13866f2b-c71b-471a-8e0e-00d0bcc49234)
