### PR TITLE
Makes icon search case insensitive

### DIFF
--- a/src/packages/core/modal/common/icon-picker/icon-picker-modal.element.ts
+++ b/src/packages/core/modal/common/icon-picker/icon-picker-modal.element.ts
@@ -26,7 +26,7 @@ export class UmbIconPickerModalElement extends UmbModalBaseElement<UmbIconPicker
 	@state()
 	private _currentAlias = 'text';
 
-	#changeIcon(e: { target: HTMLInputElement; type: any; key: unknown }) {
+	#changeIcon(e: { target: HTMLInputElement; type: string; key: unknown }) {
 		if (e.type == 'click' || (e.type == 'keyup' && e.key == 'Enter')) {
 			this.modalContext?.updateValue({ icon: e.target.id });
 		}
@@ -34,7 +34,9 @@ export class UmbIconPickerModalElement extends UmbModalBaseElement<UmbIconPicker
 
 	#filterIcons(e: { target: HTMLInputElement }) {
 		if (e.target.value) {
-			this._iconListFiltered = this._iconList.filter((icon) => icon.name.includes(e.target.value));
+			this._iconListFiltered = this._iconList.filter((icon) =>
+				icon.name.toLowerCase().includes(e.target.value.toLowerCase()),
+			);
 		} else {
 			this._iconListFiltered = this._iconList;
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Just went to search for an icon and nothing showed up. I realised it was because I searched for "Home" instead of "home".

Figured this should probably be case insensitive (it is in current backoffice).

I also terminated an `: any` ☠️

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

Search for an icon using upper or mixed case characters.

## Screenshots (if appropriate)
![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/7151793/5368c6cd-4fcf-4fe5-acd0-b2c10c5bed55)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
