### PR TITLE
Route parameters such as `uc:store` are being falsely replaced

### DIFF
--- a/src/packages/core/router/generate-route-path-builder.function.test.ts
+++ b/src/packages/core/router/generate-route-path-builder.function.test.ts
@@ -29,6 +29,11 @@ describe('createRoutePathBuilder', () => {
 		expect(buildPath({ param1: 'value1' })).to.eq('/test/value1/path/value1/');
 	});
 
+	it('should not consider parameters that are not in the params object', () => {
+		const buildPath = createRoutePathBuilder('test/:param1/path/:param2');
+		expect(buildPath({ param1: 'value1' })).to.eq('/test/value1/path/:param2/');
+	});
+
 	it('should support complex objects as parameters with a custom toString method', () => {
 		const buildPath = createRoutePathBuilder('test/:param1/path/:param2');
 		const obj = {

--- a/src/packages/core/router/generate-route-path-builder.function.test.ts
+++ b/src/packages/core/router/generate-route-path-builder.function.test.ts
@@ -8,8 +8,10 @@ describe('createRoutePathBuilder', () => {
 	});
 
 	it('should return a function that builds a route path with parameters', () => {
-		const buildPath = createRoutePathBuilder('test/:param1/path/:param2');
-		expect(buildPath({ param1: 'value1', param2: 'value2' })).to.eq('/test/value1/path/value2/');
+		const buildPath = createRoutePathBuilder(':param0/test/:param1/path/:param2');
+		expect(buildPath({ param0: 'value0', param1: 'value1', param2: 'value2' })).to.eq(
+			'/value0/test/value1/path/value2/',
+		);
 	});
 
 	it('should convert number parameters to strings', () => {

--- a/src/packages/core/router/generate-route-path-builder.function.test.ts
+++ b/src/packages/core/router/generate-route-path-builder.function.test.ts
@@ -1,0 +1,39 @@
+import { expect } from '@open-wc/testing';
+import { createRoutePathBuilder } from './generate-route-path-builder.function.js';
+
+describe('createRoutePathBuilder', () => {
+	it('should return a function that builds a route path without parameters', () => {
+		const buildPath = createRoutePathBuilder('test/path');
+		expect(buildPath(null)).to.eq('/test/path/');
+	});
+
+	it('should return a function that builds a route path with parameters', () => {
+		const buildPath = createRoutePathBuilder('test/:param1/path/:param2');
+		expect(buildPath({ param1: 'value1', param2: 'value2' })).to.eq('/test/value1/path/value2/');
+	});
+
+	it('should convert number parameters to strings', () => {
+		const buildPath = createRoutePathBuilder('test/:param1/path/:param2');
+		expect(buildPath({ param1: 123, param2: 456 })).to.eq('/test/123/path/456/');
+	});
+
+	it('should not consider route segments that resembles parameters as parameters', () => {
+		const buildPath = createRoutePathBuilder('test/uc:store/path');
+		expect(buildPath({ someOtherParam: 'test' })).to.eq('/test/uc:store/path/');
+	});
+
+	it('should support multiple parameters with the same name', () => {
+		const buildPath = createRoutePathBuilder('test/:param1/path/:param1');
+		expect(buildPath({ param1: 'value1' })).to.eq('/test/value1/path/value1/');
+	});
+
+	it('should support complex objects as parameters with a custom toString method', () => {
+		const buildPath = createRoutePathBuilder('test/:param1/path/:param2');
+		const obj = {
+			toString() {
+				return 'value1';
+			},
+		};
+		expect(buildPath({ param1: obj, param2: 'value2' })).to.eq('/test/value1/path/value2/');
+	});
+});

--- a/src/packages/core/router/generate-route-path-builder.function.ts
+++ b/src/packages/core/router/generate-route-path-builder.function.ts
@@ -1,17 +1,18 @@
 /* eslint-disable */
 import { stripSlash } from '@umbraco-cms/backoffice/external/router-slot'; // This must only include the util to avoid side effects of registering the route element.
 
-const PARAM_IDENTIFIER = /:([^\\/]+)/g;
+const PARAM_IDENTIFIER = /\/:([^\/]+)/g;
 
 export function createRoutePathBuilder(path: string) {
-	return (params: { [key: string]: string | number } | null) => {
+	return (params: { [key: string]: string | number | { toString: () => string } } | null) => {
 		return (
 			'/' +
 			stripSlash(
 				params
-					? path.replace(PARAM_IDENTIFIER, (substring: string, ...args: string[]) => {
-							return params[args[0]].toString();
-					  })
+					? path.replace(PARAM_IDENTIFIER, (_substring: string, ...args: string[]) => {
+							// Replace the parameter with the value from the params object or the parameter name if it doesn't exist (args[0] is the parameter name without the colon)
+							return '/' + (typeof params[args[0]] !== 'undefined' ? params[args[0]].toString() : `:${args[0]}`);
+						})
 					: path,
 			) +
 			'/'

--- a/src/packages/core/router/generate-route-path-builder.function.ts
+++ b/src/packages/core/router/generate-route-path-builder.function.ts
@@ -1,7 +1,7 @@
 /* eslint-disable */
 import { stripSlash } from '@umbraco-cms/backoffice/external/router-slot'; // This must only include the util to avoid side effects of registering the route element.
 
-const PARAM_IDENTIFIER = /\/:([^\/]+)/g;
+const PARAM_IDENTIFIER = /:([^\/]+)/g;
 
 export function createRoutePathBuilder(path: string) {
 	return (params: { [key: string]: string | number | { toString: () => string } } | null) => {
@@ -11,7 +11,7 @@ export function createRoutePathBuilder(path: string) {
 				params
 					? path.replace(PARAM_IDENTIFIER, (_substring: string, ...args: string[]) => {
 							// Replace the parameter with the value from the params object or the parameter name if it doesn't exist (args[0] is the parameter name without the colon)
-							return '/' + (typeof params[args[0]] !== 'undefined' ? params[args[0]].toString() : `:${args[0]}`);
+							return typeof params[args[0]] !== 'undefined' ? params[args[0]].toString() : `:${args[0]}`;
 						})
 					: path,
 			) +


### PR DESCRIPTION
Add support for having paramater-like segments of a url that shouldn't be replaced + tests