### PR TITLE
Chore: Mock data - corrects list item data structure

### DIFF
--- a/examples/dashboard-with-property-dataset/dataset-dashboard.ts
+++ b/examples/dashboard-with-property-dataset/dataset-dashboard.ts
@@ -39,11 +39,7 @@ export class ExampleDatasetDashboard extends UmbElementMixin(LitElement) {
 							},
 							{
 								alias: 'items',
-								value: {
-									0: { sortOrder: 1, value: 'First Option' },
-									1: { sortOrder: 2, value: 'Second Option' },
-									2: { sortOrder: 3, value: 'Third Option' },
-								},
+								value: [ 'First Option' , 'Second Option', 'Third Option' ],
 							},
 						]}
 						property-editor-ui-alias="Umb.PropertyEditorUi.Dropdown"></umb-property>

--- a/src/mocks/data/data-type/data-type.data.ts
+++ b/src/mocks/data/data-type/data-type.data.ts
@@ -399,11 +399,7 @@ export const data: Array<UmbMockDataTypeModel> = [
 			},
 			{
 				alias: 'items',
-				value: {
-					0: { sortOrder: 1, value: 'First Option' },
-					1: { sortOrder: 2, value: 'Second Option' },
-					2: { sortOrder: 3, value: 'I Am the third Option' },
-				},
+				value: ['First Option', 'Second Option', 'I Am the third Option'],
 			},
 		],
 	},
@@ -519,11 +515,7 @@ export const data: Array<UmbMockDataTypeModel> = [
 		values: [
 			{
 				alias: 'items',
-				value: {
-					0: { sortOrder: 1, value: 'First Option' },
-					1: { sortOrder: 2, value: 'Second Option' },
-					2: { sortOrder: 3, value: 'I Am the third Option' },
-				},
+				value: ['First Option', 'Second Option', 'I Am the third Option'],
 			},
 		],
 	},
@@ -540,11 +532,7 @@ export const data: Array<UmbMockDataTypeModel> = [
 		values: [
 			{
 				alias: 'items',
-				value: {
-					0: { sortOrder: 1, value: 'First Option' },
-					1: { sortOrder: 2, value: 'Second Option' },
-					2: { sortOrder: 3, value: 'I Am the third Option' },
-				},
+				value: ['First Option', 'Second Option', 'I Am the third Option'],
 			},
 		],
 	},


### PR DESCRIPTION
With the recent changes to the CheckboxList, DropdownList and RadioButtonList editors, I'd noticed some of the mock data wasn't aligned with the updated data structure, (`string[]`).
