### PR TITLE
Chore: Corrected casing of "MultipleTextString"

### DIFF
--- a/src/mocks/data/data-type/data-type.data.ts
+++ b/src/mocks/data/data-type/data-type.data.ts
@@ -365,7 +365,7 @@ export const data: Array<UmbMockDataTypeModel> = [
 		name: 'Multiple Text String',
 		id: 'dt-multipleTextString',
 		parent: null,
-		editorAlias: 'Umbraco.MultipleTextString',
+		editorAlias: 'Umbraco.MultipleTextstring',
 		editorUiAlias: 'Umb.PropertyEditorUi.MultipleTextString',
 		hasChildren: false,
 		isFolder: false,

--- a/src/packages/core/property-editor/schemas/Umbraco.MultipleTextString.ts
+++ b/src/packages/core/property-editor/schemas/Umbraco.MultipleTextString.ts
@@ -3,7 +3,7 @@ import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/exten
 export const manifest: ManifestPropertyEditorSchema = {
 	type: 'propertyEditorSchema',
 	name: 'Multiple Text String',
-	alias: 'Umbraco.MultipleTextString',
+	alias: 'Umbraco.MultipleTextstring',
 	meta: {
 		defaultPropertyEditorUiAlias: 'Umb.PropertyEditorUi.MultipleTextString',
 		settings: {

--- a/src/packages/core/property-editor/uis/multiple-text-string/manifests.ts
+++ b/src/packages/core/property-editor/uis/multiple-text-string/manifests.ts
@@ -7,9 +7,9 @@ export const manifest: ManifestPropertyEditorUi = {
 	element: () => import('./property-editor-ui-multiple-text-string.element.js'),
 	meta: {
 		label: 'Multiple Text String',
-		propertyEditorSchemaAlias: 'Umbraco.MultipleTextString',
+		propertyEditorSchemaAlias: 'Umbraco.MultipleTextstring',
 		icon: 'icon-ordered-list',
-		group: '',
+		group: 'lists',
 		supportsReadOnly: true,
 	},
 };


### PR DESCRIPTION
Whilst testing the property-editors, I'd noticed that the Multiple Textstring editor wasn't loading correctly, this is because the schema alias on the server is `Umbraco.MultipleTextstring` (lowercase 's') and on the client it is `Umbraco.MultipleTextString` (uppercase 'S'). I've corrected this to align with the server.

I assume that the intent was to lowercase the 'S' on the server, but this didn't happen before the beta release.
