### PR TITLE
Chore: Media Collection section-view amend (empties `dataTypeId` for server)

### DIFF
--- a/src/packages/media/media/collection/repository/media-collection.server.data-source.ts
+++ b/src/packages/media/media/collection/repository/media-collection.server.data-source.ts
@@ -13,10 +13,6 @@ export class UmbMediaCollectionServerDataSource implements UmbCollectionDataSour
 	}
 
 	async getCollection(query: UmbMediaCollectionFilterModel) {
-		if (!query.dataTypeId) {
-			throw new Error('Data type ID is required to fetch a collection.');
-		}
-
 		const params = {
 			id: query.unique ?? '',
 			dataTypeId: query.dataTypeId,

--- a/src/packages/media/media/section-view/media-section-view.element.ts
+++ b/src/packages/media/media/section-view/media-section-view.element.ts
@@ -62,7 +62,7 @@ export class UmbMediaSectionViewElement extends UmbLitElement {
 		const config = new UmbPropertyEditorConfigCollection(dataType.values);
 		return {
 			unique: '',
-			dataTypeId: dataType.unique,
+			dataTypeId: '',
 			allowedEntityBulkActions: config?.getValueByAlias<UmbCollectionBulkActionPermissions>('bulkActionPermissions'),
 			orderBy: config?.getValueByAlias('orderBy') ?? 'updateDate',
 			orderDirection: config?.getValueByAlias('orderDirection') ?? 'asc',


### PR DESCRIPTION
Updates to Media section-view collection as the server no longer needs a `dataTypeId` value for the Media root.