### PR TITLE
Fix document publishing variants

### DIFF
--- a/src/packages/block/block-grid/components/block-grid-area-config-entry/workspace/block-grid-area-type-workspace.context.ts
+++ b/src/packages/block/block-grid/components/block-grid-area-config-entry/workspace/block-grid-area-type-workspace.context.ts
@@ -119,7 +119,8 @@ export class UmbBlockGridAreaTypeWorkspaceContext
 			context.setValue(appendToFrozenArray(context.getValue() ?? [], this.#data.getValue(), (x) => x?.key));
 		});
 
-		this.saveComplete(this.#data.value);
+		this.setIsNew(false);
+		this.workspaceComplete(this.#data.value);
 	}
 
 	public destroy(): void {

--- a/src/packages/block/block-type/workspace/block-type-workspace.context.ts
+++ b/src/packages/block/block-type/workspace/block-type-workspace.context.ts
@@ -121,7 +121,8 @@ export class UmbBlockTypeWorkspaceContext<BlockTypeData extends UmbBlockTypeWith
 			);
 		});
 
-		this.saveComplete(this.#data.value);
+		this.setIsNew(false);
+		this.workspaceComplete(this.#data.value);
 	}
 
 	public destroy(): void {

--- a/src/packages/block/block/workspace/block-workspace.context.ts
+++ b/src/packages/block/block/workspace/block-workspace.context.ts
@@ -295,7 +295,8 @@ export class UmbBlockWorkspaceContext<
 			}
 		}
 
-		this.saveComplete(layoutData);
+		this.setIsNew(false);
+		this.workspaceComplete(layoutData);
 	}
 
 	#modalRejected = () => {

--- a/src/packages/core/workspace/workspace-context/editable-workspace-context-base.ts
+++ b/src/packages/core/workspace/workspace-context/editable-workspace-context-base.ts
@@ -46,13 +46,12 @@ export abstract class UmbEditableWorkspaceContextBase<WorkspaceDataModelType>
 		this.#isNew.setValue(isNew);
 	}
 
-	protected saveComplete(data: WorkspaceDataModelType) {
+	protected workspaceComplete(data: WorkspaceDataModelType | undefined) {
 		if (this.modalContext) {
-			this.modalContext?.setValue(data);
+			if (data) {
+				this.modalContext?.setValue(data);
+			}
 			this.modalContext?.submit();
-		} else {
-			// No need to have UI changing to "not new" if we are in a modal.
-			this.setIsNew(false);
 		}
 	}
 

--- a/src/packages/data-type/workspace/data-type-workspace.context.ts
+++ b/src/packages/data-type/workspace/data-type-workspace.context.ts
@@ -269,7 +269,8 @@ export class UmbDataTypeWorkspaceContext
 			await this.repository.save(this.#currentData.value);
 		}
 
-		this.saveComplete(this.#currentData.value);
+		this.setIsNew(false);
+		this.workspaceComplete(this.#currentData.value);
 	}
 
 	async delete(unique: string) {

--- a/src/packages/dictionary/workspace/dictionary-workspace.context.ts
+++ b/src/packages/dictionary/workspace/dictionary-workspace.context.ts
@@ -99,7 +99,10 @@ export class UmbDictionaryWorkspaceContext
 		}
 
 		const data = this.getData();
-		if (data) this.saveComplete(data);
+		if (!data) return;
+
+		this.setIsNew(false);
+		this.workspaceComplete(data);
 	}
 
 	public destroy(): void {

--- a/src/packages/documents/document-types/workspace/document-type-workspace.context.ts
+++ b/src/packages/documents/document-types/workspace/document-type-workspace.context.ts
@@ -185,7 +185,8 @@ export class UmbDocumentTypeWorkspaceContext
 			await this.structure.save();
 		}
 
-		this.saveComplete(data);
+		this.setIsNew(false);
+		this.workspaceComplete(data);
 	}
 
 	public destroy(): void {

--- a/src/packages/documents/documents/modals/pick-document-variant-modal.controller.ts
+++ b/src/packages/documents/documents/modals/pick-document-variant-modal.controller.ts
@@ -26,13 +26,14 @@ export class UmbPickDocumentVariantModalController extends UmbControllerBase {
 		};
 
 		if (modalData.options.length === 0) {
-			// TODO: What do to when there is no options?
+			// TODO: What do to when there is no options? [NL]
 		}
 
 		const modalContext = modalManagerContext.open(UMB_DOCUMENT_LANGUAGE_PICKER_MODAL, {
 			data: modalData,
 			// We need to turn the selected variant ids into strings for them to be serializable to the value state, in other words the value of a modal cannot hold class instances:
-			value: { selection: selected.map((x) => x.toString()) ?? [] },
+			// Make selection unique by filtering out duplicates:
+			value: { selection: selected.map((x) => x.toString()).filter((v, i, a) => a.indexOf(v) === i) ?? [] },
 		});
 
 		const result = await modalContext.onSubmit().catch(() => undefined);

--- a/src/packages/documents/documents/modals/variant-picker/document-variant-picker-modal.element.ts
+++ b/src/packages/documents/documents/modals/variant-picker/document-variant-picker-modal.element.ts
@@ -36,6 +36,9 @@ export class UmbDocumentVariantPickerModalElement extends UmbModalBaseElement<
 	async #setInitialSelection() {
 		let selected = this.value?.selection ?? [];
 
+		// Filter selection based on options:
+		selected = selected.filter((s) => this.data?.options.some((o) => o.unique === s));
+
 		if (selected.length === 0) {
 			const context = await this.getContext(UMB_APP_LANGUAGE_CONTEXT);
 			const appCulture = context.getAppCulture();

--- a/src/packages/documents/documents/modals/variant-picker/document-variant-picker-modal.element.ts
+++ b/src/packages/documents/documents/modals/variant-picker/document-variant-picker-modal.element.ts
@@ -37,15 +37,12 @@ export class UmbDocumentVariantPickerModalElement extends UmbModalBaseElement<
 		let selected = this.value?.selection ?? [];
 
 		if (selected.length === 0) {
-			// TODO: Make it possible to use consume context without callback. [NL]
-			const ctrl = this.consumeContext(UMB_APP_LANGUAGE_CONTEXT, () => {});
-			const context = await ctrl.asPromise();
+			const context = await this.getContext(UMB_APP_LANGUAGE_CONTEXT);
 			const appCulture = context.getAppCulture();
 			// If the app language is one of the options, select it by default:
 			if (appCulture && this.data?.options.some((o) => o.language.unique === appCulture)) {
 				selected = appendToFrozenArray(selected, new UmbVariantId(appCulture, null).toString());
 			}
-			ctrl.destroy();
 		}
 
 		this.#selectionManager.setMultiple(true);

--- a/src/packages/documents/documents/workspace/document-workspace.context.ts
+++ b/src/packages/documents/documents/workspace/document-workspace.context.ts
@@ -353,7 +353,10 @@ export class UmbDocumentWorkspaceContext
 
 		const activeVariantIds = activeVariants.map((activeVariant) => UmbVariantId.Create(activeVariant));
 		// TODO: We need to filter the selected array, so it only contains one of each variantId. [NL]
-		const selected = activeVariantIds.concat(this.#calculateChangedVariants());
+		const changedVariantIds = this.#calculateChangedVariants();
+		const selected = activeVariantIds.concat(changedVariantIds);
+		// Selected can contain entries that are not part of the options, therefor the modal filters selection based on options.
+
 		const options = await firstValueFrom(this.variantOptions);
 
 		// If there is only one variant, we don't need to open the modal.

--- a/src/packages/documents/documents/workspace/document-workspace.context.ts
+++ b/src/packages/documents/documents/workspace/document-workspace.context.ts
@@ -348,7 +348,7 @@ export class UmbDocumentWorkspaceContext
 		}
 	}
 
-	async #pickVariantsForAction(type: UmbDocumentVariantPickerModalType): Promise<UmbVariantId[]> {
+	async #runUserFlorFor(type: UmbDocumentVariantPickerModalType): Promise<UmbVariantId[]> {
 		const activeVariants = this.splitView.getActiveVariants();
 
 		const activeVariantIds = activeVariants.map((activeVariant) => UmbVariantId.Create(activeVariant));
@@ -445,21 +445,22 @@ export class UmbDocumentWorkspaceContext
 	}
 
 	async save() {
-		await this.#pickVariantsForAction('save');
+		await this.#runUserFlorFor('save');
 		const data = this.getData();
 		if (!data) throw new Error('Data is missing');
 
 		this.#persistedData.setValue(data);
 		this.#currentData.setValue(data);
 
-		this.saveComplete(data);
+		this.workspaceComplete(data);
 	}
 
 	public async publish() {
-		const variantIds = await this.#pickVariantsForAction('publish');
+		const variantIds = await this.#runUserFlorFor('publish');
 		const unique = this.getUnique();
 		if (variantIds.length && unique) {
 			await this.publishingRepository.publish(unique, variantIds);
+			this.workspaceComplete(this.#currentData.getValue());
 		}
 	}
 

--- a/src/packages/documents/documents/workspace/views/info/document-workspace-view-info.element.ts
+++ b/src/packages/documents/documents/workspace/views/info/document-workspace-view-info.element.ts
@@ -253,7 +253,6 @@ export class UmbDocumentWorkspaceViewInfoElement extends UmbLitElement {
 	}
 
 	async #openTemplatePicker() {
-		console.log(this._allowedTemplates);
 		const modal = this.#modalManagerContext?.open(UMB_TEMPLATE_PICKER_MODAL, {
 			data: {
 				hideTreeRoot: true,

--- a/src/packages/media/media-types/workspace/media-type-workspace.context.ts
+++ b/src/packages/media/media-types/workspace/media-type-workspace.context.ts
@@ -151,7 +151,8 @@ export class UmbMediaTypeWorkspaceContext
 			await this.structure.save();
 		}
 
-		this.saveComplete(data);
+		this.setIsNew(false);
+		this.workspaceComplete(data);
 	}
 
 	public destroy(): void {

--- a/src/packages/media/media/workspace/media-workspace.context.ts
+++ b/src/packages/media/media/workspace/media-workspace.context.ts
@@ -213,7 +213,8 @@ export class UmbMediaWorkspaceContext
 		const data = this.getData();
 		if (!data) throw new Error('Data is missing');
 		await this.#createOrSave();
-		this.saveComplete(data);
+		this.setIsNew(false);
+		this.workspaceComplete(data);
 	}
 
 	async delete() {

--- a/src/packages/members/member-group/workspace/member-group-workspace.context.ts
+++ b/src/packages/members/member-group/workspace/member-group-workspace.context.ts
@@ -61,7 +61,8 @@ export class UmbMemberGroupWorkspaceContext
 			await this.detailRepository.save(data);
 		}
 
-		this.saveComplete(data);
+		this.setIsNew(false);
+		this.workspaceComplete(data);
 	}
 
 	getData() {

--- a/src/packages/members/member-type/workspace/member-type-workspace.context.ts
+++ b/src/packages/members/member-type/workspace/member-type-workspace.context.ts
@@ -60,7 +60,8 @@ export class UmbMemberTypeWorkspaceContext
 			await this.detailRepository.save(data);
 		}
 
-		this.saveComplete(data);
+		this.setIsNew(false);
+		this.workspaceComplete(data);
 	}
 
 	getData() {

--- a/src/packages/members/member/workspace/member-workspace.context.ts
+++ b/src/packages/members/member/workspace/member-workspace.context.ts
@@ -68,7 +68,8 @@ export class UmbMemberWorkspaceContext
 			await this.repository.save(data);
 		}
 
-		this.saveComplete(data);
+		this.setIsNew(false);
+		this.workspaceComplete(data);
 	}
 
 	// Only for CRUD demonstration purposes

--- a/src/packages/templating/partial-views/workspace/partial-view-workspace.context.ts
+++ b/src/packages/templating/partial-views/workspace/partial-view-workspace.context.ts
@@ -107,7 +107,8 @@ export class UmbPartialViewWorkspaceContext
 
 		if (newData) {
 			this.#data.setValue(newData);
-			this.saveComplete(newData);
+			this.setIsNew(false);
+			this.workspaceComplete(newData);
 		}
 	}
 

--- a/src/packages/templating/scripts/workspace/script-workspace.context.ts
+++ b/src/packages/templating/scripts/workspace/script-workspace.context.ts
@@ -94,7 +94,9 @@ export class UmbScriptWorkspaceContext extends UmbEditableWorkspaceContextBase<U
 
 		if (newData) {
 			this.#data.setValue(newData);
-			this.saveComplete(newData);
+
+			this.setIsNew(false);
+			this.workspaceComplete(newData);
 		}
 	}
 

--- a/src/packages/templating/stylesheets/workspace/stylesheet-workspace.context.ts
+++ b/src/packages/templating/stylesheets/workspace/stylesheet-workspace.context.ts
@@ -102,7 +102,7 @@ export class UmbStylesheetWorkspaceContext
 
 		if (newData) {
 			this.#data.setValue(newData);
-			this.saveComplete(newData);
+			this.workspaceComplete(newData);
 		}
 	}
 

--- a/src/packages/templating/templates/workspace/template-workspace.context.ts
+++ b/src/packages/templating/templates/workspace/template-workspace.context.ts
@@ -161,7 +161,7 @@ ${currentContent}`;
 
 		if (newData) {
 			this.#data.setValue(newData);
-			this.saveComplete(newData);
+			this.workspaceComplete(newData);
 		}
 	}
 

--- a/src/packages/user/user/workspace/user-workspace.context.ts
+++ b/src/packages/user/user/workspace/user-workspace.context.ts
@@ -85,7 +85,8 @@ export class UmbUserWorkspaceContext
 		if (newData) {
 			this.#persistedData.setValue(newData);
 			this.#currentData.setValue(newData);
-			this.saveComplete(newData);
+			this.setIsNew(false);
+			this.workspaceComplete(newData);
 		}
 	}
 


### PR DESCRIPTION
* change saveComplete to workspaceComplete, for more clear purpose. As it should be called when a modal is ready to close.
* Fix saving and publishing of modals, so it only sends of the variants that was an actual option. — In this way we should also be ready to fit with permissions on variants.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
