### PR TITLE
Chore: Data Type Config clean-up: RadioButtonList

### DIFF
--- a/src/packages/core/property-editor/schemas/Umbraco.RadioButtonList.ts
+++ b/src/packages/core/property-editor/schemas/Umbraco.RadioButtonList.ts
@@ -6,5 +6,15 @@ export const manifest: ManifestPropertyEditorSchema = {
 	alias: 'Umbraco.RadioButtonList',
 	meta: {
 		defaultPropertyEditorUiAlias: 'Umb.PropertyEditorUi.RadioButtonList',
+		settings: {
+			properties: [
+				{
+					alias: 'items',
+					label: 'Add option',
+					description: 'Add, remove or sort options for the list.',
+					propertyEditorUiAlias: 'Umb.PropertyEditorUi.MultipleTextString',
+				},
+			],
+		},
 	},
 };

--- a/src/packages/core/property-editor/uis/radio-button-list/manifests.ts
+++ b/src/packages/core/property-editor/uis/radio-button-list/manifests.ts
@@ -10,15 +10,5 @@ export const manifest: ManifestPropertyEditorUi = {
 		propertyEditorSchemaAlias: 'Umbraco.RadioButtonList',
 		icon: 'icon-target',
 		group: 'lists',
-		settings: {
-			properties: [
-				{
-					alias: 'items',
-					label: 'Add option',
-					description: 'Add, remove or sort options for the list.',
-					propertyEditorUiAlias: 'Umb.PropertyEditorUi.MultipleTextString',
-				},
-			],
-		},
 	},
 };


### PR DESCRIPTION
Moves `items` from the UI to the schema settings, as they are used on the server.
