### PR TITLE
Bugfix: change app language in dropdown

### DIFF
--- a/src/packages/language/app-language-select/app-language-select.element.ts
+++ b/src/packages/language/app-language-select/app-language-select.element.ts
@@ -97,7 +97,7 @@ export class UmbAppLanguageSelectElement extends UmbLitElement {
 						<uui-menu-item
 							label=${ifDefined(language.name)}
 							@click-label=${this.#onLabelClick}
-							data-iso-code=${ifDefined(language.unique)}
+							data-unique=${ifDefined(language.unique)}
 							?active=${language.unique === this._appLanguage?.unique}></uui-menu-item>
 					`,
 				)}


### PR DESCRIPTION
Update the data attribute to use unique instead of iso code.

It is now possible to select a language in the app language dropdown.