### PR TITLE
Bugfix/workspace input offset

### DIFF
--- a/src/packages/core/workspace/components/variant-selector/variant-selector.element.ts
+++ b/src/packages/core/workspace/components/variant-selector/variant-selector.element.ts
@@ -284,7 +284,6 @@ export class UmbVariantSelectorElement extends UmbLitElement {
 		css`
 			#name-input {
 				width: 100%;
-				height: 100%; /** I really don't know why this fixes the border colliding with variant-selector-toggle, but lets this solution for now */
 			}
 
 			#variant-selector-toggle {

--- a/src/packages/core/workspace/components/variant-selector/variant-selector.element.ts
+++ b/src/packages/core/workspace/components/variant-selector/variant-selector.element.ts
@@ -212,6 +212,7 @@ export class UmbVariantSelectorElement extends UmbLitElement {
 						? html`
 								<uui-button
 									id="variant-selector-toggle"
+									compact
 									slot="append"
 									popovertarget="variant-selector-popover"
 									title=${this._variantTitleName}>


### PR DESCRIPTION
Fixes the alignment of inputs in workspaces with variants.
Also makes the padding on the button smaller (compact) to make it look nicer inside the input

Regarding the comment on height: `height: 100%; /** I really don't know why this fixes the border colliding with variant-selector-toggle, but lets this solution for now */`
This is no longer an issue, so there's no problem removing the `height: 100%`