### PR TITLE
Bugfix: Create nested media type folders

### DIFF
--- a/src/packages/media/media-types/tree/folder/media-type-folder.server.data-source.ts
+++ b/src/packages/media/media-types/tree/folder/media-type-folder.server.data-source.ts
@@ -61,7 +61,7 @@ export class UmbMediaTypeFolderServerDataSource implements UmbFolderDataSource {
 
 		const requestBody = {
 			id: args.unique,
-			parentId: args.parentUnique ? { id: args.parentUnique } : null,
+			parent: args.parentUnique ? { id: args.parentUnique } : null,
 			name: args.name,
 		};
 

--- a/src/packages/media/media-types/tree/reload-tree-item-children/manifests.ts
+++ b/src/packages/media/media-types/tree/reload-tree-item-children/manifests.ts
@@ -1,4 +1,8 @@
-import { UMB_MEDIA_TYPE_ENTITY_TYPE, UMB_MEDIA_TYPE_ROOT_ENTITY_TYPE } from '../../entity.js';
+import {
+	UMB_MEDIA_TYPE_ENTITY_TYPE,
+	UMB_MEDIA_TYPE_FOLDER_ENTITY_TYPE,
+	UMB_MEDIA_TYPE_ROOT_ENTITY_TYPE,
+} from '../../entity.js';
 import type { ManifestTypes } from '@umbraco-cms/backoffice/extension-registry';
 
 export const manifests: Array<ManifestTypes> = [
@@ -7,6 +11,6 @@ export const manifests: Array<ManifestTypes> = [
 		kind: 'reloadTreeItemChildren',
 		alias: 'Umb.EntityAction.MediaType.Tree.ReloadChildrenOf',
 		name: 'Reload Media Type Tree Item Children Entity Action',
-		forEntityTypes: [UMB_MEDIA_TYPE_ENTITY_TYPE, UMB_MEDIA_TYPE_ROOT_ENTITY_TYPE],
+		forEntityTypes: [UMB_MEDIA_TYPE_ENTITY_TYPE, UMB_MEDIA_TYPE_ROOT_ENTITY_TYPE, UMB_MEDIA_TYPE_FOLDER_ENTITY_TYPE],
 	},
 ];


### PR DESCRIPTION
This PR fixes the creation of nested media-type folders. We were passing the parent id in the wrong property to the server.

The PR also adds the reload children entity action to media type folders

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

