### PR TITLE
Feature: Content Type Property Picker

### DIFF
--- a/src/packages/core/components/index.ts
+++ b/src/packages/core/components/index.ts
@@ -15,6 +15,7 @@ export * from './history/index.js';
 export * from './icon/index.js';
 export * from './input-collection-configuration/index.js';
 export * from './input-color/index.js';
+export * from './input-content-type-property/index.js';
 export * from './input-date/index.js';
 export * from './input-dropdown/index.js';
 export * from './input-eye-dropper/index.js';

--- a/src/packages/core/components/input-content-type-property/index.ts
+++ b/src/packages/core/components/input-content-type-property/index.ts
@@ -1,0 +1,1 @@
+export * from './input-content-type-property.element.js';

--- a/src/packages/core/components/input-content-type-property/input-content-type-property.element.ts
+++ b/src/packages/core/components/input-content-type-property/input-content-type-property.element.ts
@@ -1,0 +1,277 @@
+import { UmbDocumentTypePickerContext } from '../../../documents/document-types/components/input-document-type/input-document-type.context.js';
+import { UmbMediaTypePickerContext } from '../../../media/media-types/components/input-media-type/input-media-type.context.js';
+import { UmbMemberTypePickerContext } from '../../../members/member-type/components/input-member-type/input-member-type.context.js';
+import { html, customElement, property, css } from '@umbraco-cms/backoffice/external/lit';
+import { FormControlMixin } from '@umbraco-cms/backoffice/external/uui';
+import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { UmbDocumentTypeDetailRepository } from '@umbraco-cms/backoffice/document-type';
+import { UmbMediaTypeDetailRepository } from '@umbraco-cms/backoffice/media-type';
+import { UmbMemberTypeDetailRepository } from '@umbraco-cms/backoffice/member-type';
+import { UMB_ITEM_PICKER_MODAL, UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
+import type { UmbContentTypeModel } from '@umbraco-cms/backoffice/content-type';
+import type { UmbDetailRepositoryBase } from '@umbraco-cms/backoffice/repository';
+import type { UmbItemPickerModel } from '@umbraco-cms/backoffice/modal';
+import type { UmbPickerInputContext } from '@umbraco-cms/backoffice/picker-input';
+
+export type UmbContentTypePropertyValue = {
+	label: string;
+	alias: string;
+	isSystem: boolean;
+};
+
+type UmbInputContentTypePropertyConfigurationItem = {
+	item: UmbItemPickerModel;
+	pickerContext(): UmbPickerInputContext<any>;
+	pickableFilter?(item: any): boolean;
+	repository(): UmbDetailRepositoryBase<any>;
+	systemProperties?: Array<UmbItemPickerModel>;
+};
+
+type UmbInputContentTypePropertyConfiguration = {
+	documentTypes: UmbInputContentTypePropertyConfigurationItem;
+	elementTypes: UmbInputContentTypePropertyConfigurationItem;
+	mediaTypes: UmbInputContentTypePropertyConfigurationItem;
+	memberTypes: UmbInputContentTypePropertyConfigurationItem;
+};
+
+@customElement('umb-input-content-type-property')
+export class UmbInputContentTypePropertyElement extends FormControlMixin(UmbLitElement) {
+	#configuration: UmbInputContentTypePropertyConfiguration = {
+		documentTypes: {
+			item: {
+				label: this.localize.term('content_documentType'),
+				description: this.localize.term('defaultdialogs_selectContentType'),
+				value: 'documentTypes',
+			},
+			pickerContext: () => new UmbDocumentTypePickerContext(this),
+			pickableFilter: (docType) => !docType.isElement,
+			repository: () => new UmbDocumentTypeDetailRepository(this),
+			systemProperties: [
+				{
+					label: this.localize.term('content_documentType'),
+					description: 'contentTypeAlias',
+					value: 'contentTypeAlias',
+				},
+				{ label: this.localize.term('content_createDate'), description: 'createDate', value: 'createDate' },
+				{ label: this.localize.term('content_createBy'), description: 'owner', value: 'owner' },
+				{ label: this.localize.term('content_isPublished'), description: 'published', value: 'published' },
+				{ label: this.localize.term('general_sort'), description: 'sortOrder', value: 'sortOrder' },
+				{ label: this.localize.term('content_updateDate'), description: 'updateDate', value: 'updateDate' },
+				{ label: this.localize.term('content_updatedBy'), description: 'updater', value: 'updater' },
+			],
+		},
+		elementTypes: {
+			item: {
+				label: this.localize.term('create_elementType'),
+				description: this.localize.term('content_nestedContentSelectElementTypeModalTitle'),
+				value: 'elementTypes',
+			},
+			pickerContext: () => new UmbDocumentTypePickerContext(this),
+			pickableFilter: (docType) => docType.isElement,
+			repository: () => new UmbDocumentTypeDetailRepository(this),
+			systemProperties: [
+				{
+					label: this.localize.term('content_documentType'),
+					description: 'contentTypeAlias',
+					value: 'contentTypeAlias',
+				},
+			],
+		},
+		mediaTypes: {
+			item: {
+				label: this.localize.term('content_mediatype'),
+				description: this.localize.term('defaultdialogs_selectMediaType'),
+				value: 'mediaTypes',
+			},
+			pickerContext: () => new UmbMediaTypePickerContext(this),
+			repository: () => new UmbMediaTypeDetailRepository(this),
+			systemProperties: [
+				{
+					label: this.localize.term('content_documentType'),
+					description: 'contentTypeAlias',
+					value: 'contentTypeAlias',
+				},
+				{ label: this.localize.term('content_createDate'), description: 'createDate', value: 'createDate' },
+				{ label: this.localize.term('content_createBy'), description: 'owner', value: 'owner' },
+				{ label: this.localize.term('general_sort'), description: 'sortOrder', value: 'sortOrder' },
+				{ label: this.localize.term('content_updateDate'), description: 'updateDate', value: 'updateDate' },
+				{ label: this.localize.term('content_updatedBy'), description: 'updater', value: 'updater' },
+			],
+		},
+		memberTypes: {
+			item: {
+				label: this.localize.term('content_membertype'),
+				description: this.localize.term('defaultdialogs_selectMemberType'),
+				value: 'memberTypes',
+			},
+			pickerContext: () => new UmbMemberTypePickerContext(this),
+			repository: () => new UmbMemberTypeDetailRepository(this),
+			systemProperties: [
+				{
+					label: this.localize.term('content_documentType'),
+					description: 'contentTypeAlias',
+					value: 'contentTypeAlias',
+				},
+				{ label: this.localize.term('content_createDate'), description: 'createDate', value: 'createDate' },
+				{ label: this.localize.term('general_email'), description: 'email', value: 'email' },
+				{ label: this.localize.term('content_updateDate'), description: 'updateDate', value: 'updateDate' },
+				{ label: this.localize.term('general_username'), description: 'username', value: 'username' },
+			],
+		},
+	};
+
+	#modalManager?: typeof UMB_MODAL_MANAGER_CONTEXT.TYPE;
+
+	protected getFormElement() {
+		return undefined;
+	}
+
+	public selectedProperty?: UmbContentTypePropertyValue;
+
+	@property({ type: Boolean, attribute: 'document-types' })
+	public documentTypes: boolean = false;
+
+	@property({ type: Boolean, attribute: 'element-types' })
+	public elementTypes: boolean = false;
+
+	@property({ type: Boolean, attribute: 'media-types' })
+	public mediaTypes: boolean = false;
+
+	@property({ type: Boolean, attribute: 'member-types' })
+	public memberTypes: boolean = false;
+
+	constructor() {
+		super();
+
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (modalManager) => {
+			this.#modalManager = modalManager;
+		});
+	}
+
+	async #onClick() {
+		const items: Array<UmbItemPickerModel> = [];
+
+		if (this.documentTypes) {
+			items.push(this.#configuration['documentTypes'].item);
+		}
+
+		if (this.elementTypes) {
+			items.push(this.#configuration['elementTypes'].item);
+		}
+
+		if (this.mediaTypes) {
+			items.push(this.#configuration['mediaTypes'].item);
+		}
+
+		if (this.memberTypes) {
+			items.push(this.#configuration['memberTypes'].item);
+		}
+
+		if (items.length === 1) {
+			// If there is only one item, we can skip the modal and go directly to the picker.
+			this.#openContentTypePicker(items[0].value as keyof UmbInputContentTypePropertyConfiguration);
+			return;
+		}
+
+		if (!this.#modalManager) return;
+
+		const modalContext = this.#modalManager.open(this, UMB_ITEM_PICKER_MODAL, {
+			data: {
+				headline: this.localize.term('defaultdialogs_selectContentType'),
+				items: items,
+			},
+		});
+
+		const modalValue = await modalContext.onSubmit();
+
+		if (!modalValue) return;
+
+		const configKey = modalValue.value as keyof UmbInputContentTypePropertyConfiguration;
+		this.#openContentTypePicker(configKey);
+	}
+
+	async #openContentTypePicker(configKey: keyof UmbInputContentTypePropertyConfiguration) {
+		const config = this.#configuration[configKey];
+		if (!config) return;
+
+		const pickerContext = config.pickerContext();
+
+		pickerContext.max = 1;
+
+		await pickerContext.openPicker({
+			hideTreeRoot: true,
+			multiple: false,
+			pickableFilter: config.pickableFilter,
+		});
+
+		const selectedItems = pickerContext.getSelection();
+		if (selectedItems.length === 0) return;
+
+		const repository = config.repository();
+		const { data } = await repository.requestByUnique(selectedItems[0]);
+
+		if (!data) return;
+
+		this.#openPropertyPicker(data, config.systemProperties);
+	}
+
+	async #openPropertyPicker(contentType?: UmbContentTypeModel, systemProperties?: Array<UmbItemPickerModel>) {
+		if (!contentType) return;
+		if (!this.#modalManager) return;
+
+		const properties: Array<UmbItemPickerModel> =
+			contentType?.properties.map((property) => ({
+				label: property.name,
+				value: property.alias,
+				description: property.alias,
+			})) ?? [];
+
+		const items = [...(systemProperties ?? []), ...properties];
+
+		const modalContext = this.#modalManager.open(this, UMB_ITEM_PICKER_MODAL, {
+			data: {
+				headline: `Select a property from ${contentType.name}`,
+				items: items,
+			},
+		});
+
+		const modalValue = await modalContext.onSubmit();
+
+		if (!modalValue) return;
+
+		this.selectedProperty = {
+			label: modalValue.label,
+			alias: modalValue.value,
+			isSystem: systemProperties?.some((property) => property.value === modalValue.value) ?? false,
+		};
+
+		this.dispatchEvent(new UmbChangeEvent());
+	}
+
+	render() {
+		return html`<uui-button
+			label=${this.localize.term('general_choose')}
+			look="placeholder"
+			color="default"
+			@click=${this.#onClick}></uui-button>`;
+	}
+
+	static styles = [
+		css`
+			:host {
+				display: flex;
+				flex-direction: column;
+				gap: var(--uui-size-space-1);
+			}
+		`,
+	];
+}
+
+export default UmbInputContentTypePropertyElement;
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-input-content-type-property': UmbInputContentTypePropertyElement;
+	}
+}

--- a/src/packages/core/modal/common/item-picker/item-picker-modal.element.ts
+++ b/src/packages/core/modal/common/item-picker/item-picker-modal.element.ts
@@ -1,0 +1,80 @@
+import { css, html, customElement, repeat, nothing, when } from '@umbraco-cms/backoffice/external/lit';
+import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
+import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
+import type { UmbItemPickerModalData, UmbItemPickerModel } from '@umbraco-cms/backoffice/modal';
+
+@customElement('umb-item-picker-modal')
+export class UmbItemPickerModalElement extends UmbModalBaseElement<UmbItemPickerModalData, UmbItemPickerModel> {
+	#close() {
+		this.modalContext?.reject();
+	}
+
+	#submit(item: UmbItemPickerModel) {
+		this.modalContext?.setValue(item);
+		this.modalContext?.submit();
+	}
+
+	render() {
+		if (!this.data) return nothing;
+		const items = this.data.items;
+		return html`
+			<umb-body-layout headline=${this.data.headline}>
+				<div>
+					${when(
+						items.length,
+						() => html`
+							<uui-box>
+								${repeat(
+									items,
+									(item) => item.value,
+									(item) => html`
+										<uui-button @click=${() => this.#submit(item)} look="placeholder" label="${item.label}">
+											<h4>${item.label}</h4>
+											<p>${item.description}</p>
+										</uui-button>
+									`,
+								)}
+							</uui-box>
+						`,
+						() => html`<p>There are no items to select.</p>`,
+					)}
+				</div>
+				<div slot="actions">
+					<uui-button @click=${this.#close} label="${this.localize.term('general_close')}"></uui-button>
+				</div>
+			</umb-body-layout>
+		`;
+	}
+
+	static styles = [
+		UmbTextStyles,
+		css`
+			uui-box > uui-button {
+				display: block;
+				--uui-button-content-align: flex-start;
+			}
+
+			uui-box > uui-button:not(:last-of-type) {
+				margin-bottom: var(--uui-size-space-5);
+			}
+
+			h4 {
+				text-align: left;
+				margin: 0.5rem 0;
+			}
+
+			p {
+				text-align: left;
+				margin: 0 0 0.5rem 0;
+			}
+		`,
+	];
+}
+
+export default UmbItemPickerModalElement;
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-item-picker-modal': UmbItemPickerModalElement;
+	}
+}

--- a/src/packages/core/modal/common/manifests.ts
+++ b/src/packages/core/modal/common/manifests.ts
@@ -37,6 +37,12 @@ const modals: Array<ManifestModal> = [
 		name: 'Embedded Media Modal',
 		js: () => import('./embedded-media/embedded-media-modal.element.js'),
 	},
+	{
+		type: 'modal',
+		alias: 'Umb.Modal.ItemPicker',
+		name: 'Item Picker Modal',
+		element: () => import('./item-picker/item-picker-modal.element.js'),
+	},
 ];
 
 export const manifests = [...modals];

--- a/src/packages/core/modal/token/index.ts
+++ b/src/packages/core/modal/token/index.ts
@@ -6,6 +6,7 @@ export * from './embedded-media-modal.token.js';
 export * from './entity-user-permission-settings-modal.token.js';
 export * from './examine-fields-settings-modal.token.js';
 export * from './icon-picker-modal.token.js';
+export * from './item-picker-modal.token.js';
 export * from './link-picker-modal.token.js';
 export * from './media-tree-picker-modal.token.js';
 export * from './media-type-picker-modal.token.js';

--- a/src/packages/core/modal/token/item-picker-modal.token.ts
+++ b/src/packages/core/modal/token/item-picker-modal.token.ts
@@ -1,0 +1,22 @@
+import { UmbModalToken } from './modal-token.js';
+
+export type UmbItemPickerModalData = {
+	headline: string;
+	items: Array<UmbItemPickerModel>;
+};
+
+export type UmbItemPickerModel = {
+	label: string;
+	description?: string;
+	value: string;
+};
+
+export const UMB_ITEM_PICKER_MODAL = new UmbModalToken<UmbItemPickerModalData, UmbItemPickerModel>(
+	'Umb.Modal.ItemPicker',
+	{
+		modal: {
+			type: 'sidebar',
+			size: 'small',
+		},
+	},
+);


### PR DESCRIPTION
For the Collections data-type configuration, when adding a column to the Collection View we needed a way to pick a property from a Document Type or Media Type (and also potentially Element Types and Member Types).

For the Template editor, we have the `<umb-field-dropdown-list>` component, but I wanted to explore an alternative flow for selecting a content-type, then be presented the list of properties (both system fields and user-defined properties) in a modal.

To achieve this I have introduced an **"Item Picker" modal**, _(for want of a better name),_ which will let us reuse a modal with lists of different items.  @nielslyngsoe may wish to give this a sanity check.

This PR doesn't make many changes to the `<umb-property-editor-ui-collection-view-column-configuration>` component, that'll come in a follow up PR.