### PR TITLE
Bugfix/media types

### DIFF
--- a/src/packages/media/media-types/repository/detail/media-type-detail.server.data-source.ts
+++ b/src/packages/media/media-types/repository/detail/media-type-detail.server.data-source.ts
@@ -42,7 +42,7 @@ export class UmbMediaTypeServerDataSource implements UmbDetailDataSource<UmbMedi
 			name: '',
 			alias: '',
 			description: '',
-			icon: '',
+			icon: 'icon-picture',
 			allowedAtRoot: false,
 			variesByCulture: false,
 			variesBySegment: false,

--- a/src/packages/media/media-types/workspace/views/design/media-type-workspace-view-edit-tab.element.ts
+++ b/src/packages/media/media-types/workspace/views/design/media-type-workspace-view-edit-tab.element.ts
@@ -209,8 +209,7 @@ export class UmbMediaTypeWorkspaceViewEditTabElement extends UmbLitElement {
 						label=${this.localize.term('contentTypeEditor_addGroup')}
 						id="add"
 						look="placeholder"
-						@click=${this.#onAddGroup}>
-				  </uui-button>`
+						@click=${this.#onAddGroup}></uui-button>`
 				: ''}
 		`;
 	}


### PR DESCRIPTION
Adds icon in scaffolding to prevent errors when saving a new media type.
Removes empty space to allow label to be shown