### PR TITLE
Feature: Active menu/tree item

### DIFF
--- a/src/packages/core/menu/menu-item-layout/menu-item-layout.element.ts
+++ b/src/packages/core/menu/menu-item-layout/menu-item-layout.element.ts
@@ -1,5 +1,6 @@
-import { html, customElement, property, ifDefined } from '@umbraco-cms/backoffice/external/lit';
+import { html, customElement, property, ifDefined, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { debounce } from '@umbraco-cms/backoffice/utils';
 
 /**
  * @element umb-menu-item-layout
@@ -36,8 +37,32 @@ export class UmbMenuItemLayoutElement extends UmbLitElement {
 	@property({ type: String })
 	public href?: string;
 
+	@state()
+	private _isActive = false;
+
+	connectedCallback() {
+		super.connectedCallback();
+		window.addEventListener('navigationend', this.#debouncedCheckIsActive);
+	}
+
+	#debouncedCheckIsActive = debounce(() => this.#checkIsActive(), 100);
+
+	#checkIsActive() {
+		if (!this.href) {
+			this._isActive = false;
+			return;
+		}
+
+		const location = window.location.pathname;
+		this._isActive = location.includes(this.href);
+	}
+
 	render() {
-		return html`<uui-menu-item href="${ifDefined(this.href)}" label=${this.label} ?has-children=${this.hasChildren}>
+		return html`<uui-menu-item
+			href="${ifDefined(this.href)}"
+			label=${this.label}
+			?active=${this._isActive}
+			?has-children=${this.hasChildren}>
 			<umb-icon slot="icon" name=${this.iconName}></umb-icon>
 			${this.entityType
 				? html`<umb-entity-actions-bundle
@@ -45,10 +70,15 @@ export class UmbMenuItemLayoutElement extends UmbLitElement {
 						.entityType=${this.entityType}
 						.unique=${null}
 						.label=${this.label}>
-				  </umb-entity-actions-bundle>`
+					</umb-entity-actions-bundle>`
 				: ''}
 			<slot></slot>
 		</uui-menu-item>`;
+	}
+
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		window.removeEventListener('navigationend', this.#debouncedCheckIsActive);
 	}
 }
 

--- a/src/packages/core/tree/tree-item/tree-item-base/tree-item-context-base.ts
+++ b/src/packages/core/tree/tree-item/tree-item-base/tree-item-context-base.ts
@@ -252,6 +252,7 @@ export abstract class UmbTreeItemContextBase<TreeItemType extends UmbTreeItemMod
 				if (value === true) {
 					const isSelectable = this.treeContext?.selectableFilter?.(this.getTreeItem()!) ?? true;
 					this.#isSelectable.setValue(isSelectable);
+					this.#checkIsActive();
 				}
 			},
 			'observeIsSelectable',
@@ -355,6 +356,14 @@ export abstract class UmbTreeItemContextBase<TreeItemType extends UmbTreeItemMod
 	#debouncedCheckIsActive = debounce(() => this.#checkIsActive(), 100);
 
 	#checkIsActive() {
+		// don't set the active state if the item is selectable
+		const isSelectable = this.#isSelectable.getValue();
+
+		if (isSelectable) {
+			this.#isActive.setValue(false);
+			return;
+		}
+
 		const path = this.#path.getValue();
 		const location = window.location.pathname;
 		const isActive = location.includes(path);

--- a/src/packages/core/tree/tree-item/tree-item-base/tree-item-element-base.ts
+++ b/src/packages/core/tree/tree-item/tree-item-base/tree-item-element-base.ts
@@ -17,6 +17,9 @@ export abstract class UmbTreeItemElementBase<TreeItemModelType extends UmbTreeIt
 	}
 
 	@state()
+	private _isActive = false;
+
+	@state()
 	private _childItems?: TreeItemModelType[];
 
 	@state()
@@ -62,6 +65,7 @@ export abstract class UmbTreeItemElementBase<TreeItemModelType extends UmbTreeIt
 			this.observe(this.#treeItemContext.treeItem, (value) => (this._item = value));
 			this.observe(this.#treeItemContext.childItems, (value) => (this._childItems = value));
 			this.observe(this.#treeItemContext.hasChildren, (value) => (this._hasChildren = value));
+			this.observe(this.#treeItemContext.isActive, (value) => (this._isActive = value));
 			this.observe(this.#treeItemContext.isLoading, (value) => (this._isLoading = value));
 			this.observe(this.#treeItemContext.isSelectableContext, (value) => (this._isSelectableContext = value));
 			this.observe(this.#treeItemContext.isSelectable, (value) => (this._isSelectable = value));
@@ -107,6 +111,7 @@ export abstract class UmbTreeItemElementBase<TreeItemModelType extends UmbTreeIt
 				@show-children=${this._onShowChildren}
 				@selected=${this._handleSelectedItem}
 				@deselected=${this._handleDeselectedItem}
+				?active=${this._isActive}
 				?disabled=${this._isSelectableContext && !this._isSelectable}
 				?selectable=${this._isSelectable}
 				?selected=${this._isSelected}


### PR DESCRIPTION
This PR adds an active state to a menu/tree item. The active state is based on whether the path of the navigation item is part of the current location. This also means that there is no need for a custom implementation of the active state.

Uploading Kapture 2024-03-20 at 13.53.19.mp4…


**Known missings:**
* This PR only implements the active state. The tree won't unfold to the active item. That will be fixed in another PR.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
