### PR TITLE
Bugfix: Color Picker amends

### DIFF
--- a/src/packages/core/components/input-color/input-color.element.ts
+++ b/src/packages/core/components/input-color/input-color.element.ts
@@ -1,8 +1,9 @@
-import { html, customElement, property } from '@umbraco-cms/backoffice/external/lit';
-import type { UUIColorSwatchesEvent } from '@umbraco-cms/backoffice/external/uui';
+import { html, customElement, property, map, nothing } from '@umbraco-cms/backoffice/external/lit';
 import { FormControlMixin } from '@umbraco-cms/backoffice/external/uui';
+import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { UmbSwatchDetails } from '@umbraco-cms/backoffice/models';
+import type { UUIColorSwatchesEvent } from '@umbraco-cms/backoffice/external/uui';
 
 /*
  * This wraps the UUI library uui-color-swatches component
@@ -16,35 +17,35 @@ export class UmbInputColorElement extends FormControlMixin(UmbLitElement) {
 	@property({ type: Array })
 	swatches?: UmbSwatchDetails[];
 
-	constructor() {
-		super();
-	}
-
 	protected getFormElement() {
 		return undefined;
 	}
 
-	private _onChange(e: UUIColorSwatchesEvent) {
-		e.stopPropagation();
-		super.value = e.target.value;
-		this.dispatchEvent(new CustomEvent('change'));
+	#onChange(event: UUIColorSwatchesEvent) {
+		event.stopPropagation();
+		super.value = event.target.value;
+		this.dispatchEvent(new UmbChangeEvent());
 	}
 
 	render() {
 		return html`
-			<uui-color-swatches @change="${this._onChange}" label="Color picker" value=${this.value ?? ''}
-				>${this._renderColors()}</uui-color-swatches
-			>
+			<uui-color-swatches label="Color picker" value="#${this.value ?? ''}" @change=${this.#onChange}>
+				${this.#renderColors()}
+			</uui-color-swatches>
 		`;
 	}
 
-	private _renderColors() {
-		return html`${this.swatches?.map((swatch) => {
-			return html`<uui-color-swatch
-				label="${swatch.label}"
-				value="${swatch.value}"
-				.showLabel=${this.showLabels}></uui-color-swatch>`;
-		})}`;
+	#renderColors() {
+		if (!this.swatches) return nothing;
+		return map(
+			this.swatches,
+			(swatch) => html`
+				<uui-color-swatch
+					label="${swatch.label}"
+					value="#${swatch.value}"
+					.showLabel=${this.showLabels}></uui-color-swatch>
+			`,
+		);
 	}
 }
 

--- a/src/packages/core/property-editor/uis/color-picker/property-editor-ui-color-picker.element.ts
+++ b/src/packages/core/property-editor/uis/color-picker/property-editor-ui-color-picker.element.ts
@@ -1,9 +1,10 @@
 import { html, customElement, property, state } from '@umbraco-cms/backoffice/external/lit';
-import type { UUIColorSwatchesEvent } from '@umbraco-cms/backoffice/external/uui';
-import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import type { UmbSwatchDetails } from '@umbraco-cms/backoffice/models';
+import { UmbPropertyValueChangeEvent } from '@umbraco-cms/backoffice/property-editor';
 import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
+import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbSwatchDetails } from '@umbraco-cms/backoffice/models';
+import type { UUIColorSwatchesEvent } from '@umbraco-cms/backoffice/external/uui';
 
 /**
  * @element umb-property-editor-ui-color-picker
@@ -12,8 +13,8 @@ import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/
 export class UmbPropertyEditorUIColorPickerElement extends UmbLitElement implements UmbPropertyEditorUiElement {
 	#defaultShowLabels = false;
 
-	@property()
-	value = '';
+	@property({ type: Object })
+	value?: UmbSwatchDetails;
 
 	@state()
 	private _showLabels = this.#defaultShowLabels;
@@ -27,16 +28,17 @@ export class UmbPropertyEditorUIColorPickerElement extends UmbLitElement impleme
 	}
 
 	private _onChange(event: UUIColorSwatchesEvent) {
-		this.value = event.target.value;
-		this.dispatchEvent(new CustomEvent('property-value-change'));
+		const value = event.target.value;
+		this.value = this._swatches.find((swatch) => swatch.value === value);
+		this.dispatchEvent(new UmbPropertyValueChangeEvent());
 	}
 
 	render() {
 		return html`<umb-input-color
-			@change="${this._onChange}"
-			.value=${this.value ?? ''}
-			.swatches="${this._swatches}"
-			.showLabels="${this._showLabels}"></umb-input-color>`;
+			?showLabels=${this._showLabels}
+			.swatches=${this._swatches}
+			.value=${this.value?.value ?? ''}
+			@change=${this._onChange}></umb-input-color>`;
 	}
 }
 


### PR DESCRIPTION
Wires up the correct value data structure, and corrects the `items` configuration value to prefix a `#` onto the hex colour values.

