### PR TITLE
Chore: Data Type Config clean-up: RichText

### DIFF
--- a/src/packages/core/property-editor/schemas/Umbraco.RichText.ts
+++ b/src/packages/core/property-editor/schemas/Umbraco.RichText.ts
@@ -19,6 +19,12 @@ export const manifest: ManifestPropertyEditorSchema = {
 					label: 'Ignore User Start Nodes',
 					propertyEditorUiAlias: 'Umb.PropertyEditorUi.Toggle',
 				},
+				{
+					alias: 'blocks',
+					label: 'Available Blocks',
+					description: 'Define the available blocks.',
+					propertyEditorUiAlias: 'Umb.PropertyEditorUi.BlockRteTypeConfiguration',
+				},
 			],
 		},
 	},

--- a/src/packages/core/property-editor/schemas/Umbraco.RichText.ts
+++ b/src/packages/core/property-editor/schemas/Umbraco.RichText.ts
@@ -12,7 +12,8 @@ export const manifest: ManifestPropertyEditorSchema = {
 					alias: 'mediaParentId',
 					label: 'Image Upload Folder',
 					description: 'Choose the upload location of pasted images',
-					propertyEditorUiAlias: 'Umb.PropertyEditorUi.TreePicker',
+					propertyEditorUiAlias: 'Umb.PropertyEditorUi.MediaPicker',
+					config: [{ alias: 'validationLimit', value: { min: 0, max: 1 } }],
 				},
 				{
 					alias: 'ignoreUserStartNodes',

--- a/src/packages/tiny-mce/property-editors/tiny-mce/manifests.ts
+++ b/src/packages/tiny-mce/property-editors/tiny-mce/manifests.ts
@@ -231,12 +231,6 @@ export const manifest: ManifestPropertyEditorUi = {
 					label: 'Hide Label',
 					propertyEditorUiAlias: 'Umb.PropertyEditorUi.Toggle',
 				},
-				{
-					alias: 'blocks',
-					label: 'Available Blocks',
-					description: 'Define the available blocks.',
-					propertyEditorUiAlias: 'Umb.PropertyEditorUi.BlockRteTypeConfiguration',
-				},
 			],
 		},
 	},


### PR DESCRIPTION
Moved `blocks` from the UI settings to the schema, as the server uses it.

Changed the `mediaParentId` field to use the MediaPicker UI instead of the generic TreePicker.
Additional work will need to be done to restrict the select to a Folder type only.