### PR TITLE
Chore: Remove type from mock models

### DIFF
--- a/src/external/backend-api/src/index.ts
+++ b/src/external/backend-api/src/index.ts
@@ -291,6 +291,7 @@ export type { PagedTagResponseModel } from './models/PagedTagResponseModel';
 export type { PagedTelemetryResponseModel } from './models/PagedTelemetryResponseModel';
 export type { PagedUserGroupResponseModel } from './models/PagedUserGroupResponseModel';
 export type { PagedUserResponseModel } from './models/PagedUserResponseModel';
+export type { PagedWebhookResponseModel } from './models/PagedWebhookResponseModel';
 export type { PartialViewFolderResponseModel } from './models/PartialViewFolderResponseModel';
 export type { PartialViewItemResponseModel } from './models/PartialViewItemResponseModel';
 export type { PartialViewResponseModel } from './models/PartialViewResponseModel';

--- a/src/external/backend-api/src/models/ContentTreeItemResponseModel.ts
+++ b/src/external/backend-api/src/models/ContentTreeItemResponseModel.ts
@@ -6,7 +6,6 @@
 import type { ReferenceByIdModel } from './ReferenceByIdModel';
 
 export type ContentTreeItemResponseModel = {
-    type: string;
     hasChildren: boolean;
     parent?: ReferenceByIdModel | null;
     noAccess: boolean;

--- a/src/external/backend-api/src/models/PagedWebhookResponseModel.ts
+++ b/src/external/backend-api/src/models/PagedWebhookResponseModel.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { WebhookResponseModel } from './WebhookResponseModel';
+
+export type PagedWebhookResponseModel = {
+    total: number;
+    items: Array<WebhookResponseModel>;
+};
+

--- a/src/external/backend-api/src/models/TreeItemPresentationModel.ts
+++ b/src/external/backend-api/src/models/TreeItemPresentationModel.ts
@@ -4,7 +4,6 @@
 /* eslint-disable */
 
 export type TreeItemPresentationModel = {
-    type: string;
     hasChildren: boolean;
 };
 

--- a/src/external/backend-api/src/services/WebhookResource.ts
+++ b/src/external/backend-api/src/services/WebhookResource.ts
@@ -3,6 +3,7 @@
 /* tslint:disable */
 /* eslint-disable */
 import type { CreateWebhookRequestModel } from '../models/CreateWebhookRequestModel';
+import type { PagedWebhookResponseModel } from '../models/PagedWebhookResponseModel';
 import type { UpdateWebhookRequestModel } from '../models/UpdateWebhookRequestModel';
 import type { WebhookItemResponseModel } from '../models/WebhookItemResponseModel';
 import type { WebhookResponseModel } from '../models/WebhookResponseModel';
@@ -12,6 +13,30 @@ import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
 
 export class WebhookResource {
+
+    /**
+     * @returns PagedWebhookResponseModel Success
+     * @throws ApiError
+     */
+    public static getWebhook({
+        skip,
+        take = 100,
+    }: {
+        skip?: number,
+        take?: number,
+    }): CancelablePromise<PagedWebhookResponseModel> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/umbraco/management/api/v1/webhook',
+            query: {
+                'skip': skip,
+                'take': take,
+            },
+            errors: {
+                401: `The resource is protected and requires an authentication token`,
+            },
+        });
+    }
 
     /**
      * @returns string Created

--- a/src/mocks/data/data-type/data-type.data.ts
+++ b/src/mocks/data/data-type/data-type.data.ts
@@ -4,9 +4,7 @@ import type {
 	DataTypeTreeItemResponseModel,
 } from '@umbraco-cms/backoffice/external/backend-api';
 
-type UmbMockDataTypeModelHack = DataTypeResponseModel & DataTypeTreeItemResponseModel & DataTypeItemResponseModel;
-
-export interface UmbMockDataTypeModel extends Omit<UmbMockDataTypeModelHack, 'type'> {}
+export type UmbMockDataTypeModel = DataTypeResponseModel & DataTypeTreeItemResponseModel & DataTypeItemResponseModel;
 
 export const data: Array<UmbMockDataTypeModel> = [
 	{

--- a/src/mocks/data/dictionary/dictionary.data.ts
+++ b/src/mocks/data/dictionary/dictionary.data.ts
@@ -5,12 +5,10 @@ import type {
 	NamedEntityTreeItemResponseModel,
 } from '@umbraco-cms/backoffice/external/backend-api';
 
-type UmbMockDictionaryModelHack = DictionaryItemResponseModel &
+export type UmbMockDictionaryModel = DictionaryItemResponseModel &
 	NamedEntityTreeItemResponseModel &
 	DictionaryItemItemResponseModel &
 	DictionaryOverviewResponseModel;
-
-export interface UmbMockDictionaryModel extends Omit<UmbMockDictionaryModelHack, 'type'> {}
 
 export const data: Array<UmbMockDictionaryModel> = [
 	{

--- a/src/mocks/data/dictionary/dictionary.db.ts
+++ b/src/mocks/data/dictionary/dictionary.db.ts
@@ -38,7 +38,7 @@ export class UmbDictionaryMockDB extends UmbEntityMockDbBase<UmbMockDictionaryMo
 	}
 }
 
-const treeItemMapper = (model: UmbMockDictionaryModel): Omit<NamedEntityTreeItemResponseModel, 'type'> => {
+const treeItemMapper = (model: UmbMockDictionaryModel): NamedEntityTreeItemResponseModel => {
 	return {
 		name: model.name,
 		id: model.id,

--- a/src/mocks/data/document-type/document-type.data.ts
+++ b/src/mocks/data/document-type/document-type.data.ts
@@ -5,11 +5,9 @@ import type {
 	DocumentTypeTreeItemResponseModel,
 } from '@umbraco-cms/backoffice/external/backend-api';
 
-type UmbMockDocumentTypeModelHack = DocumentTypeResponseModel &
+export type UmbMockDocumentTypeModel = DocumentTypeResponseModel &
 	DocumentTypeTreeItemResponseModel &
 	DocumentTypeItemResponseModel;
-
-export interface UmbMockDocumentTypeModel extends Omit<UmbMockDocumentTypeModelHack, 'type'> {}
 
 export const data: Array<UmbMockDocumentTypeModel> = [
 	{

--- a/src/mocks/data/document-type/document-type.db.ts
+++ b/src/mocks/data/document-type/document-type.db.ts
@@ -122,9 +122,7 @@ const documentTypeDetailMapper = (item: UmbMockDocumentTypeModel): DocumentTypeR
 	};
 };
 
-const documentTypeTreeItemMapper = (
-	item: UmbMockDocumentTypeModel,
-): Omit<DocumentTypeTreeItemResponseModel, 'type'> => {
+const documentTypeTreeItemMapper = (item: UmbMockDocumentTypeModel): DocumentTypeTreeItemResponseModel => {
 	return {
 		name: item.name,
 		hasChildren: item.hasChildren,

--- a/src/mocks/data/document/document.data.ts
+++ b/src/mocks/data/document/document.data.ts
@@ -5,9 +5,7 @@ import type {
 } from '@umbraco-cms/backoffice/external/backend-api';
 import { DocumentVariantStateModel } from '@umbraco-cms/backoffice/external/backend-api';
 
-type UmbMockDocumentTypeModelHack = DocumentResponseModel & DocumentTreeItemResponseModel & DocumentItemResponseModel;
-
-export interface UmbMockDocumentModel extends Omit<UmbMockDocumentTypeModelHack, 'type'> {}
+export type UmbMockDocumentModel = DocumentResponseModel & DocumentTreeItemResponseModel & DocumentItemResponseModel;
 
 export const data: Array<UmbMockDocumentModel> = [
 	{

--- a/src/mocks/data/document/document.db.ts
+++ b/src/mocks/data/document/document.db.ts
@@ -41,7 +41,7 @@ export class UmbDocumentMockDB extends UmbEntityMockDbBase<UmbMockDocumentModel>
 	}
 }
 
-const treeItemMapper = (model: UmbMockDocumentModel): Omit<DocumentTreeItemResponseModel, 'type'> => {
+const treeItemMapper = (model: UmbMockDocumentModel): DocumentTreeItemResponseModel => {
 	const documentType = umbDocumentTypeMockDb.read(model.documentType.id);
 	if (!documentType) throw new Error(`Document type with id ${model.documentType.id} not found`);
 

--- a/src/mocks/data/media-type/media-type.data.ts
+++ b/src/mocks/data/media-type/media-type.data.ts
@@ -4,9 +4,9 @@ import type {
 	MediaTypeTreeItemResponseModel,
 } from '@umbraco-cms/backoffice/external/backend-api';
 
-type UmbMockMediaTypeModelHack = MediaTypeResponseModel & MediaTypeTreeItemResponseModel & MediaTypeItemResponseModel;
-
-export interface UmbMockMediaTypeModel extends Omit<UmbMockMediaTypeModelHack, 'type'> {}
+export type UmbMockMediaTypeModel = MediaTypeResponseModel &
+	MediaTypeTreeItemResponseModel &
+	MediaTypeItemResponseModel;
 
 export const data: Array<UmbMockMediaTypeModel> = [
 	{
@@ -91,9 +91,7 @@ export const data: Array<UmbMockMediaTypeModel> = [
 		variesByCulture: false,
 		variesBySegment: false,
 		isElement: false,
-		allowedMediaTypes: [
-			{ mediaType: { id: 'media-type-1-id' }, sortOrder: 0 },
-		],
+		allowedMediaTypes: [{ mediaType: { id: 'media-type-1-id' }, sortOrder: 0 }],
 		compositions: [],
 		isFolder: false,
 		hasChildren: false,

--- a/src/mocks/data/media-type/media-type.db.ts
+++ b/src/mocks/data/media-type/media-type.db.ts
@@ -110,7 +110,7 @@ const mediaTypeDetailMapper = (item: UmbMockMediaTypeModel): MediaTypeResponseMo
 	};
 };
 
-const mediaTypeTreeItemMapper = (item: UmbMockMediaTypeModel): Omit<MediaTypeTreeItemResponseModel, 'type'> => {
+const mediaTypeTreeItemMapper = (item: UmbMockMediaTypeModel): MediaTypeTreeItemResponseModel => {
 	return {
 		name: item.name,
 		hasChildren: item.hasChildren,

--- a/src/mocks/data/media/media.data.ts
+++ b/src/mocks/data/media/media.data.ts
@@ -4,9 +4,7 @@ import type {
 	MediaTreeItemResponseModel,
 } from '@umbraco-cms/backoffice/external/backend-api';
 
-type UmbMockMediaModelHack = MediaResponseModel & MediaTreeItemResponseModel & MediaItemResponseModel;
-
-export interface UmbMockMediaModel extends Omit<UmbMockMediaModelHack, 'type'> {}
+export type UmbMockMediaModel = MediaResponseModel & MediaTreeItemResponseModel & MediaItemResponseModel;
 
 export const data: Array<UmbMockMediaModel> = [
 	{

--- a/src/mocks/data/media/media.db.ts
+++ b/src/mocks/data/media/media.db.ts
@@ -28,7 +28,7 @@ export class UmbMediaMockDB extends UmbEntityMockDbBase<UmbMockMediaModel> {
 	}
 }
 
-const treeItemMapper = (model: UmbMockMediaModel): Omit<MediaTreeItemResponseModel, 'type'> => {
+const treeItemMapper = (model: UmbMockMediaModel): MediaTreeItemResponseModel => {
 	const mediaType = umbMediaTypeMockDb.read(model.mediaType.id);
 	if (!mediaType) throw new Error(`Media type with id ${model.mediaType.id} not found`);
 

--- a/src/mocks/data/partial-view/partial-view.data.ts
+++ b/src/mocks/data/partial-view/partial-view.data.ts
@@ -5,11 +5,9 @@ import type {
 	PartialViewSnippetResponseModel,
 } from '@umbraco-cms/backoffice/external/backend-api';
 
-type UmbMockPartialViewModelHack = PartialViewResponseModel &
+export type UmbMockPartialViewModel = PartialViewResponseModel &
 	FileSystemTreeItemPresentationModel &
 	PartialViewItemResponseModel;
-
-export interface UmbMockPartialViewModel extends Omit<UmbMockPartialViewModelHack, 'type' | 'icon'> {}
 
 export const data: Array<UmbMockPartialViewModel> = [
 	{

--- a/src/mocks/data/relations/relation-type.data.ts
+++ b/src/mocks/data/relations/relation-type.data.ts
@@ -79,7 +79,6 @@ export const treeData: Array<NamedEntityTreeItemResponseModel> = [
 		id: 'e0d39ff5-71d8-453f-b682-9d8d31ee5e06',
 		parent: null,
 		name: 'Relate Document On Copy',
-		type: 'relation-type',
 		hasChildren: false,
 	},
 	{
@@ -87,28 +86,24 @@ export const treeData: Array<NamedEntityTreeItemResponseModel> = [
 
 		parent: null,
 		name: 'Relate Parent Document On Delete',
-		type: 'relation-type',
 		hasChildren: false,
 	},
 	{
 		id: '6f9b800c-762c-42d4-85d9-bf40a77d689e',
 		parent: null,
 		name: 'Relate Parent Media Folder On Delete',
-		type: 'relation-type',
 		hasChildren: false,
 	},
 	{
 		id: 'd421727d-43de-4205-b4c6-037404f309ad',
 		parent: null,
 		name: 'Related Media',
-		type: 'relation-type',
 		hasChildren: false,
 	},
 	{
 		id: 'e9a0a28e-2d5b-4229-ac00-66f2df230513',
 		parent: null,
 		name: 'Related Document',
-		type: 'relation-type',
 		hasChildren: false,
 	},
 ];

--- a/src/mocks/data/script/script.data.ts
+++ b/src/mocks/data/script/script.data.ts
@@ -4,9 +4,7 @@ import type {
 	ScriptResponseModel,
 } from '@umbraco-cms/backoffice/external/backend-api';
 
-type UmbMockScriptModelHack = ScriptResponseModel & FileSystemTreeItemPresentationModel & ScriptItemResponseModel;
-
-export interface UmbMockScriptModel extends Omit<UmbMockScriptModelHack, 'type' | 'icon'> {}
+export type UmbMockScriptModel = ScriptResponseModel & FileSystemTreeItemPresentationModel & ScriptItemResponseModel;
 
 export const data: Array<UmbMockScriptModel> = [
 	{

--- a/src/mocks/data/static-file/static-file.data.ts
+++ b/src/mocks/data/static-file/static-file.data.ts
@@ -3,8 +3,7 @@ import type {
 	StaticFileItemResponseModel,
 } from '@umbraco-cms/backoffice/external/backend-api';
 
-type UmbMockStaticFileModelHack = StaticFileItemResponseModel & FileSystemTreeItemPresentationModel;
-export interface UmbMockStaticFileModel extends Omit<UmbMockStaticFileModelHack, 'type'> {}
+export type UmbMockStaticFileModel = StaticFileItemResponseModel & FileSystemTreeItemPresentationModel;
 
 export const data: Array<UmbMockStaticFileModel> = [
 	{

--- a/src/mocks/data/stylesheet/stylesheet.data.ts
+++ b/src/mocks/data/stylesheet/stylesheet.data.ts
@@ -4,11 +4,9 @@ import type {
 	StylesheetResponseModel,
 } from '@umbraco-cms/backoffice/external/backend-api';
 
-type UmbMockStylesheetModelHack = StylesheetResponseModel &
+export type UmbMockStylesheetModel = StylesheetResponseModel &
 	FileSystemTreeItemPresentationModel &
 	StylesheetItemResponseModel;
-
-export interface UmbMockStylesheetModel extends Omit<UmbMockStylesheetModelHack, 'type' | 'icon'> {}
 
 export const data: Array<UmbMockStylesheetModel> = [
 	{

--- a/src/mocks/data/template/template.data.ts
+++ b/src/mocks/data/template/template.data.ts
@@ -7,9 +7,7 @@ import type {
 } from '@umbraco-cms/backoffice/external/backend-api';
 import { TemplateQueryPropertyTypeModel, OperatorModel } from '@umbraco-cms/backoffice/external/backend-api';
 
-type UmbMockTemplateModelHack = TemplateResponseModel & NamedEntityTreeItemResponseModel & TemplateItemResponseModel;
-
-export interface UmbMockTemplateModel extends Omit<UmbMockTemplateModelHack, 'type'> {}
+export type UmbMockTemplateModel = TemplateResponseModel & NamedEntityTreeItemResponseModel & TemplateItemResponseModel;
 
 export const data: Array<UmbMockTemplateModel> = [
 	{

--- a/src/mocks/data/utils.ts
+++ b/src/mocks/data/utils.ts
@@ -7,7 +7,6 @@ import type {
 export const createEntityTreeItem = (item: any): NamedEntityTreeItemResponseModel => {
 	return {
 		name: item.name,
-		type: item.type,
 		hasChildren: item.hasChildren,
 		id: item.id,
 		parent: item.parent,
@@ -21,7 +20,7 @@ export const folderTreeItemMapper = (item: any): FolderTreeItemResponseModel => 
 	};
 };
 
-export const createFileSystemTreeItem = (item: any): Omit<FileSystemTreeItemPresentationModel, 'type'> => {
+export const createFileSystemTreeItem = (item: any): FileSystemTreeItemPresentationModel => {
 	return {
 		path: item.path,
 		parent: item.parent ?? null,

--- a/src/mocks/data/utils/entity/entity-folder.manager.ts
+++ b/src/mocks/data/utils/entity/entity-folder.manager.ts
@@ -6,7 +6,7 @@ import type {
 	UpdateFolderResponseModel,
 } from '@umbraco-cms/backoffice/external/backend-api';
 
-export class UmbMockEntityFolderManager<MockItemType extends Omit<FolderTreeItemResponseModel, 'type'>> {
+export class UmbMockEntityFolderManager<MockItemType extends FolderTreeItemResponseModel> {
 	#db: UmbEntityMockDbBase<MockItemType>;
 	#createMockFolderMapper: (request: CreateFolderRequestModel) => MockItemType;
 

--- a/src/mocks/data/utils/entity/entity-recycle-bin.ts
+++ b/src/mocks/data/utils/entity/entity-recycle-bin.ts
@@ -2,9 +2,7 @@ import { UmbEntityMockDbBase } from './entity-base.js';
 import { UmbMockEntityTreeManager } from './entity-tree.manager.js';
 import type { ContentTreeItemResponseModel } from '@umbraco-cms/backoffice/external/backend-api';
 
-export class UmbEntityRecycleBin<
-	MockType extends Omit<ContentTreeItemResponseModel, 'type'>,
-> extends UmbEntityMockDbBase<MockType> {
+export class UmbEntityRecycleBin<MockType extends ContentTreeItemResponseModel> extends UmbEntityMockDbBase<MockType> {
 	tree;
 
 	constructor(data: Array<MockType>, treeItemMapper: (model: MockType) => any) {

--- a/src/mocks/data/utils/entity/entity-tree.manager.ts
+++ b/src/mocks/data/utils/entity/entity-tree.manager.ts
@@ -3,7 +3,7 @@ import type { UmbEntityMockDbBase } from './entity-base.js';
 import { UmbId } from '@umbraco-cms/backoffice/id';
 import type { EntityTreeItemResponseModel } from '@umbraco-cms/backoffice/external/backend-api';
 
-export class UmbMockEntityTreeManager<T extends Omit<EntityTreeItemResponseModel, 'type'>> {
+export class UmbMockEntityTreeManager<T extends EntityTreeItemResponseModel> {
 	#db: UmbEntityMockDbBase<T>;
 	#treeItemMapper: (item: T) => any;
 

--- a/src/mocks/data/utils/file-system/file-system-tree.manager.ts
+++ b/src/mocks/data/utils/file-system/file-system-tree.manager.ts
@@ -3,7 +3,7 @@ import { createFileSystemTreeItem } from '../../utils.js';
 import { pagedResult } from '../paged-result.js';
 import type { FileSystemTreeItemPresentationModel } from '@umbraco-cms/backoffice/external/backend-api';
 
-export class UmbMockFileSystemTreeManager<T extends Omit<FileSystemTreeItemPresentationModel, 'type'>> {
+export class UmbMockFileSystemTreeManager<T extends FileSystemTreeItemPresentationModel> {
 	#db: UmbMockDBBase<T>;
 
 	constructor(mockDb: UmbMockDBBase<T>) {
@@ -11,7 +11,7 @@ export class UmbMockFileSystemTreeManager<T extends Omit<FileSystemTreeItemPrese
 	}
 
 	getRoot({ skip = 0, take = 100 }: { skip?: number; take?: number } = {}): {
-		items: Array<Omit<FileSystemTreeItemPresentationModel, 'type'>>;
+		items: Array<FileSystemTreeItemPresentationModel>;
 		total: number;
 	} {
 		const items = this.#db.getAll().filter((item) => item.parent === null);
@@ -19,7 +19,7 @@ export class UmbMockFileSystemTreeManager<T extends Omit<FileSystemTreeItemPrese
 	}
 
 	getChildrenOf({ parentPath, skip = 0, take = 100 }: { parentPath: string; skip?: number; take?: number }): {
-		items: Array<Omit<FileSystemTreeItemPresentationModel, 'type'>>;
+		items: Array<FileSystemTreeItemPresentationModel>;
 		total: number;
 	} {
 		const items = this.#db.getAll().filter((item) => item.parent?.path === parentPath);


### PR DESCRIPTION
The type field has been moved from the server models. This PR cleans up our mocks models, so we don't have to omit it from the server model.

Merges together with: https://github.com/umbraco/Umbraco-CMS/pull/15862