### PR TITLE
Feature/publish with descendants

### DIFF
--- a/src/packages/documents/documents/modals/index.ts
+++ b/src/packages/documents/documents/modals/index.ts
@@ -1,4 +1,5 @@
 export * from './publish-modal/index.js';
+export * from './publish-with-descendants-modal/index.js';
 export * from './save-modal/index.js';
 export * from './unpublish-modal/index.js';
 export * from './schedule-modal/index.js';

--- a/src/packages/documents/documents/modals/manifests.ts
+++ b/src/packages/documents/documents/modals/manifests.ts
@@ -4,6 +4,7 @@ export const UMB_DOCUMENT_SAVE_MODAL_ALIAS = 'Umb.Modal.DocumentSave';
 export const UMB_DOCUMENT_PUBLISH_MODAL_ALIAS = 'Umb.Modal.DocumentPublish';
 export const UMB_DOCUMENT_UNPUBLISH_MODAL_ALIAS = 'Umb.Modal.DocumentUnpublish';
 export const UMB_DOCUMENT_SCHEDULE_MODAL_ALIAS = 'Umb.Modal.DocumentSchedule';
+export const UMB_DOCUMENT_PUBLISH_WITH_DESCENDANTS_MODAL_ALIAS = 'Umb.Modal.DocumentPublishWithDescendants';
 
 const modals: Array<ManifestModal> = [
 	{
@@ -29,6 +30,12 @@ const modals: Array<ManifestModal> = [
 		alias: UMB_DOCUMENT_SCHEDULE_MODAL_ALIAS,
 		name: 'Document Schedule Modal',
 		js: () => import('./schedule-modal/document-schedule-modal.element.js'),
+	},
+	{
+		type: 'modal',
+		alias: UMB_DOCUMENT_PUBLISH_WITH_DESCENDANTS_MODAL_ALIAS,
+		name: 'Document Publish With Descendants Modal',
+		js: () => import('./publish-with-descendants-modal/document-publish-with-descendants-modal.element.js'),
 	},
 ];
 

--- a/src/packages/documents/documents/modals/publish-with-descendants-modal/document-publish-with-descendants-modal.element.ts
+++ b/src/packages/documents/documents/modals/publish-with-descendants-modal/document-publish-with-descendants-modal.element.ts
@@ -16,6 +16,7 @@ export class UmbDocumentPublishWithDescendantsModalElement extends UmbModalBaseE
 	UmbDocumentPublishWithDescendantsModalValue
 > {
 	#selectionManager = new UmbSelectionManager<string>(this);
+	#includeUnpublishedDescendants = false;
 
 	@state()
 	_options: Array<UmbDocumentVariantOptionModel> = [];
@@ -50,7 +51,10 @@ export class UmbDocumentPublishWithDescendantsModalElement extends UmbModalBaseE
 	}
 
 	#submit() {
-		this.value = { ...this.value, selection: this.#selectionManager.getSelection() };
+		this.value = {
+			selection: this.#selectionManager.getSelection(),
+			includeUnpublishedDescendants: this.#includeUnpublishedDescendants,
+		};
 		this.modalContext?.submit();
 	}
 
@@ -85,8 +89,7 @@ export class UmbDocumentPublishWithDescendantsModalElement extends UmbModalBaseE
 					id="includeUnpublishedDescendants"
 					label=${this.localize.term('content_includeUnpublished')}
 					?checked=${this.value?.includeUnpublishedDescendants}
-					@change=${() =>
-						(this.value.includeUnpublishedDescendants = !this.value.includeUnpublishedDescendants)}></uui-toggle>
+					@change=${() => (this.#includeUnpublishedDescendants = !this.#includeUnpublishedDescendants)}></uui-toggle>
 			</uui-form-layout-item>
 
 			<div slot="actions">

--- a/src/packages/documents/documents/modals/publish-with-descendants-modal/document-publish-with-descendants-modal.element.ts
+++ b/src/packages/documents/documents/modals/publish-with-descendants-modal/document-publish-with-descendants-modal.element.ts
@@ -1,0 +1,121 @@
+import { UmbDocumentVariantState, type UmbDocumentVariantOptionModel } from '../../types.js';
+import type {
+	UmbDocumentPublishWithDescendantsModalData,
+	UmbDocumentPublishWithDescendantsModalValue,
+} from './document-publish-with-descendants-modal.token.js';
+import { css, customElement, html, state } from '@umbraco-cms/backoffice/external/lit';
+import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
+import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
+import { UmbSelectionManager } from '@umbraco-cms/backoffice/utils';
+
+import '../shared/document-variant-language-picker.element.js';
+
+@customElement('umb-document-publish-with-descendants-modal')
+export class UmbDocumentPublishWithDescendantsModalElement extends UmbModalBaseElement<
+	UmbDocumentPublishWithDescendantsModalData,
+	UmbDocumentPublishWithDescendantsModalValue
+> {
+	#selectionManager = new UmbSelectionManager<string>(this);
+
+	@state()
+	_options: Array<UmbDocumentVariantOptionModel> = [];
+
+	firstUpdated() {
+		this.#configureSelectionManager();
+	}
+
+	async #configureSelectionManager() {
+		this.#selectionManager.setMultiple(true);
+		this.#selectionManager.setSelectable(true);
+
+		// Only display variants that are relevant to pick from, i.e. variants that are draft or published with pending changes:
+		this._options =
+			this.data?.options.filter(
+				(option) => option.variant && option.variant.state !== UmbDocumentVariantState.NOT_CREATED,
+			) ?? [];
+
+		let selected = this.value?.selection ?? [];
+
+		// Filter selection based on options:
+		selected = selected.filter((s) => this._options.some((o) => o.unique === s));
+
+		this.#selectionManager.setSelection(selected);
+
+		// Additionally select mandatory languages:
+		this._options.forEach((variant) => {
+			if (variant.language?.isMandatory) {
+				this.#selectionManager.select(variant.unique);
+			}
+		});
+	}
+
+	#submit() {
+		this.value = { ...this.value, selection: this.#selectionManager.getSelection() };
+		this.modalContext?.submit();
+	}
+
+	#close() {
+		this.modalContext?.reject();
+	}
+
+	render() {
+		return html`<umb-body-layout headline=${this.localize.term('buttons_publishDescendants')}>
+			<p id="subtitle">
+				${this._options.length === 1
+					? html`<umb-localize
+							key="content_publishDescendantsHelp"
+							.args=${[this._options[0].variant?.name ?? this._options[0].language.name]}>
+							Publish <strong>${this._options[0].variant?.name}</strong> and all content items underneath and thereby
+							making their content publicly available.
+						</umb-localize>`
+					: html`
+							<umb-localize key="content_publishDescendantsWithVariantsHelp">
+								Publish variants and variants of same type underneath and thereby making their content publicly
+								available.
+							</umb-localize>
+						`}
+			</p>
+
+			<umb-document-variant-language-picker
+				.selectionManager=${this.#selectionManager}
+				.variantLanguageOptions=${this._options}></umb-document-variant-language-picker>
+
+			<uui-form-layout-item>
+				<uui-toggle
+					id="includeUnpublishedDescendants"
+					label=${this.localize.term('content_includeUnpublished')}
+					?checked=${this.value?.includeUnpublishedDescendants}
+					@change=${() =>
+						(this.value.includeUnpublishedDescendants = !this.value.includeUnpublishedDescendants)}></uui-toggle>
+			</uui-form-layout-item>
+
+			<div slot="actions">
+				<uui-button label=${this.localize.term('general_close')} @click=${this.#close}></uui-button>
+				<uui-button
+					label="${this.localize.term('buttons_publishDescendants')}"
+					look="primary"
+					color="positive"
+					@click=${this.#submit}></uui-button>
+			</div>
+		</umb-body-layout> `;
+	}
+
+	static styles = [
+		UmbTextStyles,
+		css`
+			:host {
+				display: block;
+				width: 400px;
+				max-width: 90vw;
+			}
+		`,
+	];
+}
+
+export default UmbDocumentPublishWithDescendantsModalElement;
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-document-publish-with-descendants-modal': UmbDocumentPublishWithDescendantsModalElement;
+	}
+}

--- a/src/packages/documents/documents/modals/publish-with-descendants-modal/document-publish-with-descendants-modal.stories.ts
+++ b/src/packages/documents/documents/modals/publish-with-descendants-modal/document-publish-with-descendants-modal.stories.ts
@@ -1,0 +1,176 @@
+import './document-publish-with-descendants-modal.element.js';
+
+import type { Meta, StoryObj } from '@storybook/web-components';
+import { UmbDocumentVariantState } from '../../types.js';
+import type {
+	UmbDocumentPublishWithDescendantsModalData,
+	UmbDocumentPublishWithDescendantsModalValue,
+} from './document-publish-with-descendants-modal.token.js';
+import type { UmbDocumentPublishWithDescendantsModalElement } from './document-publish-with-descendants-modal.element.js';
+import { html } from '@umbraco-cms/backoffice/external/lit';
+
+const modalData: UmbDocumentPublishWithDescendantsModalData = {
+	options: [
+		{
+			unique: 'en-us',
+			culture: 'en-us',
+			segment: null,
+			variant: {
+				name: 'English variant name',
+				culture: 'en-us',
+				state: UmbDocumentVariantState.PUBLISHED,
+				createDate: '2021-08-25T14:00:00Z',
+				publishDate: null,
+				updateDate: null,
+				segment: null,
+			},
+			language: {
+				entityType: 'language',
+				name: 'English',
+				unique: 'en-us',
+				isDefault: true,
+				isMandatory: true,
+				fallbackIsoCode: null,
+			},
+		},
+		{
+			unique: 'en-gb',
+			culture: 'en-gb',
+			segment: null,
+			variant: {
+				name: 'English (GB)',
+				culture: 'en-us',
+				segment: null,
+				state: UmbDocumentVariantState.DRAFT,
+				createDate: '2021-08-25T14:00:00Z',
+				publishDate: null,
+				updateDate: null,
+			},
+			language: {
+				entityType: 'language',
+				name: 'English (GB)',
+				unique: 'en-gb',
+				isDefault: true,
+				isMandatory: false,
+				fallbackIsoCode: null,
+			},
+		},
+		{
+			unique: 'da-dk',
+			culture: 'da-dk',
+			segment: null,
+			variant: {
+				name: 'Danish variant name',
+				culture: 'da-dk',
+				state: UmbDocumentVariantState.NOT_CREATED,
+				createDate: null,
+				publishDate: null,
+				updateDate: null,
+				segment: null,
+			},
+			language: {
+				entityType: 'language',
+				name: 'Danish',
+				unique: 'da-dk',
+				isDefault: false,
+				isMandatory: false,
+				fallbackIsoCode: null,
+			},
+		},
+	],
+};
+
+const modalValue: UmbDocumentPublishWithDescendantsModalValue = {
+	selection: ['en-us'],
+};
+
+const meta: Meta<UmbDocumentPublishWithDescendantsModalElement> = {
+	title: 'Workspaces/Document/Modals/Publish With Descendants Modal',
+	component: 'umb-document-publish-with-descendants-modal',
+	id: 'umb-document-publish-with-descendants-modal',
+	args: {
+		data: modalData,
+		value: modalValue,
+	},
+	decorators: [(Story) => html`<div style="border: 1px solid #000;">${Story()}</div>`],
+	parameters: {
+		layout: 'centered',
+		docs: {
+			source: {
+				language: 'ts',
+				code: `
+import { UMB_DOCUMENT_PUBLISH_WITH_DESCENDANTS_MODAL, UmbDocumentVariantState } from '@umbraco-cms/backoffice/document';
+import { UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
+
+this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (modalManager) => {
+	const result = modalManager.open(this, UMB_DOCUMENT_PUBLISH_WITH_DESCENDANTS_MODAL, {
+		data: {
+			options: [
+				{
+					unique: 'en-us',
+					culture: 'en-us',
+					segment: null,
+					variant: {
+						name: 'English variant name',
+						culture: 'en-us',
+						state: UmbDocumentVariantState.PUBLISHED,
+						createDate: '2021-08-25T14:00:00Z',
+						publishDate: null,
+						updateDate: null,
+						segment: null,
+					},
+					language: {
+						entityType: 'language',
+						name: 'English',
+						unique: 'en-us',
+						isDefault: true,
+						isMandatory: true,
+						fallbackIsoCode: null,
+					},
+				},
+				{
+					unique: 'da-dk',
+					culture: 'da-dk',
+					segment: null,
+					variant: {
+						name: 'Danish variant name',
+						culture: 'da-dk',
+						state: UmbDocumentVariantState.NOT_CREATED,
+						createDate: null,
+						publishDate: null,
+						updateDate: null,
+						segment: null,
+					},
+					language: {
+						entityType: 'language',
+						name: 'Danish',
+						unique: 'da-dk',
+						isDefault: false,
+						isMandatory: false,
+						fallbackIsoCode: null,
+					},
+				},
+			],
+		}
+	}).onSubmit().catch(() => undefined);
+});
+				`,
+			},
+		},
+	},
+};
+
+export default meta;
+type Story = StoryObj<UmbDocumentPublishWithDescendantsModalElement>;
+
+export const Overview: Story = {};
+
+export const Invariant: Story = {
+	args: {
+		data: {
+			...modalData,
+			options: modalData.options.slice(0, 1),
+		},
+		value: modalValue,
+	},
+};

--- a/src/packages/documents/documents/modals/publish-with-descendants-modal/document-publish-with-descendants-modal.token.ts
+++ b/src/packages/documents/documents/modals/publish-with-descendants-modal/document-publish-with-descendants-modal.token.ts
@@ -1,0 +1,18 @@
+import type { UmbDocumentVariantPickerData, UmbDocumentVariantPickerValue } from '../types.js';
+import { UMB_DOCUMENT_PUBLISH_WITH_DESCENDANTS_MODAL_ALIAS } from '../manifests.js';
+import { UmbModalToken } from '@umbraco-cms/backoffice/modal';
+
+export interface UmbDocumentPublishWithDescendantsModalData extends UmbDocumentVariantPickerData {}
+
+export interface UmbDocumentPublishWithDescendantsModalValue extends UmbDocumentVariantPickerValue {
+	includeUnpublishedDescendants?: boolean;
+}
+
+export const UMB_DOCUMENT_PUBLISH_WITH_DESCENDANTS_MODAL = new UmbModalToken<
+	UmbDocumentPublishWithDescendantsModalData,
+	UmbDocumentPublishWithDescendantsModalValue
+>(UMB_DOCUMENT_PUBLISH_WITH_DESCENDANTS_MODAL_ALIAS, {
+	modal: {
+		type: 'dialog',
+	},
+});

--- a/src/packages/documents/documents/modals/publish-with-descendants-modal/index.ts
+++ b/src/packages/documents/documents/modals/publish-with-descendants-modal/index.ts
@@ -1,0 +1,1 @@
+export * from './document-publish-with-descendants-modal.token.js';

--- a/src/packages/documents/documents/repository/publishing/document-publishing.repository.ts
+++ b/src/packages/documents/documents/repository/publishing/document-publishing.repository.ts
@@ -65,4 +65,27 @@ export class UmbDocumentPublishingRepository extends UmbRepositoryBase {
 
 		return { error };
 	}
+
+	/**
+	 * Publish variants of a document including its descendants
+	 * @memberof UmbDocumentPublishingRepository
+	 */
+	async publishWithDescendants(id: string, variantIds: Array<UmbVariantId>, includeUnpublishedDescendants: boolean) {
+		if (!id) throw new Error('id is missing');
+		if (!variantIds) throw new Error('variant IDs are missing');
+		await this.#init;
+
+		const { error } = await this.#publishingDataSource.publishWithDescendants(
+			id,
+			variantIds,
+			includeUnpublishedDescendants,
+		);
+
+		if (!error) {
+			const notification = { data: { message: `Document published with descendants` } };
+			this.#notificationContext?.peek('positive', notification);
+		}
+
+		return { error };
+	}
 }

--- a/src/packages/documents/documents/repository/publishing/document-publishing.server.data-source.ts
+++ b/src/packages/documents/documents/repository/publishing/document-publishing.server.data-source.ts
@@ -2,6 +2,7 @@ import type { UmbDocumentVariantPublishModel } from '../../types.js';
 import type {
 	CultureAndScheduleRequestModel,
 	PublishDocumentRequestModel,
+	PublishDocumentWithDescendantsRequestModel,
 	UnpublishDocumentRequestModel,
 } from '@umbraco-cms/backoffice/external/backend-api';
 import { DocumentResource } from '@umbraco-cms/backoffice/external/backend-api';
@@ -32,7 +33,7 @@ export class UmbDocumentPublishingServerDataSource {
 	 * @param {string} unique
 	 * @param {Array<UmbVariantId>} variantIds
 	 * @return {*}
-	 * @memberof UmbDocumentServerDataSource
+	 * @memberof UmbDocumentPublishingServerDataSource
 	 */
 	async publish(unique: string, variants: Array<UmbDocumentVariantPublishModel>) {
 		if (!unique) throw new Error('Id is missing');
@@ -59,7 +60,7 @@ export class UmbDocumentPublishingServerDataSource {
 	 * @param {string} unique
 	 * @param {Array<UmbVariantId>} variantIds
 	 * @return {*}
-	 * @memberof UmbDocumentServerDataSource
+	 * @memberof UmbDocumentPublishingServerDataSource
 	 */
 	async unpublish(unique: string, variantIds: Array<UmbVariantId>) {
 		if (!unique) throw new Error('Id is missing');
@@ -82,5 +83,27 @@ export class UmbDocumentPublishingServerDataSource {
 		};
 
 		return tryExecuteAndNotify(this.#host, DocumentResource.putDocumentByIdUnpublish({ id: unique, requestBody }));
+	}
+
+	/**
+	 * Publish variants of a document and all its descendants
+	 * @memberof UmbDocumentPublishingServerDataSource
+	 */
+	async publishWithDescendants(
+		unique: string,
+		variantIds: Array<UmbVariantId>,
+		includeUnpublishedDescendants: boolean,
+	) {
+		if (!unique) throw new Error('Id is missing');
+
+		const requestBody: PublishDocumentWithDescendantsRequestModel = {
+			cultures: variantIds.map((variant) => variant.toCultureString()),
+			includeUnpublishedDescendants,
+		};
+
+		return tryExecuteAndNotify(
+			this.#host,
+			DocumentResource.putDocumentByIdPublishWithDescendants({ id: unique, requestBody }),
+		);
 	}
 }

--- a/src/packages/documents/documents/workspace/actions/publish-with-descendants.action.ts
+++ b/src/packages/documents/documents/workspace/actions/publish-with-descendants.action.ts
@@ -1,0 +1,9 @@
+import { UMB_DOCUMENT_WORKSPACE_CONTEXT } from '../document-workspace.context-token.js';
+import { UmbWorkspaceActionBase } from '@umbraco-cms/backoffice/workspace';
+
+export class UmbDocumentPublishWithDescendantsWorkspaceAction extends UmbWorkspaceActionBase {
+	async execute() {
+		const workspaceContext = await this.getContext(UMB_DOCUMENT_WORKSPACE_CONTEXT);
+		return workspaceContext.publishWithDescendants();
+	}
+}

--- a/src/packages/documents/documents/workspace/document-workspace.context.ts
+++ b/src/packages/documents/documents/workspace/document-workspace.context.ts
@@ -625,6 +625,10 @@ export class UmbDocumentWorkspaceContext
 		new UmbUnpublishDocumentEntityAction(this, { unique, entityType, meta: {} as never }).execute();
 	}
 
+	public async publishWithDescendants() {
+		throw new Error('Method not implemented.');
+	}
+
 	async delete() {
 		const id = this.getUnique();
 		if (id) {

--- a/src/packages/documents/documents/workspace/document-workspace.context.ts
+++ b/src/packages/documents/documents/workspace/document-workspace.context.ts
@@ -9,7 +9,12 @@ import type {
 	UmbDocumentVariantModel,
 	UmbDocumentVariantOptionModel,
 } from '../types.js';
-import { UMB_DOCUMENT_PUBLISH_MODAL, UMB_DOCUMENT_SCHEDULE_MODAL } from '../modals/index.js';
+import {
+	UMB_DOCUMENT_PUBLISH_MODAL,
+	UMB_DOCUMENT_PUBLISH_WITH_DESCENDANTS_MODAL,
+	UMB_DOCUMENT_SCHEDULE_MODAL,
+	UMB_DOCUMENT_SAVE_MODAL,
+} from '../modals/index.js';
 import { UmbDocumentPublishingRepository } from '../repository/publishing/index.js';
 import { UmbUnpublishDocumentEntityAction } from '../entity-actions/unpublish.action.js';
 import { UMB_DOCUMENT_WORKSPACE_ALIAS } from './manifests.js';
@@ -36,7 +41,6 @@ import { UmbReloadTreeItemChildrenRequestEntityActionEvent } from '@umbraco-cms/
 import { UmbRequestReloadStructureForEntityEvent } from '@umbraco-cms/backoffice/event';
 import { UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
 import type { UmbDocumentTypeDetailModel } from '@umbraco-cms/backoffice/document-type';
-import { UMB_DOCUMENT_SAVE_MODAL } from '../modals/save-modal/document-save-modal.token.js';
 
 type EntityType = UmbDocumentDetailModel;
 export class UmbDocumentWorkspaceContext
@@ -626,7 +630,41 @@ export class UmbDocumentWorkspaceContext
 	}
 
 	public async publishWithDescendants() {
-		throw new Error('Method not implemented.');
+		const { options, selected } = await this.#determineVariantOptions();
+
+		const modalManagerContext = await this.getContext(UMB_MODAL_MANAGER_CONTEXT);
+		const result = await modalManagerContext
+			.open(this, UMB_DOCUMENT_PUBLISH_WITH_DESCENDANTS_MODAL, {
+				data: {
+					options,
+				},
+				value: { selection: selected },
+			})
+			.onSubmit()
+			.catch(() => undefined);
+
+		if (!result?.selection.length) return;
+
+		// Map to variantIds
+		const variantIds = result?.selection.map((x) => UmbVariantId.FromString(x)) ?? [];
+
+		if (!variantIds.length) return;
+
+		const unique = this.getUnique();
+		if (!unique) throw new Error('Unique is missing');
+		await this.publishingRepository.publishWithDescendants(
+			unique,
+			variantIds,
+			result.includeUnpublishedDescendants ?? false,
+		);
+
+		const data = this.getData();
+		if (!data) throw new Error('Data is missing');
+
+		this.#persistedData.setValue(data);
+		this.#currentData.setValue(data);
+
+		this.workspaceComplete(data);
 	}
 
 	async delete() {

--- a/src/packages/documents/documents/workspace/manifests.ts
+++ b/src/packages/documents/documents/workspace/manifests.ts
@@ -2,6 +2,7 @@ import { UMB_DOCUMENT_ENTITY_TYPE } from '../entity.js';
 import { UmbDocumentSaveAndScheduleWorkspaceAction } from './actions/save-and-schedule.action.js';
 import { UmbDocumentUnpublishWorkspaceAction } from './actions/unpublish.action.js';
 import { UmbDocumentSaveAndPublishWorkspaceAction } from './actions/save-and-publish.action.js';
+import { UmbDocumentPublishWithDescendantsWorkspaceAction } from './actions/publish-with-descendants.action.js';
 import { UmbSaveWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
 import type {
 	ManifestWorkspace,
@@ -162,10 +163,10 @@ const workspaceActionMenuItems: Array<ManifestWorkspaceActionMenuItem> = [
 		alias: 'Umb.Document.WorkspaceActionMenuItem.PublishWithDescendants',
 		name: 'Publish with descendants',
 		weight: 20,
-		api: UmbDocumentSaveAndPublishWorkspaceAction,
+		api: UmbDocumentPublishWithDescendantsWorkspaceAction,
 		forWorkspaceActions: 'Umb.WorkspaceAction.Document.SaveAndPublish',
 		meta: {
-			label: 'Publish with descendants (TBD)',
+			label: 'Publish with descendants...',
 			icon: 'icon-globe',
 		},
 	},

--- a/src/packages/documents/documents/workspace/manifests.ts
+++ b/src/packages/documents/documents/workspace/manifests.ts
@@ -149,7 +149,7 @@ const workspaceActionMenuItems: Array<ManifestWorkspaceActionMenuItem> = [
 		kind: 'default',
 		alias: 'Umb.Document.WorkspaceActionMenuItem.Unpublish',
 		name: 'Unpublish',
-		weight: 10,
+		weight: 0,
 		api: UmbDocumentUnpublishWorkspaceAction,
 		forWorkspaceActions: 'Umb.WorkspaceAction.Document.SaveAndPublish',
 		meta: {
@@ -162,7 +162,7 @@ const workspaceActionMenuItems: Array<ManifestWorkspaceActionMenuItem> = [
 		kind: 'default',
 		alias: 'Umb.Document.WorkspaceActionMenuItem.PublishWithDescendants',
 		name: 'Publish with descendants',
-		weight: 20,
+		weight: 10,
 		api: UmbDocumentPublishWithDescendantsWorkspaceAction,
 		forWorkspaceActions: 'Umb.WorkspaceAction.Document.SaveAndPublish',
 		meta: {


### PR DESCRIPTION
### Description
Adds the "Publish with descendants" workspace menu item and modal.

### How to test
- [x] Go to a page with **no variants** and check that the modal opens with a text including the name of the page
- [x] Go to a page with **more than one variant** and check that they can be selected
- [x] Verify that "Include unpublished content items" work as expected, i.e. it publishes content item children that were not previously published

There are two stories to test both views of the modal: https://ambitious-stone-0033b3603-1433.westeurope.1.azurestaticapps.net/?path=/docs/umb-document-publish-with-descendants-modal--docs

### Screenshots

Menu item:
![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/752371/56e1eabc-aaaa-4377-ba53-4c263bd0d83f)

Modal:
![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/752371/fb6d1bda-f695-4d05-aac3-ab3fc4831dec)