### PR TITLE
Rename to contextConsumer method to skipHost + one more test

### DIFF
--- a/src/libs/context-api/consume/context-consumer.ts
+++ b/src/libs/context-api/consume/context-consumer.ts
@@ -13,7 +13,9 @@ import { UmbContextRequestEventImplementation } from './context-request.event.js
  * @class UmbContextConsumer
  */
 export class UmbContextConsumer<BaseType = unknown, ResultType extends BaseType = BaseType> {
-	#skipOrigin?: boolean;
+	protected _host: Element;
+
+	#skipHost?: boolean;
 	#stopAtContextMatch = true;
 	#callback?: UmbContextCallback<ResultType>;
 	#promise?: Promise<ResultType>;
@@ -31,16 +33,17 @@ export class UmbContextConsumer<BaseType = unknown, ResultType extends BaseType 
 
 	/**
 	 * Creates an instance of UmbContextConsumer.
-	 * @param {Element} element
+	 * @param {Element} host
 	 * @param {string} contextIdentifier
 	 * @param {UmbContextCallback} callback
 	 * @memberof UmbContextConsumer
 	 */
 	constructor(
-		protected element: Element,
+		host: Element,
 		contextIdentifier: string | UmbContextToken<BaseType, ResultType>,
 		callback?: UmbContextCallback<ResultType>,
 	) {
+		this._host = host;
 		const idSplit = contextIdentifier.toString().split('#');
 		this.#contextAlias = idSplit[0];
 		this.#apiAlias = idSplit[1] ?? 'default';
@@ -51,10 +54,11 @@ export class UmbContextConsumer<BaseType = unknown, ResultType extends BaseType 
 	/**
 	 * @public
 	 * @memberof UmbContextConsumer
-	 * @description Skip the contexts provided by the requesting element.
+	 * @description Make the consumption skip the contexts provided by the Host element.
 	 */
-	public skipOrigin(): void {
-		this.#skipOrigin = true;
+	public skipHost() {
+		this.#skipHost = true;
+		return this;
 	}
 
 	/**
@@ -63,8 +67,9 @@ export class UmbContextConsumer<BaseType = unknown, ResultType extends BaseType 
 	 * @description Pass beyond any context aliases that matches this.
 	 * The default behavior is to stop at first Context Alias match, this is to avoid receiving unforeseen descending contexts.
 	 */
-	public passContextAliasMatches(): void {
+	public passContextAliasMatches() {
 		this.#stopAtContextMatch = false;
+		return this;
 	}
 
 	protected _onResponse = (instance: BaseType): boolean => {
@@ -119,7 +124,7 @@ export class UmbContextConsumer<BaseType = unknown, ResultType extends BaseType 
 			this._onResponse,
 			this.#stopAtContextMatch,
 		);
-		(this.#skipOrigin ? this.element.parentNode : this.element)?.dispatchEvent(event);
+		(this.#skipHost ? this._host.parentNode : this._host)?.dispatchEvent(event);
 	}
 
 	public hostConnected(): void {

--- a/src/libs/controller-api/controller-host.mixin.ts
+++ b/src/libs/controller-api/controller-host.mixin.ts
@@ -56,7 +56,7 @@ export const UmbControllerHostMixin = <T extends ClassConstructor>(superClass: T
 
 			this.#controllers.push(ctrl);
 			if (this.#attached) {
-				// If a controller is created on a already attached element, then it will be added directly. This might not be optimal. As the controller it self has not finished its constructor method jet. therefor i postpone the call:
+				// If a controller is created on a already attached element, then it will be added directly. This might not be optimal. As the controller it self has not finished its constructor method jet. therefor i postpone the call: [NL]
 				Promise.resolve().then(() => {
 					// Extra check to see if we are still attached at this point:
 					if (this.#attached) {

--- a/src/libs/element-api/element.test.ts
+++ b/src/libs/element-api/element.test.ts
@@ -6,7 +6,7 @@ import { UmbStringState } from '@umbraco-cms/backoffice/observable-api';
 @customElement('test-my-umb-element')
 class UmbTestUmbElement extends UmbElementMixin(HTMLElement) {}
 
-describe('UmbElement', () => {
+describe('UmbElementMixin', () => {
 	let hostElement: UmbTestUmbElement;
 
 	beforeEach(() => {
@@ -198,6 +198,17 @@ describe('UmbElement', () => {
 			expect(hostElement.hasController(ctrl)).to.be.false;
 			expect(ctrl2).to.be.undefined;
 			expect(hostElement.hasController(ctrl2)).to.be.false;
+		});
+
+		it('an undefined observer executes the callback method with undefined', () => {
+			let callbackWasCalled = false;
+			const ctrl = hostElement.observe(undefined, (value) => {
+				expect(value).to.be.undefined;
+				callbackWasCalled = true;
+			});
+			expect(callbackWasCalled).to.be.true;
+			expect(ctrl).to.be.undefined;
+			expect(hostElement.hasController(ctrl)).to.be.false;
 		});
 	});
 });

--- a/src/packages/core/modal/common/property-settings/property-settings-modal.element.ts
+++ b/src/packages/core/modal/common/property-settings/property-settings-modal.element.ts
@@ -65,7 +65,7 @@ export class UmbPropertySettingsModalElement extends UmbModalBaseElement<
 
 			this.observe(instance.variesByCulture, (variesByCulture) => (this._documentVariesByCulture = variesByCulture));
 			this.observe(instance.variesBySegment, (variesBySegment) => (this._documentVariesBySegment = variesBySegment));
-		}).skipOrigin();
+		}).skipHost();
 
 		this._originalPropertyData = this.value;
 		this.#isNew = this.value.alias === '';
@@ -357,7 +357,7 @@ export class UmbPropertySettingsModalElement extends UmbModalBaseElement<
 							name="pattern-message"
 							@change=${this.#onValidationMessageChange}
 							.value=${this.value.validation?.regExMessage ?? ''}></uui-textarea>
-				  `
+					`
 				: nothing} `;
 	}
 


### PR DESCRIPTION
Just a few minor updates.

renaming to skipHost is breaking, but I assume no one uses this jet.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
