### PR TITLE
Don't allow reload of data type children

### DIFF
--- a/src/packages/data-type/tree/reload-tree-item-children/manifests.ts
+++ b/src/packages/data-type/tree/reload-tree-item-children/manifests.ts
@@ -1,8 +1,4 @@
-import {
-	UMB_DATA_TYPE_ENTITY_TYPE,
-	UMB_DATA_TYPE_FOLDER_ENTITY_TYPE,
-	UMB_DATA_TYPE_ROOT_ENTITY_TYPE,
-} from '../../entity.js';
+import { UMB_DATA_TYPE_FOLDER_ENTITY_TYPE, UMB_DATA_TYPE_ROOT_ENTITY_TYPE } from '../../entity.js';
 import type { ManifestTypes } from '@umbraco-cms/backoffice/extension-registry';
 
 export const manifests: Array<ManifestTypes> = [
@@ -11,7 +7,7 @@ export const manifests: Array<ManifestTypes> = [
 		kind: 'reloadTreeItemChildren',
 		alias: 'Umb.EntityAction.DataType.Tree.ReloadChildrenOf',
 		name: 'Reload Data Type Tree Item Children Entity Action',
-		forEntityTypes: [UMB_DATA_TYPE_ENTITY_TYPE, UMB_DATA_TYPE_ROOT_ENTITY_TYPE, UMB_DATA_TYPE_FOLDER_ENTITY_TYPE],
+		forEntityTypes: [UMB_DATA_TYPE_ROOT_ENTITY_TYPE, UMB_DATA_TYPE_FOLDER_ENTITY_TYPE],
 		meta: {},
 	},
 ];


### PR DESCRIPTION
It is not possible to reload children of a data type so this PR removes that option.