### PR TITLE
Bugfix: Slider value

### DIFF
--- a/src/packages/core/components/input-slider/input-slider.element.ts
+++ b/src/packages/core/components/input-slider/input-slider.element.ts
@@ -1,7 +1,7 @@
-import { css, html, customElement, property } from '@umbraco-cms/backoffice/external/lit';
-import type { UUISliderEvent } from '@umbraco-cms/backoffice/external/uui';
+import { html, customElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { FormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import type { UUISliderEvent } from '@umbraco-cms/backoffice/external/uui';
 
 @customElement('umb-input-slider')
 export class UmbInputSliderElement extends FormControlMixin(UmbLitElement) {
@@ -15,10 +15,10 @@ export class UmbInputSliderElement extends FormControlMixin(UmbLitElement) {
 	step = 1;
 
 	@property({ type: Number })
-	initVal1 = 0;
+	valueLow = 0;
 
 	@property({ type: Number })
-	initVal2 = 0;
+	valueHigh = 0;
 
 	@property({ type: Boolean, attribute: 'enable-range' })
 	enableRange = false;
@@ -34,8 +34,7 @@ export class UmbInputSliderElement extends FormControlMixin(UmbLitElement) {
 	}
 
 	render() {
-		if (this.enableRange) return this.#renderRangeSlider();
-		else return this.#renderSlider();
+		return this.enableRange ? this.#renderRangeSlider() : this.#renderSlider();
 	}
 
 	#renderSlider() {
@@ -43,7 +42,7 @@ export class UmbInputSliderElement extends FormControlMixin(UmbLitElement) {
 			.min="${this.min}"
 			.max="${this.max}"
 			.step="${this.step}"
-			.value="${this.initVal1.toString()}"
+			.value="${this.valueLow.toString()}"
 			@change="${this.#onChange}"></uui-slider>`;
 	}
 	#renderRangeSlider() {
@@ -51,8 +50,7 @@ export class UmbInputSliderElement extends FormControlMixin(UmbLitElement) {
 			.min="${this.min}"
 			.max="${this.max}"
 			.step="${this.step}"
-			.valueLow="${this.initVal1}"
-			.valueHigh="${this.initVal2}"
+			.value="${this.valueLow},${this.valueHigh}"
 			@change="${this.#onChange}"></uui-range-slider>`;
 	}
 }

--- a/src/packages/core/components/input-slider/input-slider.stories.ts
+++ b/src/packages/core/components/input-slider/input-slider.stories.ts
@@ -15,7 +15,7 @@ export const Overview: Story = {
 		min: 0,
 		max: 100,
 		step: 10,
-		initVal1: 20,
+		valueLow: 20,
 	},
 };
 
@@ -24,8 +24,8 @@ export const WithRange: Story = {
 		min: 0,
 		max: 100,
 		step: 10,
-		initVal1: 20,
-		initVal2: 80,
+		valueLow: 20,
+		valueHigh: 80,
 		enableRange: true,
 	},
 };
@@ -35,7 +35,7 @@ export const WithSmallStep: Story = {
 		min: 0,
 		max: 5,
 		step: 1,
-		initVal1: 4,
+		valueLow: 4,
 	},
 };
 
@@ -44,6 +44,6 @@ export const WithLargeMinMax: Story = {
 		min: 0,
 		max: 100,
 		step: 1,
-		initVal1: 86,
+		valueLow: 86,
 	},
 };


### PR DESCRIPTION
Wires up the persisted value with the Slider UI.

Renames the component's `initVal1` and `initVal2` properties to `valueLow` and `valueHigh` respectively.
