### PR TITLE
add weight + icons + missing stubs for entity actions

### DIFF
--- a/src/packages/core/entity-action/common/sort-children-of/manifests.ts
+++ b/src/packages/core/entity-action/common/sort-children-of/manifests.ts
@@ -1,0 +1,3 @@
+import { manifest as sortKindManifest } from './sort-children-of.action.kind.js';
+
+export const manifests = [sortKindManifest];

--- a/src/packages/core/entity-action/common/sort-children-of/sort-children-of.action.kind.ts
+++ b/src/packages/core/entity-action/common/sort-children-of/sort-children-of.action.kind.ts
@@ -1,0 +1,24 @@
+import { UMB_ENTITY_ACTION_DEFAULT_KIND_MANIFEST } from '../../default/default.action.kind.js';
+import type { UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+
+export const manifest: UmbBackofficeManifestKind = {
+	type: 'kind',
+	alias: 'Umb.Kind.EntityAction.Sort',
+	matchKind: 'sort',
+	matchType: 'entityAction',
+	manifest: {
+		...UMB_ENTITY_ACTION_DEFAULT_KIND_MANIFEST.manifest,
+		type: 'entityAction',
+		kind: 'sort',
+		api: () => import('./sort-children-of.action.js'),
+		weight: 100,
+		forEntityTypes: [],
+		meta: {
+			icon: 'icon-height',
+			label: 'Sort (TBD)...',
+			itemRepositoryAlias: '',
+			moveRepositoryAlias: '',
+			pickerModal: '',
+		},
+	},
+};

--- a/src/packages/core/entity-action/manifests.ts
+++ b/src/packages/core/entity-action/manifests.ts
@@ -4,6 +4,7 @@ import { manifests as duplicateEntityActionManifests } from './common/duplicate/
 import { manifests as moveEntityActionManifests } from './common/move/manifests.js';
 import { manifests as renameEntityActionManifests } from './common/rename/manifests.js';
 import { manifests as trashEntityActionManifests } from './common/trash/manifests.js';
+import { manifests as sortChildrenOfEntityActionManifests } from './common/sort-children-of/manifests.js';
 
 export const manifests = [
 	...defaultEntityActionManifests,
@@ -12,4 +13,5 @@ export const manifests = [
 	...moveEntityActionManifests,
 	...renameEntityActionManifests,
 	...trashEntityActionManifests,
+	...sortChildrenOfEntityActionManifests,
 ];

--- a/src/packages/core/tree/reload-tree-item-children/reload-tree-item-children.action.kind.ts
+++ b/src/packages/core/tree/reload-tree-item-children/reload-tree-item-children.action.kind.ts
@@ -11,7 +11,7 @@ export const manifest: UmbBackofficeManifestKind = {
 		type: 'entityAction',
 		kind: 'reloadTreeItemChildren',
 		api: () => import('./reload-tree-item-children.action.js'),
-		weight: 100,
+		weight: 0,
 		forEntityTypes: [],
 		meta: {
 			icon: 'icon-refresh',

--- a/src/packages/documents/documents/entity-actions/create/manifests.ts
+++ b/src/packages/documents/documents/entity-actions/create/manifests.ts
@@ -7,12 +7,12 @@ const entityActions: Array<ManifestTypes> = [
 		kind: 'default',
 		alias: 'Umb.EntityAction.Document.Create',
 		name: 'Create Document Entity Action',
-		weight: 1000,
+		weight: 1200,
 		api: () => import('./create.action.js'),
 		forEntityTypes: [UMB_DOCUMENT_ROOT_ENTITY_TYPE, UMB_DOCUMENT_ENTITY_TYPE],
 		meta: {
 			icon: 'icon-add',
-			label: 'Create',
+			label: 'Create...',
 		},
 	},
 ];

--- a/src/packages/documents/documents/entity-actions/culture-and-hostnames/manifests.ts
+++ b/src/packages/documents/documents/entity-actions/culture-and-hostnames/manifests.ts
@@ -13,7 +13,7 @@ const entityActions: Array<ManifestTypes> = [
 		forEntityTypes: [UMB_DOCUMENT_ENTITY_TYPE],
 		meta: {
 			icon: 'icon-home',
-			label: 'Culture and Hostnames',
+			label: 'Culture and Hostnames...',
 		},
 	},
 ];

--- a/src/packages/documents/documents/entity-actions/manifests.ts
+++ b/src/packages/documents/documents/entity-actions/manifests.ts
@@ -9,9 +9,23 @@ import type { ManifestEntityAction } from '@umbraco-cms/backoffice/extension-reg
 const entityActions: Array<ManifestEntityAction> = [
 	{
 		type: 'entityAction',
+		kind: 'delete',
+		alias: 'Umb.EntityAction.Document.Delete',
+		name: 'Delete Document Entity Action',
+		weight: 1100,
+		forEntityTypes: [UMB_DOCUMENT_ENTITY_TYPE],
+		meta: {
+			deleteRepositoryAlias: UMB_DOCUMENT_DETAIL_REPOSITORY_ALIAS,
+			itemRepositoryAlias: UMB_DOCUMENT_DETAIL_REPOSITORY_ALIAS,
+			pickerModalAlias: UMB_DOCUMENT_PICKER_MODAL,
+		},
+	},
+	{
+		type: 'entityAction',
 		kind: 'default',
 		alias: 'Umb.EntityAction.Document.CreateBlueprint',
 		name: 'Create Document Blueprint Entity Action',
+		weight: 1000,
 		api: () => import('./create-blueprint.action.js'),
 		forEntityTypes: [UMB_DOCUMENT_ENTITY_TYPE],
 		meta: {
@@ -25,6 +39,7 @@ const entityActions: Array<ManifestEntityAction> = [
 		name: 'Move Document Entity Action ',
 		kind: 'move',
 		forEntityTypes: [UMB_DOCUMENT_ENTITY_TYPE],
+		weight: 900,
 		meta: {
 			moveRepositoryAlias: UMB_DOCUMENT_DETAIL_REPOSITORY_ALIAS,
 			itemRepositoryAlias: UMB_DOCUMENT_DETAIL_REPOSITORY_ALIAS,
@@ -36,6 +51,7 @@ const entityActions: Array<ManifestEntityAction> = [
 		kind: 'duplicate',
 		alias: 'Umb.EntityAction.Document.Duplicate',
 		name: 'Duplicate Document Entity Action',
+		weight: 800,
 		forEntityTypes: [UMB_DOCUMENT_ENTITY_TYPE],
 		meta: {
 			duplicateRepositoryAlias: UMB_DOCUMENT_DETAIL_REPOSITORY_ALIAS,
@@ -45,9 +61,19 @@ const entityActions: Array<ManifestEntityAction> = [
 	},
 	{
 		type: 'entityAction',
+		kind: 'sort',
+		alias: 'Umb.EntityAction.Document.Sort',
+		name: 'Sort Document Entity Action',
+		weight: 700,
+		forEntityTypes: [UMB_DOCUMENT_ENTITY_TYPE],
+		meta: {},
+	},
+	{
+		type: 'entityAction',
 		kind: 'default',
 		alias: 'Umb.EntityAction.Document.Publish',
 		name: 'Publish Document Entity Action',
+		weight: 600,
 		api: () => import('./publish.action.js'),
 		forEntityTypes: [UMB_DOCUMENT_ENTITY_TYPE],
 		meta: {
@@ -60,11 +86,38 @@ const entityActions: Array<ManifestEntityAction> = [
 		kind: 'default',
 		alias: 'Umb.EntityAction.Document.Unpublish',
 		name: 'Unpublish Document Entity Action',
+		weight: 500,
 		api: () => import('./unpublish.action.js'),
 		forEntityTypes: [UMB_DOCUMENT_ENTITY_TYPE],
 		meta: {
 			icon: 'icon-globe',
-			label: 'Unpublish',
+			label: 'Unpublish...',
+		},
+	},
+	{
+		type: 'entityAction',
+		kind: 'default',
+		alias: 'Umb.EntityAction.Document.Permissions',
+		name: 'Permissions Document Entity Action',
+		weight: 300,
+		forEntityTypes: [UMB_DOCUMENT_ENTITY_TYPE],
+		api: () => import('./permissions.action.js'),
+		meta: {
+			icon: 'icon-name-badge',
+			label: 'Permissions...',
+		},
+	},
+	{
+		type: 'entityAction',
+		kind: 'default',
+		alias: 'Umb.EntityAction.Document.Notifications',
+		name: 'Notifications Document Entity Action',
+		weight: 100,
+		forEntityTypes: [UMB_DOCUMENT_ENTITY_TYPE],
+		api: () => import('./permissions.action.js'),
+		meta: {
+			icon: 'icon-rss',
+			label: 'Notifications...',
 		},
 	},
 ];

--- a/src/packages/documents/documents/entity-actions/manifests.ts
+++ b/src/packages/documents/documents/entity-actions/manifests.ts
@@ -116,7 +116,7 @@ const entityActions: Array<ManifestEntityAction> = [
 		forEntityTypes: [UMB_DOCUMENT_ENTITY_TYPE],
 		api: () => import('./permissions.action.js'),
 		meta: {
-			icon: 'icon-rss',
+			icon: 'icon-megaphone',
 			label: 'Notifications...',
 		},
 	},

--- a/src/packages/documents/documents/entity-actions/permissions.action.ts
+++ b/src/packages/documents/documents/entity-actions/permissions.action.ts
@@ -1,0 +1,15 @@
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import { type UmbEntityActionArgs, UmbEntityActionBase } from '@umbraco-cms/backoffice/entity-action';
+
+export class UmbPermissionsEntityAction extends UmbEntityActionBase<never> {
+	constructor(host: UmbControllerHost, args: UmbEntityActionArgs<never>) {
+		super(host, args);
+	}
+
+	async execute() {
+		alert('Not implemented');
+		throw new Error('Method not implemented.');
+	}
+}
+
+export default UmbPermissionsEntityAction;

--- a/src/packages/documents/documents/entity-actions/public-access/manifests.ts
+++ b/src/packages/documents/documents/entity-actions/public-access/manifests.ts
@@ -8,11 +8,12 @@ const entityActions: Array<ManifestTypes> = [
 		kind: 'default',
 		alias: 'Umb.EntityAction.Document.PublicAccess',
 		name: 'Document Permissions Entity Action',
+		weight: 200,
 		api: UmbDocumentPublicAccessEntityAction,
 		forEntityTypes: [UMB_DOCUMENT_ENTITY_TYPE],
 		meta: {
 			icon: 'icon-lock',
-			label: 'Restrict Public Access',
+			label: 'Restrict Public Access...',
 		},
 	},
 ];


### PR DESCRIPTION
### Description

This adds a weight + a few missing actions to signal where the Core actions will be located and under which weight. This enables extension developers to be aware of which weight the built-in actions have so that they may place their own actions.

![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/752371/b0e02ae6-6173-47dc-8f65-76c327631593)
