### PR TITLE
Bugfix: Pass meta to highlighted entity action

### DIFF
--- a/src/packages/core/components/entity-actions-bundle/entity-actions-bundle.element.ts
+++ b/src/packages/core/components/entity-actions-bundle/entity-actions-bundle.element.ts
@@ -53,7 +53,7 @@ export class UmbEntityActionsBundleElement extends UmbLitElement {
 					this._numberOfActions > 0 ? (actions[0] as ManifestEntityActionDefaultKind) : undefined;
 				if (!this._firstActionManifest) return;
 				this._firstActionApi = await createExtensionApi(this, this._firstActionManifest, [
-					{ unique: this.unique, entityType: this.entityType, meta: this._firstActionManifest.meta }
+					{ unique: this.unique, entityType: this.entityType, meta: this._firstActionManifest.meta },
 				]);
 			},
 			'umbEntityActionsObserver',

--- a/src/packages/core/components/entity-actions-bundle/entity-actions-bundle.element.ts
+++ b/src/packages/core/components/entity-actions-bundle/entity-actions-bundle.element.ts
@@ -53,8 +53,7 @@ export class UmbEntityActionsBundleElement extends UmbLitElement {
 					this._numberOfActions > 0 ? (actions[0] as ManifestEntityActionDefaultKind) : undefined;
 				if (!this._firstActionManifest) return;
 				this._firstActionApi = await createExtensionApi(this, this._firstActionManifest, [
-					{ unique: this.unique, entityType: this.entityType, meta: this._firstActionManifest.meta },
-					this._firstActionManifest.meta,
+					{ unique: this.unique, entityType: this.entityType, meta: this._firstActionManifest.meta }
 				]);
 			},
 			'umbEntityActionsObserver',

--- a/src/packages/core/components/entity-actions-bundle/entity-actions-bundle.element.ts
+++ b/src/packages/core/components/entity-actions-bundle/entity-actions-bundle.element.ts
@@ -53,7 +53,8 @@ export class UmbEntityActionsBundleElement extends UmbLitElement {
 					this._numberOfActions > 0 ? (actions[0] as ManifestEntityActionDefaultKind) : undefined;
 				if (!this._firstActionManifest) return;
 				this._firstActionApi = await createExtensionApi(this, this._firstActionManifest, [
-					{ unique: this.unique, entityType: this.entityType },
+					{ unique: this.unique, entityType: this.entityType, meta: this._firstActionManifest.meta },
+					this._firstActionManifest.meta,
 				]);
 			},
 			'umbEntityActionsObserver',


### PR DESCRIPTION
## Description

We have missed passing the meta object to the highlighted entity action on a tree item. That result in the entity action not working. 

How to test:
* Test that it is possible to delete a member type or data type trough the "highlighted" action.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
