### PR TITLE
Chore: update user filter request handler to use the correct path

### DIFF
--- a/src/mocks/handlers/user/filter.handlers.ts
+++ b/src/mocks/handlers/user/filter.handlers.ts
@@ -4,7 +4,7 @@ import { UMB_SLUG } from './slug.js';
 import { umbracoPath } from '@umbraco-cms/backoffice/utils';
 
 export const handlers = [
-	rest.get(umbracoPath(`${UMB_SLUG}/filter`), (req, res, ctx) => {
+	rest.get(umbracoPath(`/filter${UMB_SLUG}`), (req, res, ctx) => {
 		const skip = Number(req.url.searchParams.get('skip'));
 		const take = Number(req.url.searchParams.get('take'));
 		const orderBy = req.url.searchParams.get('orderBy');


### PR DESCRIPTION
At one point the filter endpoints were change in the management api and we never got our mocks updated.

This PR updates the url to match the management api so we now can see mocked users in the collection