### PR TITLE
Bugfix: Remove option to reload children of file system file

### DIFF
--- a/src/packages/templating/partial-views/tree/reload-tree-item-children/manifests.ts
+++ b/src/packages/templating/partial-views/tree/reload-tree-item-children/manifests.ts
@@ -1,8 +1,4 @@
-import {
-	UMB_PARTIAL_VIEW_ROOT_ENTITY_TYPE,
-	UMB_PARTIAL_VIEW_ENTITY_TYPE,
-	UMB_PARTIAL_VIEW_FOLDER_ENTITY_TYPE,
-} from '../../entity.js';
+import { UMB_PARTIAL_VIEW_ROOT_ENTITY_TYPE, UMB_PARTIAL_VIEW_FOLDER_ENTITY_TYPE } from '../../entity.js';
 import type { ManifestTypes } from '@umbraco-cms/backoffice/extension-registry';
 
 export const manifests: Array<ManifestTypes> = [
@@ -11,10 +7,6 @@ export const manifests: Array<ManifestTypes> = [
 		kind: 'reloadTreeItemChildren',
 		alias: 'Umb.EntityAction.PartialView.Tree.ReloadChildrenOf',
 		name: 'Reload Partial View Tree Item Children Entity Action',
-		forEntityTypes: [
-			UMB_PARTIAL_VIEW_ROOT_ENTITY_TYPE,
-			UMB_PARTIAL_VIEW_ENTITY_TYPE,
-			UMB_PARTIAL_VIEW_FOLDER_ENTITY_TYPE,
-		],
+		forEntityTypes: [UMB_PARTIAL_VIEW_ROOT_ENTITY_TYPE, UMB_PARTIAL_VIEW_FOLDER_ENTITY_TYPE],
 	},
 ];

--- a/src/packages/templating/scripts/tree/reload-tree-item-children/manifests.ts
+++ b/src/packages/templating/scripts/tree/reload-tree-item-children/manifests.ts
@@ -1,4 +1,4 @@
-import { UMB_SCRIPT_ROOT_ENTITY_TYPE, UMB_SCRIPT_ENTITY_TYPE, UMB_SCRIPT_FOLDER_ENTITY_TYPE } from '../../entity.js';
+import { UMB_SCRIPT_ROOT_ENTITY_TYPE, UMB_SCRIPT_FOLDER_ENTITY_TYPE } from '../../entity.js';
 import type { ManifestTypes } from '@umbraco-cms/backoffice/extension-registry';
 
 export const manifests: Array<ManifestTypes> = [
@@ -7,6 +7,6 @@ export const manifests: Array<ManifestTypes> = [
 		alias: 'Umb.EntityAction.Script.Tree.ReloadChildrenOf',
 		name: 'Reload Script Tree Item Children Entity Action',
 		kind: 'reloadTreeItemChildren',
-		forEntityTypes: [UMB_SCRIPT_ROOT_ENTITY_TYPE, UMB_SCRIPT_ENTITY_TYPE, UMB_SCRIPT_FOLDER_ENTITY_TYPE],
+		forEntityTypes: [UMB_SCRIPT_ROOT_ENTITY_TYPE, UMB_SCRIPT_FOLDER_ENTITY_TYPE],
 	},
 ];

--- a/src/packages/templating/stylesheets/tree/reload-tree-item-children/manifests.ts
+++ b/src/packages/templating/stylesheets/tree/reload-tree-item-children/manifests.ts
@@ -1,6 +1,5 @@
 import {
 	UMB_STYLESHEET_ROOT_ENTITY_TYPE,
-	UMB_STYLESHEET_ENTITY_TYPE,
 	UMB_STYLESHEET_FOLDER_ENTITY_TYPE,
 } from '../../entity.js';
 import type { ManifestTypes } from '@umbraco-cms/backoffice/extension-registry';
@@ -11,6 +10,6 @@ export const manifests: Array<ManifestTypes> = [
 		kind: 'reloadTreeItemChildren',
 		alias: 'Umb.EntityAction.Stylesheet.Tree.ReloadChildrenOf',
 		name: 'Reload Stylesheet Tree Item Children Entity Action',
-		forEntityTypes: [UMB_STYLESHEET_ROOT_ENTITY_TYPE, UMB_STYLESHEET_ENTITY_TYPE, UMB_STYLESHEET_FOLDER_ENTITY_TYPE],
+		forEntityTypes: [UMB_STYLESHEET_ROOT_ENTITY_TYPE, UMB_STYLESHEET_FOLDER_ENTITY_TYPE],
 	},
 ];


### PR DESCRIPTION
File system files can't be nested. This PR removes the option to reload children of such.