### PR TITLE
Chore: Data Type Config clean-up: MultiNodeTreePicker

### DIFF
--- a/src/packages/core/property-editor/schemas/Umbraco.MultiNodeTreePicker.ts
+++ b/src/packages/core/property-editor/schemas/Umbraco.MultiNodeTreePicker.ts
@@ -26,6 +26,12 @@ export const manifest: ManifestPropertyEditorSchema = {
 					description: 'Selecting this option allows a user to choose nodes that they normally dont have access to.',
 					propertyEditorUiAlias: 'Umb.PropertyEditorUi.Toggle',
 				},
+				{
+					alias: 'startNode',
+					label: 'Node type',
+					description: '',
+					propertyEditorUiAlias: 'Umb.PropertyEditorUi.TreePicker.SourcePicker',
+				},
 			],
 			defaultData: [
 				{

--- a/src/packages/core/property-editor/uis/tree-picker/manifests.ts
+++ b/src/packages/core/property-editor/uis/tree-picker/manifests.ts
@@ -15,16 +15,10 @@ const manifest: ManifestPropertyEditorUi = {
 		settings: {
 			properties: [
 				{
-					alias: 'startNode',
-					label: 'Node type',
-					description: '',
-					propertyEditorUiAlias: sourcePicker.alias,
-				},
-				{
 					alias: 'filter',
 					label: 'Allow items of type',
 					description: 'Select the applicable types',
-					propertyEditorUiAlias: sourceTypePicker.alias,
+					propertyEditorUiAlias: 'Umb.PropertyEditorUi.TreePicker.SourceTypePicker',
 				},
 				{
 					alias: 'showOpenButton',


### PR DESCRIPTION
Moves the `startNode` setting to the schema, as this is used by the server.

