### PR TITLE
Feature/better-500-handling

### DIFF
--- a/src/packages/core/resources/resource.controller.ts
+++ b/src/packages/core/resources/resource.controller.ts
@@ -62,6 +62,11 @@ export class UmbResourceController extends UmbControllerBase {
 				// Cancelled - do nothing
 				return {};
 			} else {
+				console.group('UmbResourceController');
+				console.error('Request failed', error.request);
+				console.error('ProblemDetails', error.body);
+				console.error('Error', error);
+
 				// ApiError - body could hold a ProblemDetails from the server
 				if (typeof error.body !== 'undefined' && !!error.body) {
 					try {
@@ -90,9 +95,6 @@ export class UmbResourceController extends UmbControllerBase {
 						break;
 					case 500:
 						// Server Error
-						console.group('UmbResourceController');
-						console.error(error);
-						console.groupEnd();
 
 						if (this.#notificationContext) {
 							let message = 'A fatal server error occurred. If this continues, please reach out to your administrator.';
@@ -122,12 +124,10 @@ export class UmbResourceController extends UmbControllerBase {
 								},
 								...options,
 							});
-						} else {
-							console.group('UmbResourceController');
-							console.error(error);
-							console.groupEnd();
 						}
 				}
+
+				console.groupEnd();
 			}
 		}
 

--- a/src/packages/core/resources/resource.controller.ts
+++ b/src/packages/core/resources/resource.controller.ts
@@ -88,6 +88,30 @@ export class UmbResourceController extends UmbControllerBase {
 							},
 						});
 						break;
+					case 500:
+						// Server Error
+						console.group('UmbResourceController');
+						console.error(error);
+						console.groupEnd();
+
+						if (this.#notificationContext) {
+							let message = 'A fatal server error occurred. If this continues, please reach out to your administrator.';
+
+							// Special handling for ObjectCacheAppCache corruption errors, which we are investigating
+							if (error.body?.detail?.includes('ObjectCacheAppCache')) {
+								message =
+									'The Umbraco object cache is corrupt, but your action may still have been executed. Please restart the server to reset the cache. This is a work in progress.';
+							}
+
+							this.#notificationContext.peek('danger', {
+								data: {
+									headline: error.body?.title ?? error.name ?? 'Server Error',
+									message,
+								},
+								...options,
+							});
+						}
+						break;
 					default:
 						// Other errors
 						if (this.#notificationContext) {

--- a/src/packages/core/resources/resource.controller.ts
+++ b/src/packages/core/resources/resource.controller.ts
@@ -101,7 +101,10 @@ export class UmbResourceController extends UmbControllerBase {
 							let message = 'A fatal server error occurred. If this continues, please reach out to your administrator.';
 
 							// Special handling for ObjectCacheAppCache corruption errors, which we are investigating
-							if (error.body?.detail?.includes('ObjectCacheAppCache')) {
+							if (
+								error.body?.detail?.includes('ObjectCacheAppCache') ||
+								error.body?.detail?.includes('Umbraco.Cms.Infrastructure.Scoping.Scope.DisposeLastScope()')
+							) {
 								headline = 'Please restart the server';
 								message =
 									'The Umbraco object cache is corrupt, but your action may still have been executed. Please restart the server to reset the cache. This is a work in progress.';

--- a/src/packages/core/resources/resource.controller.ts
+++ b/src/packages/core/resources/resource.controller.ts
@@ -97,17 +97,19 @@ export class UmbResourceController extends UmbControllerBase {
 						// Server Error
 
 						if (this.#notificationContext) {
+							let headline = error.body?.title ?? error.name ?? 'Server Error';
 							let message = 'A fatal server error occurred. If this continues, please reach out to your administrator.';
 
 							// Special handling for ObjectCacheAppCache corruption errors, which we are investigating
 							if (error.body?.detail?.includes('ObjectCacheAppCache')) {
+								headline = 'Please restart the server';
 								message =
 									'The Umbraco object cache is corrupt, but your action may still have been executed. Please restart the server to reset the cache. This is a work in progress.';
 							}
 
 							this.#notificationContext.peek('danger', {
 								data: {
-									headline: error.body?.title ?? error.name ?? 'Server Error',
+									headline,
 									message,
 								},
 								...options,

--- a/src/packages/core/resources/resource.controller.ts
+++ b/src/packages/core/resources/resource.controller.ts
@@ -78,7 +78,7 @@ export class UmbResourceController extends UmbControllerBase {
 						console.log('Unauthorized');
 
 						// TODO: Do not remove the token here but instead let whatever is listening to the event decide what to do
-						localStorage.removeItem('tokenResponse');
+						localStorage.removeItem('umb:userAuthTokenResponse');
 
 						// TODO: Show a modal dialog to login either by bubbling an event to UmbAppElement or by showing a modal directly
 						this.#notificationContext?.peek('warning', {

--- a/src/packages/core/resources/resource.controller.ts
+++ b/src/packages/core/resources/resource.controller.ts
@@ -62,7 +62,7 @@ export class UmbResourceController extends UmbControllerBase {
 				// Cancelled - do nothing
 				return {};
 			} else {
-				console.group('UmbResourceController');
+				console.group('ApiError caught in UmbResourceController');
 				console.error('Request failed', error.request);
 				console.error('ProblemDetails', error.body);
 				console.error('Error', error);


### PR DESCRIPTION
There is a bug where the Umbraco object cache becomes corrupted. The solution is to restart the server. We are investigating. While the investigation is ongoing, we would like to catch that error upfront and let the user know they should restart the server, so we have added a few keywords here to catch that.

While I was at it, I added more generic error handling specifically for 500 errors, so any developer can find the complete stack trace in the console while informing the user with a more human-readable message -- the old notification filled up the whole UI before.

To test, create a document type and repeatedly click Save until you start getting 500 errors. The message should inform you to restart your server. You should also see a group of error messages in the console.