### PR TITLE
Bugfix/fix misc richtexteditor bugs

### DIFF
--- a/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
+++ b/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
@@ -195,8 +195,8 @@ export class UmbInputTinyMceElement extends FormControlMixin(UmbLitElement) {
 		// create an object by merging the configuration onto the fallback config
 		const configurationOptions: RawEditorOptions = {
 			...defaultFallbackConfig,
-			height: dimensions?.height,
-			width: dimensions?.width,
+			height: dimensions?.height || undefined,
+			width: dimensions?.width || undefined,
 			content_css: stylesheets,
 			style_formats: styleFormats,
 		};

--- a/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
+++ b/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
@@ -217,8 +217,10 @@ export class UmbInputTinyMceElement extends FormControlMixin(UmbLitElement) {
 		}
 
 		// set the configured inline mode
-		const mode = this.configuration?.getValueByAlias<Array<string>>('mode');
-		if (mode?.[0].toLocaleLowerCase() === 'inline') {
+		const mode = this.configuration?.getValueByAlias<string | Array<string>>('mode'); // Migration: Bellissima (PropertyEditorUi.Dropdown) saves as Array.
+		if (typeof mode === 'string' && mode.toLocaleLowerCase() === 'inline') {
+			configurationOptions.inline = true;
+		} else if (Array.isArray(mode) && mode.length && mode?.[0].toLocaleLowerCase() === 'inline') {
 			configurationOptions.inline = true;
 		}
 

--- a/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
+++ b/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
@@ -214,13 +214,13 @@ export class UmbInputTinyMceElement extends FormControlMixin(UmbLitElement) {
 		}
 
 		// set the configured inline mode
-		const mode = this.configuration?.getValueByAlias<string>('mode');
-		if (mode?.toLocaleLowerCase() === 'inline') {
+		const mode = this.configuration?.getValueByAlias<Array<string>>('mode');
+		if (mode?.[0].toLocaleLowerCase() === 'inline') {
 			configurationOptions.inline = true;
 		}
 
 		// set the maximum image size
-		const maxImageSize = this.configuration?.getValueByAlias<number>('maxImageSize');
+		const maxImageSize = this.configuration?.getValueByAlias<string>('maxImageSize');
 		if (maxImageSize !== undefined) {
 			configurationOptions.maxImageSize = maxImageSize;
 		}

--- a/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
+++ b/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
@@ -223,8 +223,8 @@ export class UmbInputTinyMceElement extends FormControlMixin(UmbLitElement) {
 		}
 
 		// set the maximum image size
-		const maxImageSize = this.configuration?.getValueByAlias<string>('maxImageSize');
-		if (maxImageSize !== undefined) {
+		const maxImageSize = this.configuration?.getValueByAlias<number>('maxImageSize');
+		if (maxImageSize) {
 			configurationOptions.maxImageSize = maxImageSize;
 		}
 
@@ -335,7 +335,6 @@ export class UmbInputTinyMceElement extends FormControlMixin(UmbLitElement) {
 				}
 			});
 		});
-
 		editor.on('init', () => editor.setContent(this.value?.toString() ?? ''));
 	}
 

--- a/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
+++ b/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
@@ -207,11 +207,9 @@ export class UmbInputTinyMceElement extends FormControlMixin(UmbLitElement) {
 			}
 		}
 
-		// set the configured toolbar if any
+		// set the configured toolbar if any, otherwise false
 		const toolbar = this.configuration?.getValueByAlias<string[]>('toolbar');
-		if (toolbar) {
-			configurationOptions.toolbar = toolbar.join(' ');
-		}
+		configurationOptions.toolbar = toolbar?.join(' ') ?? false;
 
 		// set the configured inline mode
 		const mode = this.configuration?.getValueByAlias<Array<string>>('mode');

--- a/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
+++ b/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
@@ -138,7 +138,8 @@ export class UmbInputTinyMceElement extends FormControlMixin(UmbLitElement) {
 		const stylesheetResponses = await Promise.all(promises);
 
 		stylesheetResponses.forEach(({ data }) => {
-			if (!data) return;
+			if (!data?.content) return;
+
 			const rulesFromContent = this.#umbStylesheetRuleManager.extractRules(data.content);
 
 			rulesFromContent.forEach((rule) => {

--- a/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
+++ b/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
@@ -217,10 +217,8 @@ export class UmbInputTinyMceElement extends FormControlMixin(UmbLitElement) {
 		}
 
 		// set the configured inline mode
-		const mode = this.configuration?.getValueByAlias<string | Array<string>>('mode'); // Migration: Bellissima (PropertyEditorUi.Dropdown) saves as Array.
-		if (typeof mode === 'string' && mode.toLocaleLowerCase() === 'inline') {
-			configurationOptions.inline = true;
-		} else if (Array.isArray(mode) && mode.length && mode?.[0].toLocaleLowerCase() === 'inline') {
+		const mode = this.configuration?.getValueByAlias<string>('mode');
+		if (mode?.toLocaleLowerCase() === 'inline') {
 			configurationOptions.inline = true;
 		}
 

--- a/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
+++ b/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
@@ -209,7 +209,11 @@ export class UmbInputTinyMceElement extends FormControlMixin(UmbLitElement) {
 
 		// set the configured toolbar if any, otherwise false
 		const toolbar = this.configuration?.getValueByAlias<string[]>('toolbar');
-		configurationOptions.toolbar = toolbar?.join(' ') ?? false;
+		if (toolbar && toolbar.length) {
+			configurationOptions.toolbar = toolbar?.join(' ');
+		} else {
+			configurationOptions.toolbar = false;
+		}
 
 		// set the configured inline mode
 		const mode = this.configuration?.getValueByAlias<Array<string>>('mode');

--- a/src/packages/tiny-mce/index.ts
+++ b/src/packages/tiny-mce/index.ts
@@ -1,1 +1,2 @@
 export * from './components/index.js';
+export * from './modals/index.js';

--- a/src/packages/tiny-mce/manifests.ts
+++ b/src/packages/tiny-mce/manifests.ts
@@ -1,4 +1,5 @@
 import { manifests as propertyEditors } from './property-editors/manifests.js';
 import { manifests as plugins } from './plugins/manifests.js';
+import { manifests as modalManifests } from './modals/manifests.js';
 
-export const manifests = [...propertyEditors, ...plugins];
+export const manifests = [...propertyEditors, ...plugins, ...modalManifests];

--- a/src/packages/tiny-mce/modals/index.ts
+++ b/src/packages/tiny-mce/modals/index.ts
@@ -1,0 +1,1 @@
+export * from './media-caption-alt-text/index.js';

--- a/src/packages/tiny-mce/modals/manifests.ts
+++ b/src/packages/tiny-mce/modals/manifests.ts
@@ -1,0 +1,12 @@
+import type { ManifestModal } from '@umbraco-cms/backoffice/extension-registry';
+
+const modals: Array<ManifestModal> = [
+	{
+		type: 'modal',
+		alias: 'Umb.Modal.MediaCaptionAltText',
+		name: 'Media Caption Alt Text',
+		js: () => import('./media-caption-alt-text/media-caption-alt-text-modal.element.js'),
+	},
+];
+
+export const manifests = [...modals];

--- a/src/packages/tiny-mce/modals/media-caption-alt-text/index.ts
+++ b/src/packages/tiny-mce/modals/media-caption-alt-text/index.ts
@@ -1,0 +1,2 @@
+export * from './media-caption-alt-text-modal.element.js';
+export * from './media-caption-alt-text-modal.token.js';

--- a/src/packages/tiny-mce/modals/media-caption-alt-text/media-caption-alt-text-modal.element.ts
+++ b/src/packages/tiny-mce/modals/media-caption-alt-text/media-caption-alt-text-modal.element.ts
@@ -1,0 +1,87 @@
+import type {
+	UmbMediaCaptionAltTextModalData,
+	UmbMediaCaptionAltTextModalValue,
+} from './media-caption-alt-text-modal.token.js';
+import { css, html, customElement, state, ifDefined } from '@umbraco-cms/backoffice/external/lit';
+import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
+import '@umbraco-cms/backoffice/block-type';
+import { UmbMediaDetailRepository } from '@umbraco-cms/backoffice/media';
+import type { UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
+
+@customElement('umb-media-caption-alt-text-modal')
+export class UmbMediaCaptionAltTextModalElement extends UmbModalBaseElement<
+	UmbMediaCaptionAltTextModalData,
+	UmbMediaCaptionAltTextModalValue
+> {
+	#mediaUnique?: string;
+	#mediaDetailRepository = new UmbMediaDetailRepository(this);
+
+	connectedCallback() {
+		super.connectedCallback();
+		this.#mediaUnique = this.data?.mediaUnique;
+		this.#getMediaDetail();
+	}
+
+	async #getMediaDetail() {
+		if (!this.#mediaUnique) return;
+		const { data } = await this.#mediaDetailRepository.requestByUnique(this.#mediaUnique);
+		if (!data) return;
+
+		this.value = { altText: data.variants[0].name, caption: undefined, url: data.urls[0]?.url ?? '' };
+	}
+
+	render() {
+		return html`
+			<umb-body-layout .headline=${this.localize.term('defaultdialogs_editSelectedMedia')}>
+				<div id="wrapper">
+					<uui-label for="alt-text">${this.localize.term('content_altTextOptional')}</uui-label>
+					<uui-input
+						id="alt-text"
+						label="alt text"
+						.value=${this.value?.altText ?? ''}
+						@input=${(e: UUIInputEvent) =>
+							(this.value = { ...this.value, altText: e.target.value as string })}></uui-input>
+
+					<uui-label for="caption">${this.localize.term('content_captionTextOptional')}</uui-label>
+					<uui-input
+						id="caption"
+						label="caption"
+						@input=${(e: UUIInputEvent) =>
+							(this.value = { ...this.value, caption: e.target.value as string })}></uui-input>
+
+					<img src=${this.value?.url ?? ''} alt=${this.value?.altText ?? ''} />
+					${this.value?.caption ?? ''}
+				</div>
+				<div slot="actions">
+					<uui-button label=${this.localize.term('general_close')} @click=${this._rejectModal}></uui-button>
+					<uui-button
+						label=${this.localize.term('general_submit')}
+						look="primary"
+						color="positive"
+						@click=${this._submitModal}></uui-button>
+				</div>
+			</umb-body-layout>
+		`;
+	}
+
+	static styles = [
+		css`
+			uui-input {
+				margin-bottom: var(--uui-size-layout-1);
+			}
+
+			#wrapper {
+				display: flex;
+				flex-direction: column;
+			}
+		`,
+	];
+}
+
+export default UmbMediaCaptionAltTextModalElement;
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-media-caption-alt-text-modal': UmbMediaCaptionAltTextModalElement;
+	}
+}

--- a/src/packages/tiny-mce/modals/media-caption-alt-text/media-caption-alt-text-modal.token.ts
+++ b/src/packages/tiny-mce/modals/media-caption-alt-text/media-caption-alt-text-modal.token.ts
@@ -1,0 +1,21 @@
+import { UmbModalToken } from '@umbraco-cms/backoffice/modal';
+
+export interface UmbMediaCaptionAltTextModalData {
+	mediaUnique: string;
+}
+
+export type UmbMediaCaptionAltTextModalValue = {
+	altText?: string;
+	caption?: string;
+	url: string;
+};
+
+export const UMB_MEDIA_CAPTION_ALT_TEXT_MODAL = new UmbModalToken<
+	UmbMediaCaptionAltTextModalData,
+	UmbMediaCaptionAltTextModalValue
+>('Umb.Modal.MediaCaptionAltText', {
+	modal: {
+		type: 'sidebar',
+		size: 'small',
+	},
+});

--- a/src/packages/tiny-mce/plugins/tiny-mce-embeddedmedia.plugin.ts
+++ b/src/packages/tiny-mce/plugins/tiny-mce-embeddedmedia.plugin.ts
@@ -1,9 +1,5 @@
 import { type TinyMcePluginArguments, UmbTinyMcePluginBase } from '../components/input-tiny-mce/tiny-mce-plugin.js';
-import type {
-	UmbEmbeddedMediaModalData,
-	UmbEmbeddedMediaModalValue,
-	UmbModalManagerContext,
-} from '@umbraco-cms/backoffice/modal';
+import type { UmbEmbeddedMediaModalData, UmbEmbeddedMediaModalValue } from '@umbraco-cms/backoffice/modal';
 import { UMB_EMBEDDED_MEDIA_MODAL, UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
 
 export default class UmbTinyMceEmbeddedMediaPlugin extends UmbTinyMcePluginBase {

--- a/src/packages/tiny-mce/plugins/tiny-mce-mediapicker.plugin.ts
+++ b/src/packages/tiny-mce/plugins/tiny-mce-mediapicker.plugin.ts
@@ -1,11 +1,11 @@
+import { UMB_MEDIA_CAPTION_ALT_TEXT_MODAL } from '../modals/media-caption-alt-text/media-caption-alt-text-modal.token.js';
 import { type TinyMcePluginArguments, UmbTinyMcePluginBase } from '../components/input-tiny-mce/tiny-mce-plugin.js';
-import type { UmbModalManagerContext } from '@umbraco-cms/backoffice/modal';
 import { UMB_MEDIA_TREE_PICKER_MODAL, UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
 import type { UMB_CURRENT_USER_CONTEXT, UmbCurrentUserModel } from '@umbraco-cms/backoffice/current-user';
 import type { RawEditorOptions } from '@umbraco-cms/backoffice/external/tinymce';
 import { UmbTemporaryFileRepository } from '@umbraco-cms/backoffice/temporary-file';
 import { UmbId } from '@umbraco-cms/backoffice/id';
-import { sizeImageInEditor, uploadBlobImages } from '@umbraco-cms/backoffice/media';
+import { UmbMediaDetailRepository, sizeImageInEditor, uploadBlobImages } from '@umbraco-cms/backoffice/media';
 
 interface MediaPickerTargetData {
 	altText?: string;
@@ -27,12 +27,19 @@ interface MediaPickerResultData {
 export default class UmbTinyMceMediaPickerPlugin extends UmbTinyMcePluginBase {
 	#currentUser?: UmbCurrentUserModel;
 	#currentUserContext?: typeof UMB_CURRENT_USER_CONTEXT.TYPE;
+	#modalManager?: typeof UMB_MODAL_MANAGER_CONTEXT.TYPE;
 	#temporaryFileRepository;
+
+	#mediaDetailRepository = new UmbMediaDetailRepository(this);
 
 	constructor(args: TinyMcePluginArguments) {
 		super(args);
 
 		this.#temporaryFileRepository = new UmbTemporaryFileRepository(args.host);
+
+		this.consumeContext(UMB_MODAL_MANAGER_CONTEXT, (instance) => {
+			this.#modalManager = instance;
+		});
 
 		// TODO => this breaks tests. disabling for now
 		// will ignore user media start nodes
@@ -69,6 +76,8 @@ export default class UmbTinyMceMediaPickerPlugin extends UmbTinyMcePluginBase {
 			// Listen for SetContent to update images
 			this.editor.on('SetContent', async (e) => {
 				const content = e.content;
+
+				console.log('set content', content);
 
 				// Handle images that are pasted in
 				uploadBlobImages(this.editor, content);
@@ -131,10 +140,12 @@ export default class UmbTinyMceMediaPickerPlugin extends UmbTinyMcePluginBase {
 		*/
 
 		// TODO => startNodeId and startNodeIsVirtual do not exist on ContentTreeItemResponseModel
-		const modalManager = await this.getContext(UMB_MODAL_MANAGER_CONTEXT);
-		const modalHandler = modalManager.open(this, UMB_MEDIA_TREE_PICKER_MODAL, {
+
+		const modalHandler = this.#modalManager?.open(this, UMB_MEDIA_TREE_PICKER_MODAL, {
 			data: {
 				multiple: false,
+				hideTreeRoot: true,
+
 				//startNodeId,
 				//startNodeIsVirtual,
 			},
@@ -145,31 +156,48 @@ export default class UmbTinyMceMediaPickerPlugin extends UmbTinyMcePluginBase {
 
 		if (!modalHandler) return;
 
-		const { selection } = await modalHandler.onSubmit();
-		if (!selection.length) return;
+		const { selection } = await modalHandler.onSubmit().catch(() => ({ selection: undefined }));
+		if (!selection || !selection.length) return;
 
-		this.#insertInEditor(selection[0]);
+		this.#showMediaCaptionAltText(selection[0]);
 		this.editor.dispatch('Change');
 	}
 
-	// TODO => mediaPicker returns a UDI, so need to fetch it. Wait for backend CLI before implementing
-	async #insertInEditor(img: any) {
-		if (!img) return;
+	async #showMediaCaptionAltText(mediaUnique: string | null) {
+		if (!mediaUnique) return;
+
+		const modalHandler = this.#modalManager?.open(this, UMB_MEDIA_CAPTION_ALT_TEXT_MODAL, { data: { mediaUnique } });
+
+		await modalHandler?.onSubmit().catch(() => undefined);
+		const mediaData = modalHandler?.getValue();
+
+		const media: MediaPickerTargetData = {
+			altText: mediaData?.altText,
+			caption: mediaData?.caption,
+			url: mediaData?.url,
+			udi: mediaUnique,
+		};
+
+		this.#insertInEditor(media);
+	}
+
+	async #insertInEditor(media: MediaPickerTargetData) {
+		if (!media) return;
 
 		// We need to create a NEW DOM <img> element to insert
 		// setting an attribute of ID to __mcenew, so we can gather a reference to the node, to be able to update its size accordingly to the size of the image.
-		const data: MediaPickerResultData = {
-			alt: img.altText || '',
-			src: img.url ? img.url : 'nothing.jpg',
+		const img: MediaPickerResultData = {
+			alt: media.altText,
+			src: media.url ? media.url : 'nothing.jpg',
 			id: '__mcenew',
-			'data-udi': img.udi,
-			'data-caption': img.caption,
+			'data-udi': media.udi,
+			'data-caption': media.caption,
 		};
-		const newImage = this.editor.dom.createHTML('img', data as Record<string, string | null>);
+		const newImage = this.editor.dom.createHTML('img', img as Record<string, string | null>);
 		const parentElement = this.editor.selection.getNode().parentElement;
 
-		if (img.caption && parentElement) {
-			const figCaption = this.editor.dom.createHTML('figcaption', {}, img.caption);
+		if (img['data-caption'] && parentElement) {
+			const figCaption = this.editor.dom.createHTML('figcaption', {}, img['data-caption']);
 			const combined = newImage + figCaption;
 
 			if (parentElement.nodeName !== 'FIGURE') {
@@ -190,13 +218,14 @@ export default class UmbTinyMceMediaPickerPlugin extends UmbTinyMcePluginBase {
 		// Using settimeout to wait for a DoM-render, so we can find the new element by ID.
 		setTimeout(() => {
 			const imgElm = this.editor.dom.get('__mcenew') as HTMLImageElement;
+			console.log('timeout?', imgElm);
 			if (!imgElm) return;
 
 			this.editor.dom.setAttrib(imgElm, 'id', null);
 
 			// When image is loaded we are ready to call sizeImageInEditor.
 			const onImageLoaded = () => {
-				sizeImageInEditor(this.editor, imgElm, img.url);
+				sizeImageInEditor(this.editor, imgElm, img.src);
 				this.editor.dispatch('Change');
 			};
 

--- a/src/packages/tiny-mce/plugins/tiny-mce-mediapicker.plugin.ts
+++ b/src/packages/tiny-mce/plugins/tiny-mce-mediapicker.plugin.ts
@@ -171,7 +171,7 @@ export default class UmbTinyMceMediaPickerPlugin extends UmbTinyMcePluginBase {
 			altText: mediaData?.altText,
 			caption: mediaData?.caption,
 			url: mediaData?.url,
-			udi: mediaUnique,
+			udi: 'umb://media/' + mediaUnique?.replace(/-/g, ''),
 		};
 
 		this.#insertInEditor(media);

--- a/src/packages/tiny-mce/plugins/tiny-mce-mediapicker.plugin.ts
+++ b/src/packages/tiny-mce/plugins/tiny-mce-mediapicker.plugin.ts
@@ -5,7 +5,7 @@ import type { UMB_CURRENT_USER_CONTEXT, UmbCurrentUserModel } from '@umbraco-cms
 import type { RawEditorOptions } from '@umbraco-cms/backoffice/external/tinymce';
 import { UmbTemporaryFileRepository } from '@umbraco-cms/backoffice/temporary-file';
 import { UmbId } from '@umbraco-cms/backoffice/id';
-import { UmbMediaDetailRepository, sizeImageInEditor, uploadBlobImages } from '@umbraco-cms/backoffice/media';
+import { sizeImageInEditor, uploadBlobImages } from '@umbraco-cms/backoffice/media';
 
 interface MediaPickerTargetData {
 	altText?: string;
@@ -29,8 +29,6 @@ export default class UmbTinyMceMediaPickerPlugin extends UmbTinyMcePluginBase {
 	#currentUserContext?: typeof UMB_CURRENT_USER_CONTEXT.TYPE;
 	#modalManager?: typeof UMB_MODAL_MANAGER_CONTEXT.TYPE;
 	#temporaryFileRepository;
-
-	#mediaDetailRepository = new UmbMediaDetailRepository(this);
 
 	constructor(args: TinyMcePluginArguments) {
 		super(args);
@@ -76,8 +74,6 @@ export default class UmbTinyMceMediaPickerPlugin extends UmbTinyMcePluginBase {
 			// Listen for SetContent to update images
 			this.editor.on('SetContent', async (e) => {
 				const content = e.content;
-
-				console.log('set content', content);
 
 				// Handle images that are pasted in
 				uploadBlobImages(this.editor, content);
@@ -218,7 +214,6 @@ export default class UmbTinyMceMediaPickerPlugin extends UmbTinyMcePluginBase {
 		// Using settimeout to wait for a DoM-render, so we can find the new element by ID.
 		setTimeout(() => {
 			const imgElm = this.editor.dom.get('__mcenew') as HTMLImageElement;
-			console.log('timeout?', imgElm);
 			if (!imgElm) return;
 
 			this.editor.dom.setAttrib(imgElm, 'id', null);

--- a/src/packages/tiny-mce/property-editors/tiny-mce/manifests.ts
+++ b/src/packages/tiny-mce/property-editors/tiny-mce/manifests.ts
@@ -212,7 +212,7 @@ export const manifest: ManifestPropertyEditorUi = {
 					alias: 'mode',
 					label: 'Mode',
 					description: 'Select the mode for the editor',
-					propertyEditorUiAlias: 'Umb.PropertyEditorUi.Dropdown',
+					propertyEditorUiAlias: 'Umb.PropertyEditorUi.RadioButtonList',
 					config: [
 						{
 							alias: 'items',
@@ -230,6 +230,12 @@ export const manifest: ManifestPropertyEditorUi = {
 					alias: 'hideLabel',
 					label: 'Hide Label',
 					propertyEditorUiAlias: 'Umb.PropertyEditorUi.Toggle',
+				},
+			],
+			defaultData: [
+				{
+					alias: 'mode',
+					value: 'Classic',
 				},
 			],
 		},

--- a/src/packages/tiny-mce/property-editors/toolbar/property-editor-ui-tiny-mce-toolbar-configuration.element.ts
+++ b/src/packages/tiny-mce/property-editors/toolbar/property-editor-ui-tiny-mce-toolbar-configuration.element.ts
@@ -1,6 +1,6 @@
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import type { PropertyValueMap } from '@umbraco-cms/backoffice/external/lit';
-import { customElement, css, html, property, map, state } from '@umbraco-cms/backoffice/external/lit';
+import { customElement, css, html, property, state, repeat } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extension-registry';
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
@@ -25,7 +25,7 @@ export class UmbPropertyEditorUITinyMceToolbarConfigurationElement
 	extends UmbLitElement
 	implements UmbPropertyEditorUiElement
 {
-	@property()
+	@property({ attribute: false })
 	set value(value: string | string[] | null) {
 		if (!value) return;
 
@@ -48,7 +48,6 @@ export class UmbPropertyEditorUITinyMceToolbarConfigurationElement
 			v.selected = this.#selectedValues.includes(v.alias);
 		});
 	}
-
 	get value(): string[] {
 		return this.#selectedValues;
 	}
@@ -101,19 +100,20 @@ export class UmbPropertyEditorUITinyMceToolbarConfigurationElement
 		const checkbox = event.target as HTMLInputElement;
 		const alias = checkbox.value;
 
-		if (checkbox.checked) {
-			this.value = [...this.value, alias];
-		} else {
-			this.value = this.value.filter((v) => v !== alias);
-		}
+		const value = this._toolbarConfig
+			.filter((t) => (t.alias !== alias && t.selected) || (t.alias === alias && checkbox.checked))
+			.map((v) => v.alias);
+
+		this.value = value;
 
 		this.dispatchEvent(new CustomEvent('property-value-change'));
 	}
 
 	render() {
 		return html`<ul>
-			${map(
+			${repeat(
 				this._toolbarConfig,
+				(v) => v.alias,
 				(v) =>
 					html`<li>
 						<uui-checkbox label=${v.label} value=${v.alias} ?checked=${v.selected} @change=${this.onChange}>


### PR DESCRIPTION
## Description
Bug fixes:
- Fixed a crash caused by editor mode
- Datatype now saves the toolbar plugins in the order they are in the list: shows up in the same order in the editor
- Fixed an issue that caused the editor to act weird, when no toolbar plugins were picked.
- Fixed an issue where editor would crash, if a stylesheet didn't have any content
- Setting height and width to 0 acts the same as undefined, rather than collapsing the editor to 0px
- Setting img max width to 0 acts the same as undefined, rather than collapsing the image to 0px 
- Misc. media upload settings

New Features:
- Added modal for setting media alt text and caption
- Disabled the toolbar when there is no toolbar plugins picked.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

