### PR TITLE
clean up property editor manifests

### DIFF
--- a/src/packages/block/block-grid/property-editors/block-grid-editor/manifests.ts
+++ b/src/packages/block/block-grid/property-editors/block-grid-editor/manifests.ts
@@ -15,6 +15,11 @@ export const manifest: ManifestPropertyEditorUi = {
 		settings: {
 			properties: [
 				{
+					alias: 'blockGroups',
+					label: '',
+					propertyEditorUiAlias: 'Umb.PropertyEditorUi.BlockTypeGroupConfiguration',
+				},
+				{
 					alias: 'useLiveEditing',
 					label: 'Live editing mode',
 					description: 'Live update content when editing in overlay',

--- a/src/packages/block/block-grid/property-editors/block-grid-type-configuration/manifests.ts
+++ b/src/packages/block/block-grid/property-editors/block-grid-type-configuration/manifests.ts
@@ -7,7 +7,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	js: () => import('./property-editor-ui-block-grid-type-configuration.element.js'),
 	meta: {
 		label: 'Block Grid Block Configuration',
-		propertyEditorSchemaAlias: 'Umbraco.BlockGrid.BlockConfiguration',
 		icon: 'icon-autofill',
 		group: 'blocks',
 	},

--- a/src/packages/block/block-list/property-editors/block-list-type-configuration/manifests.ts
+++ b/src/packages/block/block-list/property-editors/block-list-type-configuration/manifests.ts
@@ -7,7 +7,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	js: () => import('./property-editor-ui-block-list-type-configuration.element.js'),
 	meta: {
 		label: 'Block List Type Configuration',
-		propertyEditorSchemaAlias: '',
 		icon: 'icon-autofill',
 		group: 'common',
 	},

--- a/src/packages/block/block-type/property-editors/block-type-group-configuration/manifests.ts
+++ b/src/packages/block/block-type/property-editors/block-type-group-configuration/manifests.ts
@@ -7,7 +7,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	js: () => import('./property-editor-ui-block-type-group-configuration.element.js'),
 	meta: {
 		label: 'Block Grid Group Configuration',
-		propertyEditorSchemaAlias: 'Umbraco.BlockGrid.GroupConfiguration',
 		icon: 'icon-autofill',
 		group: 'blocks',
 	},

--- a/src/packages/core/components/input-number-range/input-number-range.element.ts
+++ b/src/packages/core/components/input-number-range/input-number-range.element.ts
@@ -1,4 +1,4 @@
-import { css, html, customElement, property, state } from '@umbraco-cms/backoffice/external/lit';
+import { html, customElement, property, state } from '@umbraco-cms/backoffice/external/lit';
 import { FormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 
@@ -17,24 +17,26 @@ export class UmbInputNumberRangeElement extends FormControlMixin(UmbLitElement) 
 
 	@state()
 	private _minValue?: number;
-	@property()
-	public get minValue() {
-		return this._minValue;
-	}
+
+	@property({ type: Number })
 	public set minValue(value: number | undefined) {
 		this._minValue = value;
 		this.updateValue();
 	}
+	public get minValue() {
+		return this._minValue;
+	}
 
 	@state()
 	private _maxValue?: number;
-	@property()
-	public get maxValue() {
-		return this._maxValue;
-	}
+
+	@property({ type: Number })
 	public set maxValue(value: number | undefined) {
 		this._maxValue = value;
 		this.updateValue();
+	}
+	public get maxValue() {
+		return this._maxValue;
 	}
 
 	private updateValue() {

--- a/src/packages/core/modal/common/property-settings/property-settings-modal.element.ts
+++ b/src/packages/core/modal/common/property-settings/property-settings-modal.element.ts
@@ -6,7 +6,7 @@ import { UMB_DOCUMENT_TYPE_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/doc
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import type { UUIBooleanInputEvent, UUIInputEvent, UUISelectEvent } from '@umbraco-cms/backoffice/external/uui';
 import type { PropertyValueMap } from '@umbraco-cms/backoffice/external/lit';
-import { css, html, nothing, customElement, state } from '@umbraco-cms/backoffice/external/lit';
+import { css, html, nothing, customElement, state, ifDefined } from '@umbraco-cms/backoffice/external/lit';
 import type { UmbPropertySettingsModalValue, UmbPropertySettingsModalData } from '@umbraco-cms/backoffice/modal';
 import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 import { generateAlias } from '@umbraco-cms/backoffice/utils';
@@ -260,7 +260,7 @@ export class UmbPropertySettingsModalElement extends UmbModalBaseElement<
 										.value=${this.value.description}></uui-textarea>
 								</div>
 								<umb-data-type-flow-input
-									.value=${this.value.dataType?.unique}
+									.value=${ifDefined(this.value.dataType?.unique)}
 									@change=${this.#onDataTypeIdChange}></umb-data-type-flow-input>
 								<hr />
 								<div class="container">

--- a/src/packages/core/modal/common/property-settings/property-settings-modal.element.ts
+++ b/src/packages/core/modal/common/property-settings/property-settings-modal.element.ts
@@ -234,6 +234,7 @@ export class UmbPropertySettingsModalElement extends UmbModalBaseElement<
 									<uui-input
 										id="name-input"
 										name="name"
+										label="property name (TODO: Localize)"
 										@input=${this.#onNameChange}
 										.value=${this.value.name}
 										placeholder="Enter a name...">

--- a/src/packages/core/property-editor/schemas/Umbraco.BlockGrid.ts
+++ b/src/packages/core/property-editor/schemas/Umbraco.BlockGrid.ts
@@ -15,11 +15,6 @@ export const manifest: ManifestPropertyEditorSchema = {
 					propertyEditorUiAlias: 'Umb.PropertyEditorUi.BlockGridTypeConfiguration',
 				},
 				{
-					alias: 'blockGroups',
-					label: '',
-					propertyEditorUiAlias: 'Umb.PropertyEditorUi.BlockTypeGroupConfiguration',
-				},
-				{
 					alias: 'validationLimit',
 					label: 'Amount',
 					propertyEditorUiAlias: 'Umb.PropertyEditorUi.NumberRange',

--- a/src/packages/core/property-editor/uis/collection-view/config/bulk-action-permissions/manifests.ts
+++ b/src/packages/core/property-editor/uis/collection-view/config/bulk-action-permissions/manifests.ts
@@ -7,7 +7,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	element: () => import('./property-editor-ui-collection-view-bulk-action-permissions.element.js'),
 	meta: {
 		label: 'Collection View Bulk Action Permissions',
-		propertyEditorSchemaAlias: '',
 		icon: 'icon-autofill',
 		group: 'lists',
 	},

--- a/src/packages/core/property-editor/uis/collection-view/config/column-configuration/manifests.ts
+++ b/src/packages/core/property-editor/uis/collection-view/config/column-configuration/manifests.ts
@@ -7,7 +7,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	element: () => import('./property-editor-ui-collection-view-column-configuration.element.js'),
 	meta: {
 		label: 'Collection View Column Configuration',
-		propertyEditorSchemaAlias: '',
 		icon: 'icon-autofill',
 		group: 'lists',
 	},

--- a/src/packages/core/property-editor/uis/collection-view/config/layout-configuration/manifests.ts
+++ b/src/packages/core/property-editor/uis/collection-view/config/layout-configuration/manifests.ts
@@ -7,7 +7,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	element: () => import('./property-editor-ui-collection-view-layout-configuration.element.js'),
 	meta: {
 		label: 'Collection View Layout Configuration',
-		propertyEditorSchemaAlias: '',
 		icon: 'icon-autofill',
 		group: 'lists',
 	},

--- a/src/packages/core/property-editor/uis/collection-view/config/order-by/manifests.ts
+++ b/src/packages/core/property-editor/uis/collection-view/config/order-by/manifests.ts
@@ -7,7 +7,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	element: () => import('./property-editor-ui-collection-view-order-by.element.js'),
 	meta: {
 		label: 'Collection View Order By',
-		propertyEditorSchemaAlias: '',
 		icon: 'icon-autofill',
 		group: 'lists',
 	},

--- a/src/packages/core/property-editor/uis/number-range/manifests.ts
+++ b/src/packages/core/property-editor/uis/number-range/manifests.ts
@@ -7,7 +7,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	element: () => import('./property-editor-ui-number-range.element.js'),
 	meta: {
 		label: 'Number Range',
-		propertyEditorSchemaAlias: '',
 		icon: 'icon-autofill',
 		group: 'common',
 	},

--- a/src/packages/core/property-editor/uis/order-direction/manifests.ts
+++ b/src/packages/core/property-editor/uis/order-direction/manifests.ts
@@ -7,7 +7,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	element: () => import('./property-editor-ui-order-direction.element.js'),
 	meta: {
 		label: 'Order Direction',
-		propertyEditorSchemaAlias: '',
 		icon: 'icon-autofill',
 		group: 'common',
 	},

--- a/src/packages/core/property-editor/uis/overlay-size/manifests.ts
+++ b/src/packages/core/property-editor/uis/overlay-size/manifests.ts
@@ -7,7 +7,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	element: () => import('./property-editor-ui-overlay-size.element.js'),
 	meta: {
 		label: 'Overlay Size',
-		propertyEditorSchemaAlias: '',
 		icon: 'icon-document',
 		group: '',
 	},

--- a/src/packages/core/property-editor/uis/tree-picker/config/source-picker/manifests.ts
+++ b/src/packages/core/property-editor/uis/tree-picker/config/source-picker/manifests.ts
@@ -9,6 +9,5 @@ export const manifest: ManifestPropertyEditorUi = {
 		label: 'Tree Picker Source Picker',
 		icon: 'icon-page-add',
 		group: 'pickers',
-		propertyEditorSchemaAlias: '',
 	},
 };

--- a/src/packages/core/property-editor/uis/tree-picker/config/source-type-picker/manifests.ts
+++ b/src/packages/core/property-editor/uis/tree-picker/config/source-type-picker/manifests.ts
@@ -9,6 +9,5 @@ export const manifest: ManifestPropertyEditorUi = {
 		label: 'Tree Picker Source Type Picker',
 		icon: 'icon-page-add',
 		group: 'pickers',
-		propertyEditorSchemaAlias: '',
 	},
 };

--- a/src/packages/core/workspace/components/variant-selector/variant-selector.element.ts
+++ b/src/packages/core/workspace/components/variant-selector/variant-selector.element.ts
@@ -201,7 +201,12 @@ export class UmbVariantSelectorElement extends UmbLitElement {
 
 	render() {
 		return html`
-			<uui-input id="name-input" .value=${this._name ?? ''} @input="${this.#handleInput}">
+			<uui-input
+				id="name-input"
+				label="Document name (TODO: Localize)"
+				.value=${this._name ?? ''}
+				@input=${this.#handleInput}
+			>
 				${
 					this._variants?.length
 						? html`
@@ -246,8 +251,7 @@ export class UmbVariantSelectorElement extends UmbLitElement {
 																? html`<uui-icon class="add-icon" name="icon-add"></uui-icon>`
 																: nothing}
 															<div>
-																${variant.title}
-																${variant.culture ? html` <i>(${variant.culture})</i>` : ''}
+																${variant.title} ${variant.culture ? html` <i>(${variant.culture})</i>` : ''}
 																${variant.segment}
 																<div class="variant-selector-state">${variant.state}</div>
 															</div>

--- a/src/packages/data-type/components/data-type-flow-input/data-type-flow-input.element.ts
+++ b/src/packages/data-type/components/data-type-flow-input/data-type-flow-input.element.ts
@@ -27,15 +27,15 @@ export class UmbInputDataTypeElement extends FormControlMixin(UmbLitElement) {
 	 * @default []
 	 */
 	@property({ type: String, attribute: false })
-	get value(): string {
-		return super.value?.toString() ?? '';
-	}
 	set value(dataTypeId: string) {
 		super.value = dataTypeId ?? '';
 		this._ids = super.value
 			.split(',')
 			.map((tag) => tag.trim())
 			.filter((id) => id.length !== 0);
+	}
+	get value(): string {
+		return super.value?.toString() ?? '';
 	}
 
 	#editDataTypeModal?: UmbModalRouteRegistrationController;

--- a/src/packages/data-type/workspace/data-type-workspace.context.ts
+++ b/src/packages/data-type/workspace/data-type-workspace.context.ts
@@ -47,20 +47,20 @@ export class UmbDataTypeWorkspaceContext
 	#properties = new UmbArrayState<PropertyEditorSettingsProperty>([], (x) => x.alias);
 	readonly properties = this.#properties.asObservable();
 
-	private _propertyEditorSchemaConfigDefaultData: Array<PropertyEditorSettingsDefaultData> = [];
-	private _propertyEditorUISettingsDefaultData: Array<PropertyEditorSettingsDefaultData> = [];
-
-	private _propertyEditorSchemaConfigProperties: Array<PropertyEditorSettingsProperty> = [];
-	private _propertyEditorUISettingsProperties: Array<PropertyEditorSettingsProperty> = [];
-
-	private _propertyEditorSchemaConfigDefaultUIAlias: string | null = null;
-
-	private _configDefaultData?: Array<PropertyEditorSettingsDefaultData>;
-
-	private _propertyEditorUISettingsSchemaAlias?: string;
-
 	#defaults = new UmbArrayState<PropertyEditorSettingsDefaultData>([], (entry) => entry.alias);
 	readonly defaults = this.#defaults.asObservable();
+
+	#propertyEditorSchemaSettingsDefaultData: Array<PropertyEditorSettingsDefaultData> = [];
+	#propertyEditorUISettingsDefaultData: Array<PropertyEditorSettingsDefaultData> = [];
+
+	#propertyEditorSchemaSettingsProperties: Array<PropertyEditorSettingsProperty> = [];
+	#propertyEditorUISettingsProperties: Array<PropertyEditorSettingsProperty> = [];
+
+	#propertyEditorSchemaConfigDefaultUIAlias: string | null = null;
+
+	#settingsDefaultData?: Array<PropertyEditorSettingsDefaultData>;
+
+	#propertyEditorUISettingsSchemaAlias?: string;
 
 	#propertyEditorUiIcon = new UmbStringState<string | null>(null);
 	readonly propertyEditorUiIcon = this.#propertyEditorUiIcon.asObservable();
@@ -89,10 +89,10 @@ export class UmbDataTypeWorkspaceContext
 				// if the property editor ui alias is not set, we use the default alias from the schema
 				if (propertyEditorUiAlias === null) {
 					await this.#observePropertyEditorSchemaAlias();
-					this.setPropertyEditorUiAlias(this._propertyEditorSchemaConfigDefaultUIAlias!);
+					this.setPropertyEditorUiAlias(this.#propertyEditorSchemaConfigDefaultUIAlias!);
 				} else {
 					await this.#setPropertyEditorUIConfig(propertyEditorUiAlias);
-					this.setPropertyEditorSchemaAlias(this._propertyEditorUISettingsSchemaAlias!);
+					this.setPropertyEditorSchemaAlias(this.#propertyEditorUISettingsSchemaAlias!);
 					await this.#observePropertyEditorSchemaAlias();
 				}
 
@@ -122,9 +122,9 @@ export class UmbDataTypeWorkspaceContext
 		return this.observe(
 			umbExtensionsRegistry.byTypeAndAlias('propertyEditorSchema', propertyEditorSchemaAlias),
 			(manifest) => {
-				this._propertyEditorSchemaConfigProperties = manifest?.meta.settings?.properties || [];
-				this._propertyEditorSchemaConfigDefaultData = manifest?.meta.settings?.defaultData || [];
-				this._propertyEditorSchemaConfigDefaultUIAlias = manifest?.meta.defaultPropertyEditorUiAlias || null;
+				this.#propertyEditorSchemaSettingsProperties = manifest?.meta.settings?.properties || [];
+				this.#propertyEditorSchemaSettingsDefaultData = manifest?.meta.settings?.defaultData || [];
+				this.#propertyEditorSchemaConfigDefaultUIAlias = manifest?.meta.defaultPropertyEditorUiAlias || null;
 			},
 			'schema',
 		).asPromise();
@@ -137,35 +137,35 @@ export class UmbDataTypeWorkspaceContext
 				this.#propertyEditorUiIcon.setValue(manifest?.meta.icon || null);
 				this.#propertyEditorUiName.setValue(manifest?.name || null);
 
-				this._propertyEditorUISettingsSchemaAlias = manifest?.meta.propertyEditorSchemaAlias;
-				this._propertyEditorUISettingsProperties = manifest?.meta.settings?.properties || [];
-				this._propertyEditorUISettingsDefaultData = manifest?.meta.settings?.defaultData || [];
+				this.#propertyEditorUISettingsSchemaAlias = manifest?.meta.propertyEditorSchemaAlias;
+				this.#propertyEditorUISettingsProperties = manifest?.meta.settings?.properties || [];
+				this.#propertyEditorUISettingsDefaultData = manifest?.meta.settings?.defaultData || [];
 			},
 			'editorUi',
 		).asPromise();
 	}
 
 	private _mergeConfigProperties() {
-		if (this._propertyEditorSchemaConfigProperties && this._propertyEditorUISettingsProperties) {
+		if (this.#propertyEditorSchemaSettingsProperties && this.#propertyEditorUISettingsProperties) {
 			// Reset the value to this array, and then afterwards append:
-			this.#properties.setValue(this._propertyEditorSchemaConfigProperties);
+			this.#properties.setValue(this.#propertyEditorSchemaSettingsProperties);
 			// Append the UI settings properties to the schema properties, so they can override the schema properties:
-			this.#properties.append(this._propertyEditorUISettingsProperties);
+			this.#properties.append(this.#propertyEditorUISettingsProperties);
 		}
 	}
 
 	private _mergeConfigDefaultData() {
-		if (!this._propertyEditorSchemaConfigDefaultData || !this._propertyEditorUISettingsDefaultData) return;
+		if (!this.#propertyEditorSchemaSettingsDefaultData || !this.#propertyEditorUISettingsDefaultData) return;
 
-		this._configDefaultData = [
-			...this._propertyEditorSchemaConfigDefaultData,
-			...this._propertyEditorUISettingsDefaultData,
+		this.#settingsDefaultData = [
+			...this.#propertyEditorSchemaSettingsDefaultData,
+			...this.#propertyEditorUISettingsDefaultData,
 		];
-		this.#defaults.setValue(this._configDefaultData);
+		this.#defaults.setValue(this.#settingsDefaultData);
 	}
 
 	public getPropertyDefaultValue(alias: string) {
-		return this._configDefaultData?.find((x) => x.alias === alias)?.value;
+		return this.#settingsDefaultData?.find((x) => x.alias === alias)?.value;
 	}
 
 	createPropertyDatasetContext(host: UmbControllerHost): UmbPropertyDatasetContext {
@@ -174,8 +174,9 @@ export class UmbDataTypeWorkspaceContext
 
 	async load(unique: string) {
 		this.resetState();
-		this.#getDataPromise = this.repository.requestByUnique(unique);
-		const { data } = await this.#getDataPromise;
+		const request = this.repository.requestByUnique(unique);
+		this.#getDataPromise = request;
+		const { data } = await request;
 		if (!data) return undefined;
 
 		this.setIsNew(false);
@@ -185,8 +186,10 @@ export class UmbDataTypeWorkspaceContext
 
 	async create(parentUnique: string | null) {
 		this.resetState();
-		this.#getDataPromise = this.repository.createScaffold(parentUnique);
-		let { data } = await this.#getDataPromise;
+		const request = this.repository.createScaffold(parentUnique);
+		this.#getDataPromise = request;
+		let { data } = await request;
+		if (!data) return undefined;
 		if (this.modalContext) {
 			data = { ...data, ...this.modalContext.data.preset };
 		}

--- a/src/packages/media/media/property-editors/image-crops-configuration/manifests.ts
+++ b/src/packages/media/media/property-editors/image-crops-configuration/manifests.ts
@@ -9,6 +9,5 @@ export const manifest: ManifestPropertyEditorUi = {
 		label: 'Image Crops Configuration',
 		icon: 'icon-autofill',
 		group: 'common',
-		propertyEditorSchemaAlias: 'Umbraco.ImageCropper.Configuration',
 	},
 };

--- a/src/packages/tags/property-editors/tags/config/storage-type/manifests.ts
+++ b/src/packages/tags/property-editors/tags/config/storage-type/manifests.ts
@@ -8,7 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	js: () => import('./property-editor-ui-tags-storage-type.element.js'),
 	meta: {
 		label: 'Tags Storage Type',
-		propertyEditorSchemaAlias: '',
 		icon: 'icon-autofill',
 		group: 'common',
 	},

--- a/src/packages/tiny-mce/property-editors/manifests.ts
+++ b/src/packages/tiny-mce/property-editors/manifests.ts
@@ -12,7 +12,6 @@ export const manifests: Array<ManifestPropertyEditorUi> = [
 		js: () => import('./toolbar/property-editor-ui-tiny-mce-toolbar-configuration.element.js'),
 		meta: {
 			label: 'TinyMCE Toolbar Configuration',
-			propertyEditorSchemaAlias: 'Umbraco.RichText.Configuration',
 			icon: 'icon-autofill',
 			group: 'common',
 		},
@@ -24,7 +23,6 @@ export const manifests: Array<ManifestPropertyEditorUi> = [
 		js: () => import('./stylesheets/property-editor-ui-tiny-mce-stylesheets-configuration.element.js'),
 		meta: {
 			label: 'TinyMCE Stylesheets Configuration',
-			propertyEditorSchemaAlias: 'Umbraco.RichText.Configuration',
 			icon: 'icon-autofill',
 			group: 'common',
 		},
@@ -36,7 +34,6 @@ export const manifests: Array<ManifestPropertyEditorUi> = [
 		js: () => import('./dimensions/property-editor-ui-tiny-mce-dimensions-configuration.element.js'),
 		meta: {
 			label: 'TinyMCE Dimensions Configuration',
-			propertyEditorSchemaAlias: 'Umbraco.RichText.Configuration',
 			icon: 'icon-autofill',
 			group: 'common',
 		},
@@ -48,7 +45,6 @@ export const manifests: Array<ManifestPropertyEditorUi> = [
 		js: () => import('./max-image-size/property-editor-ui-tiny-mce-maximagesize-configuration.element.js'),
 		meta: {
 			label: 'TinyMCE Max Image Size Configuration',
-			propertyEditorSchemaAlias: 'Umbraco.RichText.Configuration',
 			icon: 'icon-autofill',
 			group: 'common',
 		},


### PR DESCRIPTION
what it says + minor few render html corrections like adding label and moving getter/setter

Mainly this makes only the real property editors appear in the property editor picker modals. (real property editors, are property editors with a schema... )

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
