### PR TITLE
Bugfix: EmailAddress corrected alias

### DIFF
--- a/src/packages/core/property-editor/uis/text-box/manifests.ts
+++ b/src/packages/core/property-editor/uis/text-box/manifests.ts
@@ -32,7 +32,7 @@ export const manifests: Array<ManifestPropertyEditorUi> = [
 	},
 	{
 		type: 'propertyEditorUi',
-		alias: 'Umb.PropertyEditorUi.Email',
+		alias: 'Umb.PropertyEditorUi.EmailAddress',
 		name: 'Email Property Editor UI',
 		element: () => import('./property-editor-ui-text-box.element.js'),
 		meta: {


### PR DESCRIPTION
The Email property-editor UI alias was `“Umb.PropertyEditorUi.Email”`, but the schema was referencing `“Umb.PropertyEditorUi.EmailAddress”`. These aliases needed to be aligned, I've opted to use the server schema alias of "EmailAddress" over "Email".
