### PR TITLE
Chore: Data Type Config clean-up: List View

### DIFF
--- a/src/packages/core/property-editor/schemas/Umbraco.ListView.ts
+++ b/src/packages/core/property-editor/schemas/Umbraco.ListView.ts
@@ -9,33 +9,10 @@ export const manifest: ManifestPropertyEditorSchema = {
 		settings: {
 			properties: [
 				{
-					alias: 'pageSize',
-					label: 'Page Size',
-					description: 'Number of items per page.',
-					propertyEditorUiAlias: 'Umb.PropertyEditorUi.Number',
-				},
-				{
 					alias: 'includeProperties',
 					label: 'Columns Displayed',
 					description: 'The properties that will be displayed for each column.',
 					propertyEditorUiAlias: 'Umb.PropertyEditorUi.CollectionView.ColumnConfiguration',
-				},
-				{
-					alias: 'orderBy',
-					label: 'Order By',
-					description: 'The default sort order for the list.',
-					propertyEditorUiAlias: 'Umb.PropertyEditorUi.CollectionView.OrderBy',
-				},
-				{
-					alias: 'orderDirection',
-					label: 'Order Direction',
-					propertyEditorUiAlias: 'Umb.PropertyEditorUi.OrderDirection',
-				},
-				{
-					alias: 'bulkActionPermissions',
-					label: 'Bulk Action Permissions',
-					description: 'The bulk actions that are allowed from the list view.',
-					propertyEditorUiAlias: 'Umb.PropertyEditorUi.CollectionView.BulkActionPermissions',
 				},
 			],
 		},

--- a/src/packages/core/property-editor/uis/collection-view/manifests.ts
+++ b/src/packages/core/property-editor/uis/collection-view/manifests.ts
@@ -23,6 +23,29 @@ const manifest: ManifestPropertyEditorUi = {
 					propertyEditorUiAlias: 'Umb.PropertyEditorUi.CollectionView.LayoutConfiguration',
 				},
 				{
+					alias: 'pageSize',
+					label: 'Page Size',
+					description: 'Number of items per page.',
+					propertyEditorUiAlias: 'Umb.PropertyEditorUi.Number',
+				},
+				{
+					alias: 'orderBy',
+					label: 'Order By',
+					description: 'The default sort order for the list.',
+					propertyEditorUiAlias: 'Umb.PropertyEditorUi.CollectionView.OrderBy',
+				},
+				{
+					alias: 'orderDirection',
+					label: 'Order Direction',
+					propertyEditorUiAlias: 'Umb.PropertyEditorUi.OrderDirection',
+				},
+				{
+					alias: 'bulkActionPermissions',
+					label: 'Bulk Action Permissions',
+					description: 'The bulk actions that are allowed from the list view.',
+					propertyEditorUiAlias: 'Umb.PropertyEditorUi.CollectionView.BulkActionPermissions',
+				},
+				{
 					alias: 'icon',
 					label: 'Content app icon',
 					description: 'The icon of the listview content app.',


### PR DESCRIPTION
Moves the unused schema fields, e.g. `pageSize`, `orderDirection`, `orderBy`, `bulkActionPermissions` to the UI settings.

The server only uses `includeProperties`.
