### PR TITLE
Chore: Data Type Config clean-up: ContentPicker

### DIFF
--- a/src/packages/core/property-editor/schemas/Umbraco.ContentPicker.ts
+++ b/src/packages/core/property-editor/schemas/Umbraco.ContentPicker.ts
@@ -9,10 +9,10 @@ export const manifest: ManifestPropertyEditorSchema = {
 		settings: {
 			properties: [
 				{
-					alias: 'startNodeId',
-					label: 'Start node',
-					description: '',
-					propertyEditorUiAlias: 'Umb.PropertyEditorUi.TreePicker',
+					alias: 'ignoreUserStartNodes',
+					label: 'Ignore user start nodes',
+					description: 'Selecting this option allows a user to choose nodes that they normally dont have access to.',
+					propertyEditorUiAlias: 'Umb.PropertyEditorUi.Toggle',
 				},
 			],
 		},

--- a/src/packages/documents/documents/property-editors/document-picker/manifests.ts
+++ b/src/packages/documents/documents/property-editors/document-picker/manifests.ts
@@ -13,6 +13,12 @@ export const manifest: ManifestPropertyEditorUi = {
 		settings: {
 			properties: [
 				{
+					alias: 'startNodeId',
+					label: 'Start node',
+					description: '',
+					propertyEditorUiAlias: 'Umb.PropertyEditorUi.TreePicker',
+				},
+				{
 					alias: 'showOpenButton',
 					label: 'Show open button',
 					description: 'Opens the node in a dialog',


### PR DESCRIPTION
Adds `ignoreUserStartNodes` setting to the server schema; and moves `startNodeId` to the UI settings, as it is not used by the server.
