### PR TITLE
Bugfix: Document Collections: Adds `creator` to the views label lookup

### DIFF
--- a/src/packages/documents/documents/collection/views/index.ts
+++ b/src/packages/documents/documents/collection/views/index.ts
@@ -6,6 +6,8 @@ export function getPropertyValueByAlias(sortOrder: number, item: UmbDocumentColl
 	switch (alias) {
 		case 'createDate':
 			return item.createDate.toLocaleString();
+		case 'creator':
+			return item.creator;
 		case 'entityName':
 			return item.name;
 		case 'entityState':


### PR DESCRIPTION
`creator` was missed off during the initial implementation. 🤦 