### PR TITLE
Refactor: Dynamic Root modals

### DIFF
--- a/src/packages/documents/documents/components/input-document-root-picker/input-document-root-picker.element.ts
+++ b/src/packages/documents/documents/components/input-document-root-picker/input-document-root-picker.element.ts
@@ -87,7 +87,9 @@ export class UmbInputDocumentRootPickerElement extends FormControlMixin(UmbLitEl
 	});
 
 	#openDynamicRootOriginPicker() {
-		this.#openModal = this.#modalContext?.open(this, UMB_DYNAMIC_ROOT_ORIGIN_PICKER_MODAL, {});
+		this.#openModal = this.#modalContext?.open(this, UMB_DYNAMIC_ROOT_ORIGIN_PICKER_MODAL, {
+			data: { items: this._originManifests },
+		});
 		this.#openModal?.onSubmit().then((data: UmbTreePickerDynamicRoot) => {
 			const existingData = { ...this.data };
 			existingData.originKey = undefined;
@@ -98,7 +100,9 @@ export class UmbInputDocumentRootPickerElement extends FormControlMixin(UmbLitEl
 	}
 
 	#openDynamicRootQueryStepPicker() {
-		this.#openModal = this.#modalContext?.open(this, UMB_DYNAMIC_ROOT_QUERY_STEP_PICKER_MODAL, {});
+		this.#openModal = this.#modalContext?.open(this, UMB_DYNAMIC_ROOT_QUERY_STEP_PICKER_MODAL, {
+			data: { items: this._queryStepManifests },
+		});
 		this.#openModal?.onSubmit().then((step) => {
 			if (this.data) {
 				const querySteps = [...(this.data.querySteps ?? []), step];

--- a/src/packages/dynamic-root/modals/dynamic-root-origin-picker-modal.element.ts
+++ b/src/packages/dynamic-root/modals/dynamic-root-origin-picker-modal.element.ts
@@ -1,12 +1,12 @@
 import { UmbDocumentPickerContext } from '../../documents/documents/components/input-document/input-document.context.js';
+import type { UmbDynamicRootOriginModalData } from './index.js';
 import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 import { css, html, customElement, state, ifDefined, repeat } from '@umbraco-cms/backoffice/external/lit';
-import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import type { ManifestDynamicRootOrigin } from '@umbraco-cms/backoffice/extension-registry';
 import type { UmbTreePickerDynamicRoot } from '@umbraco-cms/backoffice/components';
 
 @customElement('umb-dynamic-root-origin-picker-modal')
-export class UmbDynamicRootOriginPickerModalModalElement extends UmbModalBaseElement {
+export class UmbDynamicRootOriginPickerModalModalElement extends UmbModalBaseElement<UmbDynamicRootOriginModalData> {
 	@state()
 	private _origins: Array<ManifestDynamicRootOrigin> = [];
 
@@ -16,10 +16,14 @@ export class UmbDynamicRootOriginPickerModalModalElement extends UmbModalBaseEle
 		super();
 
 		this.#documentPickerContext.max = 1;
+	}
 
-		this.observe(umbExtensionsRegistry.byType('dynamicRootOrigin'), (origins: Array<ManifestDynamicRootOrigin>) => {
-			this._origins = origins;
-		});
+	connectedCallback() {
+		super.connectedCallback();
+
+		if (this.data) {
+			this._origins = this.data.items;
+		}
 	}
 
 	#choose(item: ManifestDynamicRootOrigin) {

--- a/src/packages/dynamic-root/modals/dynamic-root-query-step-picker-modal.element.ts
+++ b/src/packages/dynamic-root/modals/dynamic-root-query-step-picker-modal.element.ts
@@ -1,28 +1,25 @@
 import { UmbDocumentTypePickerContext } from '../../documents/document-types/components/input-document-type/input-document-type.context.js';
+import type { UmbDynamicRootQueryStepModalData } from './index.js';
 import { UmbId } from '@umbraco-cms/backoffice/id';
 import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { css, html, customElement, state, ifDefined, repeat } from '@umbraco-cms/backoffice/external/lit';
-import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import type { UmbTreePickerDynamicRootQueryStep } from '@umbraco-cms/backoffice/components';
 import type { ManifestDynamicRootQueryStep } from '@umbraco-cms/backoffice/extension-registry';
 
 @customElement('umb-dynamic-root-query-step-picker-modal')
-export class UmbDynamicRootQueryStepPickerModalModalElement extends UmbModalBaseElement {
+export class UmbDynamicRootQueryStepPickerModalModalElement extends UmbModalBaseElement<UmbDynamicRootQueryStepModalData> {
 	@state()
 	private _querySteps: Array<ManifestDynamicRootQueryStep> = [];
 
 	#documentTypePickerContext = new UmbDocumentTypePickerContext(this);
 
-	constructor() {
-		super();
+	connectedCallback() {
+		super.connectedCallback();
 
-		this.observe(
-			umbExtensionsRegistry.byType('dynamicRootQueryStep'),
-			(querySteps: Array<ManifestDynamicRootQueryStep>) => {
-				this._querySteps = querySteps;
-			},
-		);
+		if (this.data) {
+			this._querySteps = this.data.items;
+		}
 	}
 
 	#choose(item: ManifestDynamicRootQueryStep) {

--- a/src/packages/dynamic-root/modals/index.ts
+++ b/src/packages/dynamic-root/modals/index.ts
@@ -2,16 +2,31 @@ import {
 	UMB_DYNAMIC_ROOT_ORIGIN_PICKER_MODAL_ALIAS,
 	UMB_DYNAMIC_ROOT_QUERY_STEP_PICKER_MODAL_ALIAS,
 } from './manifests.js';
+import type {
+	ManifestDynamicRootOrigin,
+	ManifestDynamicRootQueryStep,
+} from '@umbraco-cms/backoffice/extension-registry';
 import { UmbModalToken } from '@umbraco-cms/backoffice/modal';
 
-export const UMB_DYNAMIC_ROOT_ORIGIN_PICKER_MODAL = new UmbModalToken(UMB_DYNAMIC_ROOT_ORIGIN_PICKER_MODAL_ALIAS, {
-	modal: {
-		type: 'sidebar',
-		size: 'small',
-	},
-});
+export interface UmbDynamicRootOriginModalData {
+	items: Array<ManifestDynamicRootOrigin>;
+}
 
-export const UMB_DYNAMIC_ROOT_QUERY_STEP_PICKER_MODAL = new UmbModalToken(
+export interface UmbDynamicRootQueryStepModalData {
+	items: Array<ManifestDynamicRootQueryStep>;
+}
+
+export const UMB_DYNAMIC_ROOT_ORIGIN_PICKER_MODAL = new UmbModalToken<UmbDynamicRootOriginModalData>(
+	UMB_DYNAMIC_ROOT_ORIGIN_PICKER_MODAL_ALIAS,
+	{
+		modal: {
+			type: 'sidebar',
+			size: 'small',
+		},
+	},
+);
+
+export const UMB_DYNAMIC_ROOT_QUERY_STEP_PICKER_MODAL = new UmbModalToken<UmbDynamicRootQueryStepModalData>(
 	UMB_DYNAMIC_ROOT_QUERY_STEP_PICKER_MODAL_ALIAS,
 	{
 		modal: {

--- a/src/packages/dynamic-root/modals/manifests.ts
+++ b/src/packages/dynamic-root/modals/manifests.ts
@@ -12,13 +12,13 @@ const modals: Array<ManifestModal> = [
 		type: 'modal',
 		alias: UMB_DYNAMIC_ROOT_ORIGIN_PICKER_MODAL_ALIAS,
 		name: 'Choose an origin',
-		js: () => import('./dynamic-root-origin-picker-modal.element.js'),
+		element: () => import('./dynamic-root-origin-picker-modal.element.js'),
 	},
 	{
 		type: 'modal',
 		alias: UMB_DYNAMIC_ROOT_QUERY_STEP_PICKER_MODAL_ALIAS,
 		name: 'Append step to query',
-		js: () => import('./dynamic-root-query-step-picker-modal.element.js'),
+		element: () => import('./dynamic-root-query-step-picker-modal.element.js'),
 	},
 ];
 


### PR DESCRIPTION
Refactored the modals for the Dynamic Root Origin picker and Query Step picker, as they were performing an extra call to the `umbExtensionsRegistry` to re-get the associated manifests.