### PR TITLE
Bugfix: Use decimals in step property for decimals

### DIFF
--- a/src/packages/core/property-editor/schemas/Umbraco.Decimal.ts
+++ b/src/packages/core/property-editor/schemas/Umbraco.Decimal.ts
@@ -25,6 +25,12 @@ export const manifest: ManifestPropertyEditorSchema = {
 					label: 'Step size',
 					description: 'Enter the intervals amount between each step of number to be entered',
 					propertyEditorUiAlias: 'Umb.PropertyEditorUi.Decimal',
+					config: [
+						{
+							alias: 'step',
+							value: '0.01',
+						},
+					],
 				},
 			],
 		},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Just a small fix that when toggling value up/down, increases value by 0.01 for decimals and avoid showing error when number is decimal 😊

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
