### PR TITLE
Bugfix: Dropdown data structure

### DIFF
--- a/src/packages/core/components/input-dropdown/input-dropdown-list.element.ts
+++ b/src/packages/core/components/input-dropdown/input-dropdown-list.element.ts
@@ -1,7 +1,8 @@
 import { css, html, customElement, property, query } from '@umbraco-cms/backoffice/external/lit';
-import type { UUISelectEvent } from '@umbraco-cms/backoffice/external/uui';
 import { FormControlMixin } from '@umbraco-cms/backoffice/external/uui';
+import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import type { UUISelectEvent } from '@umbraco-cms/backoffice/external/uui';
 
 @customElement('umb-input-dropdown-list')
 export class UmbInputDropdownListElement extends FormControlMixin(UmbLitElement) {
@@ -25,7 +26,7 @@ export class UmbInputDropdownListElement extends FormControlMixin(UmbLitElement)
 	#onChange(e: UUISelectEvent) {
 		e.stopPropagation();
 		if (e.target.value) this.value = e.target.value;
-		this.dispatchEvent(new CustomEvent('change', { bubbles: true, composed: true }));
+		this.dispatchEvent(new UmbChangeEvent());
 	}
 
 	render() {


### PR DESCRIPTION
With recent changes to how the Management API sends the data structure for the Dropdown, the UI was completely broken™. This PR fixes that.

A slight complexity with the Dropdown property-editor, due to legacy support for multiple values, the input value needs to support both `string` and `string[]` value types. This PR also handles those scenarios. However the UI currently only supporting the single value (non-multiple) UI, (e.g. `uui-select` instead of `uui-combobox-list`) This will need a separate review/fix.
