### PR TITLE
bugfix: Callback value type should be undefined-able where the given observable is undefined-able

### DIFF
--- a/src/libs/class-api/class.interface.ts
+++ b/src/libs/class-api/class.interface.ts
@@ -24,8 +24,9 @@ export interface UmbClassInterface extends UmbControllerHost {
 				? U | undefined
 				: U
 			: undefined,
-		R extends UmbObserverController<SpecificT> = UmbObserverController<SpecificT>,
-		SpecificR = ObservableType extends undefined ? R | undefined : R,
+		SpecificR = ObservableType extends undefined
+			? UmbObserverController<SpecificT> | undefined
+			: UmbObserverController<SpecificT>,
 	>(
 		// This type dance checks if the Observable given could be undefined, if it potentially could be undefined it means that this potentially could return undefined and then call the callback with undefined. [NL]
 		source: ObservableType,

--- a/src/libs/class-api/class.interface.ts
+++ b/src/libs/class-api/class.interface.ts
@@ -17,7 +17,7 @@ export interface UmbClassInterface extends UmbControllerHost {
 	 * @memberof UmbClassMixin
 	 */
 	observe<
-		ObservableType extends Observable<T>,
+		ObservableType extends Observable<T> | undefined,
 		T,
 		SpecificT = ObservableType extends Observable<infer U>
 			? ObservableType extends undefined
@@ -25,10 +25,10 @@ export interface UmbClassInterface extends UmbControllerHost {
 				: U
 			: undefined,
 		R extends UmbObserverController<SpecificT> = UmbObserverController<SpecificT>,
-		SpecificR extends R | undefined = ObservableType extends undefined ? R | undefined : R,
+		SpecificR = ObservableType extends undefined ? R | undefined : R,
 	>(
 		// This type dance checks if the Observable given could be undefined, if it potentially could be undefined it means that this potentially could return undefined and then call the callback with undefined. [NL]
-		source: ObservableType | undefined,
+		source: ObservableType,
 		callback: ObserverCallback<SpecificT>,
 		controllerAlias?: UmbControllerAlias,
 	): SpecificR;

--- a/src/libs/class-api/class.mixin.ts
+++ b/src/libs/class-api/class.mixin.ts
@@ -47,8 +47,9 @@ export const UmbClassMixin = <T extends ClassConstructor<EventTarget>>(superClas
 					? U | undefined
 					: U
 				: undefined,
-			R extends UmbObserverController<SpecificT> = UmbObserverController<SpecificT>,
-			SpecificR = ObservableType extends undefined ? R | undefined : R,
+			SpecificR = ObservableType extends undefined
+				? UmbObserverController<SpecificT> | undefined
+				: UmbObserverController<SpecificT>,
 		>(
 			// This type dance checks if the Observable given could be undefined, if it potentially could be undefined it means that this potentially could return undefined and then call the callback with undefined. [NL]
 			source: ObservableType,

--- a/src/libs/class-api/class.mixin.ts
+++ b/src/libs/class-api/class.mixin.ts
@@ -40,7 +40,7 @@ export const UmbClassMixin = <T extends ClassConstructor<EventTarget>>(superClas
 		}
 
 		observe<
-			ObservableType extends Observable<T>,
+			ObservableType extends Observable<T> | undefined,
 			T,
 			SpecificT = ObservableType extends Observable<infer U>
 				? ObservableType extends undefined
@@ -48,10 +48,10 @@ export const UmbClassMixin = <T extends ClassConstructor<EventTarget>>(superClas
 					: U
 				: undefined,
 			R extends UmbObserverController<SpecificT> = UmbObserverController<SpecificT>,
-			SpecificR extends R | undefined = ObservableType extends undefined ? R | undefined : R,
+			SpecificR = ObservableType extends undefined ? R | undefined : R,
 		>(
 			// This type dance checks if the Observable given could be undefined, if it potentially could be undefined it means that this potentially could return undefined and then call the callback with undefined. [NL]
-			source: ObservableType | undefined,
+			source: ObservableType,
 			callback: ObserverCallback<SpecificT>,
 			controllerAlias?: UmbControllerAlias,
 		): SpecificR {

--- a/src/libs/element-api/element.mixin.ts
+++ b/src/libs/element-api/element.mixin.ts
@@ -20,8 +20,9 @@ export const UmbElementMixin = <T extends HTMLElementConstructor>(superClass: T)
 					? U | undefined
 					: U
 				: undefined,
-			R extends UmbObserverController<SpecificT> = UmbObserverController<SpecificT>,
-			SpecificR = ObservableType extends undefined ? R | undefined : R,
+			SpecificR = ObservableType extends undefined
+				? UmbObserverController<SpecificT> | undefined
+				: UmbObserverController<SpecificT>,
 		>(
 			// This type dance checks if the Observable given could be undefined, if it potentially could be undefined it means that this potentially could return undefined and then call the callback with undefined. [NL]
 			source: ObservableType,

--- a/src/libs/element-api/element.mixin.ts
+++ b/src/libs/element-api/element.mixin.ts
@@ -13,7 +13,7 @@ export const UmbElementMixin = <T extends HTMLElementConstructor>(superClass: T)
 		localize: UmbLocalizationController = new UmbLocalizationController(this);
 
 		observe<
-			ObservableType extends Observable<T>,
+			ObservableType extends Observable<T> | undefined,
 			T,
 			SpecificT = ObservableType extends Observable<infer U>
 				? ObservableType extends undefined
@@ -21,10 +21,10 @@ export const UmbElementMixin = <T extends HTMLElementConstructor>(superClass: T)
 					: U
 				: undefined,
 			R extends UmbObserverController<SpecificT> = UmbObserverController<SpecificT>,
-			SpecificR extends R | undefined = ObservableType extends undefined ? R | undefined : R,
+			SpecificR = ObservableType extends undefined ? R | undefined : R,
 		>(
 			// This type dance checks if the Observable given could be undefined, if it potentially could be undefined it means that this potentially could return undefined and then call the callback with undefined. [NL]
-			source: ObservableType | undefined,
+			source: ObservableType,
 			callback: ObserverCallback<SpecificT>,
 			controllerAlias?: UmbControllerAlias,
 		): SpecificR {

--- a/src/libs/element-api/element.test.ts
+++ b/src/libs/element-api/element.test.ts
@@ -180,7 +180,6 @@ describe('UmbElement', () => {
 			// The controller is removed from the host, and the new one was NOT added:
 			expect(hostElement.hasController(ctrl)).to.be.false;
 			expect(ctrl2).to.be.undefined;
-			expect(hostElement.hasController(ctrl2)).to.be.false;
 		});
 
 		it('observe is removed when observer is undefined and using the same callback method', () => {
@@ -197,7 +196,6 @@ describe('UmbElement', () => {
 			// The controller is removed from the host, and the new one was NOT added:
 			expect(hostElement.hasController(ctrl)).to.be.false;
 			expect(ctrl2).to.be.undefined;
-			expect(hostElement.hasController(ctrl2)).to.be.false;
 		});
 	});
 });


### PR DESCRIPTION
Correcting type case, to match the expected + correcting test.

The type correction is moving the | undefined, so the type extend test actually take undefined into account.

the test correction removes the hasController check as that is an illegal check when the controller is undefined.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
