### PR TITLE
Chore: Document Type Structure View localizations

### DIFF
--- a/src/assets/lang/da-dk.ts
+++ b/src/assets/lang/da-dk.ts
@@ -1565,8 +1565,8 @@ export default {
 			'Konfigurér indholdet til at blive vist i en sortérbar og søgbar liste;\n      undersider vil ikke blive vist i træet\n    ',
 		allowedTemplatesHeading: 'Tilladte skabeloner',
 		allowedTemplatesDescription: 'Vælg hvilke skabeloner, der er tilladt at bruge på dette indhold.',
-		allowAsRootHeading: 'Tillad på rodniveau',
-		allowAsRootDescription:
+		allowAtRootHeading: 'Tillad på rodniveau',
+		allowAtRootDescription:
 			'Kun dokumenttyper med denne indstilling aktiveret kan oprettes i rodniveau under\n      indhold og mediearkiv.\n    ',
 		childNodesHeading: 'Tilladte typer',
 		childNodesDescription: 'Tillad at oprette indhold af en specifik type under denne.',

--- a/src/assets/lang/da-dk.ts
+++ b/src/assets/lang/da-dk.ts
@@ -1659,6 +1659,7 @@ export default {
 		collectionsDescription:
 			'Konfigurerer indholdselementet til at vise listen over dets underordnede elementer, underordnede elementer vil ikke blive vist i træet.',
 		structure: 'Struktur',
+		presentation: 'Præsentation',
 	},
 	languages: {
 		addLanguage: 'Tilføj sprog',

--- a/src/assets/lang/da-dk.ts
+++ b/src/assets/lang/da-dk.ts
@@ -1658,6 +1658,7 @@ export default {
 		collections: 'Samlinger',
 		collectionsDescription:
 			'Konfigurerer indholdselementet til at vise listen over dets underordnede elementer, underordnede elementer vil ikke blive vist i træet.',
+		structure: 'Struktur',
 	},
 	languages: {
 		addLanguage: 'Tilføj sprog',

--- a/src/assets/lang/en-us.ts
+++ b/src/assets/lang/en-us.ts
@@ -1654,6 +1654,7 @@ export default {
 		collections: 'Collections',
 		collectionsDescription:
 			'Configures the content item to show list of its children, the children will not be shown in the tree.',
+		structure: 'Structure',
 	},
 	languages: {
 		addLanguage: 'Add language',

--- a/src/assets/lang/en-us.ts
+++ b/src/assets/lang/en-us.ts
@@ -1566,8 +1566,7 @@ export default {
 		allowAtRootHeading: 'Allow at root',
 		allowAtRootDescription: 'Allow editors to create content of this type in the root of the content tree.\n    ',
 		childNodesHeading: 'Allowed child node types',
-		childNodesDescription:
-			'Allow content of the specified types to be created underneath content of this\n      type.\n    ',
+		childNodesDescription: 'Allow content of the specified types to be created underneath content of this type.',
 		chooseChildNode: 'Choose child node',
 		compositionsDescription:
 			'Inherit tabs and properties from an existing Document Type. New tabs will be\n      added to the current Document Type or merged if a tab with an identical name exists.\n    ',

--- a/src/assets/lang/en-us.ts
+++ b/src/assets/lang/en-us.ts
@@ -1563,8 +1563,8 @@ export default {
 			'Configures the content item to show a sortable and searchable list of its\n      children, the children will not be shown in the tree\n    ',
 		allowedTemplatesHeading: 'Allowed Templates',
 		allowedTemplatesDescription: 'Choose which templates editors are allowed to use on content of this type',
-		allowAsRootHeading: 'Allow as root',
-		allowAsRootDescription: 'Allow editors to create content of this type in the root of the content tree.\n    ',
+		allowAtRootHeading: 'Allow at root',
+		allowAtRootDescription: 'Allow editors to create content of this type in the root of the content tree.\n    ',
 		childNodesHeading: 'Allowed child node types',
 		childNodesDescription:
 			'Allow content of the specified types to be created underneath content of this\n      type.\n    ',

--- a/src/assets/lang/en-us.ts
+++ b/src/assets/lang/en-us.ts
@@ -1655,6 +1655,7 @@ export default {
 		collectionsDescription:
 			'Configures the content item to show list of its children, the children will not be shown in the tree.',
 		structure: 'Structure',
+		presentation: 'Presentation',
 	},
 	languages: {
 		addLanguage: 'Add language',

--- a/src/packages/documents/document-types/workspace/views/structure/document-type-workspace-view-structure.element.ts
+++ b/src/packages/documents/document-types/workspace/views/structure/document-type-workspace-view-structure.element.ts
@@ -65,11 +65,11 @@ export class UmbDocumentTypeWorkspaceViewStructureElement extends UmbLitElement 
 	render() {
 		return html`
 			<uui-box headline="Structure">
-				<umb-property-layout alias="Root" label="Allow as Root">
-					<div slot="description">${this.localize.term('contentTypeEditor_allowAsRootDescription')}</div>
+				<umb-property-layout alias="Root" label=${this.localize.term('contentTypeEditor_allowAtRootHeading')}>
+					<div slot="description">${this.localize.term('contentTypeEditor_allowAtRootDescription')}</div>
 					<div slot="editor">
 						<uui-toggle
-							label=${this.localize.term('contentTypeEditor_allowAsRootHeading')}
+							label=${this.localize.term('contentTypeEditor_allowAtRootHeading')}
 							?checked=${this._allowedAtRoot}
 							@change=${(e: CustomEvent) => {
 								this.#workspaceContext?.setAllowedAsRoot((e.target as UUIToggleElement).checked);

--- a/src/packages/documents/document-types/workspace/views/structure/document-type-workspace-view-structure.element.ts
+++ b/src/packages/documents/document-types/workspace/views/structure/document-type-workspace-view-structure.element.ts
@@ -64,7 +64,7 @@ export class UmbDocumentTypeWorkspaceViewStructureElement extends UmbLitElement 
 
 	render() {
 		return html`
-			<uui-box headline="Structure">
+			<uui-box headline=${this.localize.term('contentTypeEditor_structure')}>
 				<umb-property-layout alias="Root" label=${this.localize.term('contentTypeEditor_allowAtRootHeading')}>
 					<div slot="description">${this.localize.term('contentTypeEditor_allowAtRootDescription')}</div>
 					<div slot="editor">

--- a/src/packages/documents/document-types/workspace/views/structure/document-type-workspace-view-structure.element.ts
+++ b/src/packages/documents/document-types/workspace/views/structure/document-type-workspace-view-structure.element.ts
@@ -96,7 +96,7 @@ export class UmbDocumentTypeWorkspaceViewStructureElement extends UmbLitElement 
 					</div>
 				</umb-property-layout>
 			</uui-box>
-			<uui-box headline="Presentation">
+			<uui-box headline=${this.localize.term('contentTypeEditor_presentation')}>
 				<umb-property-layout alias="collection" label="${this.localize.term('contentTypeEditor_collections')}">
 					<div slot="description">${this.localize.term('contentTypeEditor_collectionsDescription')}</div>
 					<div slot="editor">

--- a/src/packages/documents/document-types/workspace/views/structure/document-type-workspace-view-structure.element.ts
+++ b/src/packages/documents/document-types/workspace/views/structure/document-type-workspace-view-structure.element.ts
@@ -76,10 +76,8 @@ export class UmbDocumentTypeWorkspaceViewStructureElement extends UmbLitElement 
 							}}></uui-toggle>
 					</div>
 				</umb-property-layout>
-				<umb-property-layout alias="ChildNodeType" label="Allowed child node types">
-					<div slot="description">
-						Allow content of the specified types to be created underneath content of this type.
-					</div>
+				<umb-property-layout alias="ChildNodeType" label=${this.localize.term('contentTypeEditor_childNodesHeading')}>
+					<div slot="description">${this.localize.term('contentTypeEditor_childNodesDescription')}</div>
 					<div slot="editor">
 						<!-- TODO: maybe we want to somehow display the hierarchy, but not necessary in the same way as old backoffice? -->
 						<umb-input-document-type

--- a/src/packages/media/media-types/workspace/views/structure/media-type-workspace-view-structure.element.ts
+++ b/src/packages/media/media-types/workspace/views/structure/media-type-workspace-view-structure.element.ts
@@ -54,10 +54,8 @@ export class UmbMediaTypeWorkspaceViewStructureElement extends UmbLitElement imp
 							}}></uui-toggle>
 					</div>
 				</umb-property-layout>
-				<umb-property-layout alias="ChildNodeType" label="Allowed child node types">
-					<div slot="description">
-						Allow content of the specified types to be created underneath content of this type.
-					</div>
+				<umb-property-layout alias="ChildNodeType" label=${this.localize.term('contentTypeEditor_childNodesHeading')}>
+					<div slot="description">${this.localize.term('contentTypeEditor_childNodesDescription')}</div>
 					<div slot="editor">
 						<!-- TODO: maybe we want to somehow display the hierarchy, but not necessary in the same way as old backoffice? -->
 						<umb-input-media-type

--- a/src/packages/media/media-types/workspace/views/structure/media-type-workspace-view-structure.element.ts
+++ b/src/packages/media/media-types/workspace/views/structure/media-type-workspace-view-structure.element.ts
@@ -43,11 +43,11 @@ export class UmbMediaTypeWorkspaceViewStructureElement extends UmbLitElement imp
 	render() {
 		return html`
 			<uui-box headline="Structure">
-				<umb-property-layout alias="Root" label="Allow as Root">
-					<div slot="description">${this.localize.term('contentTypeEditor_allowAsRootDescription')}</div>
+				<umb-property-layout alias="Root" label=${this.localize.term('contentTypeEditor_allowAtRootHeading')}>
+					<div slot="description">${this.localize.term('contentTypeEditor_allowAtRootDescription')}</div>
 					<div slot="editor">
 						<uui-toggle
-							label=${this.localize.term('contentTypeEditor_allowAsRootHeading')}
+							label=${this.localize.term('contentTypeEditor_allowAtRootHeading')}
 							?checked=${this._allowedAsRoot}
 							@change=${(e: CustomEvent) => {
 								this.#workspaceContext?.updateProperty('allowedAsRoot', (e.target as UUIToggleElement).checked);

--- a/src/packages/media/media-types/workspace/views/structure/media-type-workspace-view-structure.element.ts
+++ b/src/packages/media/media-types/workspace/views/structure/media-type-workspace-view-structure.element.ts
@@ -73,7 +73,7 @@ export class UmbMediaTypeWorkspaceViewStructureElement extends UmbLitElement imp
 					</div>
 				</umb-property-layout>
 			</uui-box>
-			<uui-box headline="Presentation">
+			<uui-box headline=${this.localize.term('contentTypeEditor_presentation')}>
 				<umb-property-layout alias="Root" label="Collection view">
 					<div slot="description">Provides an overview of child content and hides it in the tree.</div>
 					<div slot="editor"><uui-toggle label="Display children in a Collection view"></uui-toggle></div>

--- a/src/packages/media/media-types/workspace/views/structure/media-type-workspace-view-structure.element.ts
+++ b/src/packages/media/media-types/workspace/views/structure/media-type-workspace-view-structure.element.ts
@@ -42,7 +42,7 @@ export class UmbMediaTypeWorkspaceViewStructureElement extends UmbLitElement imp
 
 	render() {
 		return html`
-			<uui-box headline="Structure">
+			<uui-box headline=${this.localize.term('contentTypeEditor_structure')}>
 				<umb-property-layout alias="Root" label=${this.localize.term('contentTypeEditor_allowAtRootHeading')}>
 					<div slot="description">${this.localize.term('contentTypeEditor_allowAtRootDescription')}</div>
 					<div slot="editor">


### PR DESCRIPTION
Following on from https://github.com/umbraco/Umbraco.CMS.Backoffice/pull/1306#discussion_r1506289825, this PR adds and wires up the missing localization keys.