### PR TITLE
Feature: Collection View Layouts

### DIFF
--- a/src/packages/core/collection/collection-bulk-action-permission.condition.ts
+++ b/src/packages/core/collection/collection-bulk-action-permission.condition.ts
@@ -15,7 +15,7 @@ export class UmbCollectionBulkActionPermissionCondition
 		super(host, args);
 
 		this.consumeContext(UMB_DEFAULT_COLLECTION_CONTEXT, (context) => {
-			const allowedActions = context.getConfig().allowedEntityBulkActions;
+			const allowedActions = context.getConfig()?.allowedEntityBulkActions;
 			this.permitted = allowedActions ? this.config.match(allowedActions) : false;
 		});
 	}

--- a/src/packages/core/collection/collection-view.manager.test.ts
+++ b/src/packages/core/collection/collection-view.manager.test.ts
@@ -43,7 +43,8 @@ describe('UmbCollectionViewManager', () => {
 
 	beforeEach(() => {
 		const hostElement = new UmbTestControllerHostElement();
-		manager = new UmbCollectionViewManager(hostElement, config);
+		manager = new UmbCollectionViewManager(hostElement);
+		manager.setConfig(config);
 	});
 
 	describe('Public API', () => {
@@ -60,8 +61,8 @@ describe('UmbCollectionViewManager', () => {
 				expect(manager).to.have.property('routes').to.be.an.instanceOf(Observable);
 			});
 
-			it('has a rootPathname property', () => {
-				expect(manager).to.have.property('rootPathname').to.be.an.instanceOf(Observable);
+			it('has a rootPathName property', () => {
+				expect(manager).to.have.property('rootPathName').to.be.an.instanceOf(Observable);
 			});
 		});
 

--- a/src/packages/core/collection/collection-view.manager.ts
+++ b/src/packages/core/collection/collection-view.manager.ts
@@ -8,6 +8,7 @@ import type { UmbRoute } from '@umbraco-cms/backoffice/router';
 
 export interface UmbCollectionViewManagerConfig {
 	defaultViewAlias?: string;
+	manifestFilter?: (manifest: ManifestCollectionView) => boolean
 }
 
 export class UmbCollectionViewManager extends UmbControllerBase {
@@ -20,22 +21,24 @@ export class UmbCollectionViewManager extends UmbControllerBase {
 	#routes = new UmbArrayState<UmbRoute>([], (x) => x.path);
 	public readonly routes = this.#routes.asObservable();
 
-	#rootPathname = new UmbStringState('');
-	public readonly rootPathname = this.#rootPathname.asObservable();
+	#rootPathName = new UmbStringState('');
+	public readonly rootPathName = this.#rootPathName.asObservable();
 
 	#defaultViewAlias?: string;
 
-	constructor(host: UmbControllerHost, config: UmbCollectionViewManagerConfig) {
+	constructor(host: UmbControllerHost) {
 		super(host);
-
-		this.#defaultViewAlias = config.defaultViewAlias;
-		this.#observeViews();
 
 		// TODO: hack - we need to figure out how to get the "parent path" from the router
 		setTimeout(() => {
 			const currentUrl = new URL(window.location.href);
-			this.#rootPathname.setValue(currentUrl.pathname.substring(0, currentUrl.pathname.lastIndexOf('/')));
+			this.#rootPathName.setValue(currentUrl.pathname.substring(0, currentUrl.pathname.lastIndexOf('/')));
 		}, 100);
+	}
+
+	public setConfig(config: UmbCollectionViewManagerConfig) {
+		this.#defaultViewAlias = config.defaultViewAlias;
+		this.#observeViews(config.manifestFilter);
 	}
 
 	// Views
@@ -57,12 +60,18 @@ export class UmbCollectionViewManager extends UmbControllerBase {
 		return this.#currentView.getValue();
 	}
 
-	#observeViews() {
-		return new UmbExtensionsManifestInitializer(this, umbExtensionsRegistry, 'collectionView', null, (views) => {
-			const manifests = views.map((view) => view.manifest);
-			this.#views.setValue(manifests);
-			this.#createRoutes(manifests);
-		});
+	#observeViews(filter?: (manifest: ManifestCollectionView) => boolean) {
+		return new UmbExtensionsManifestInitializer(
+			this,
+			umbExtensionsRegistry,
+			'collectionView',
+			filter ?? null,
+			(views) => {
+				const manifests = views.map((view) => view.manifest);
+				this.#views.setValue(manifests);
+				this.#createRoutes(manifests);
+			},
+		);
 	}
 
 	#createRoutes(views: ManifestCollectionView[] | null) {

--- a/src/packages/core/collection/collection.element.ts
+++ b/src/packages/core/collection/collection.element.ts
@@ -8,6 +8,7 @@ import type { ManifestCollection } from '@umbraco-cms/backoffice/extension-regis
 @customElement('umb-collection')
 export class UmbCollectionElement extends UmbLitElement {
 	#alias?: string;
+
 	@property({ type: String, reflect: true })
 	set alias(newVal) {
 		this.#alias = newVal;
@@ -17,7 +18,8 @@ export class UmbCollectionElement extends UmbLitElement {
 		return this.#alias;
 	}
 
-	#config?: UmbCollectionConfiguration = { pageSize: 50 };
+	#config?: UmbCollectionConfiguration;
+
 	@property({ type: Object, attribute: false })
 	set config(newVal: UmbCollectionConfiguration | undefined) {
 		this.#config = newVal;

--- a/src/packages/core/collection/default/collection-default.context.ts
+++ b/src/packages/core/collection/default/collection-default.context.ts
@@ -1,16 +1,24 @@
-import type { UmbCollectionColumnConfiguration, UmbCollectionConfiguration, UmbCollectionContext } from '../types.js';
 import { UmbCollectionViewManager } from '../collection-view.manager.js';
+import type { UmbCollectionViewManagerConfig } from '../collection-view.manager.js';
+import type {
+	UmbCollectionColumnConfiguration,
+	UmbCollectionConfiguration,
+	UmbCollectionContext,
+	UmbCollectionLayoutConfiguration,
+} from '../types.js';
+import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
+import { UmbArrayState, UmbNumberState, UmbObjectState } from '@umbraco-cms/backoffice/observable-api';
+import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
 import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
-import { UmbArrayState, UmbNumberState, UmbObjectState } from '@umbraco-cms/backoffice/observable-api';
 import { UmbExtensionApiInitializer } from '@umbraco-cms/backoffice/extension-api';
-import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbSelectionManager, UmbPaginationManager } from '@umbraco-cms/backoffice/utils';
-import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import type { ManifestCollection, ManifestRepository } from '@umbraco-cms/backoffice/extension-registry';
 import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
 import type { UmbCollectionFilterModel, UmbCollectionRepository } from '@umbraco-cms/backoffice/collection';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+
+const LOCAL_STORAGE_KEY = 'umb-collection-view';
 
 export class UmbDefaultCollectionContext<
 		CollectionItemType = any,
@@ -19,7 +27,9 @@ export class UmbDefaultCollectionContext<
 	extends UmbContextBase<UmbDefaultCollectionContext>
 	implements UmbCollectionContext, UmbApi
 {
+	#config?: UmbCollectionConfiguration = { pageSize: 50 };
 	#manifest?: ManifestCollection;
+	#repository?: UmbCollectionRepository;
 
 	#items = new UmbArrayState<CollectionItemType>([], (x) => x);
 	public readonly items = this.#items.asObservable();
@@ -30,10 +40,17 @@ export class UmbDefaultCollectionContext<
 	#filter = new UmbObjectState<FilterModelType | object>({});
 	public readonly filter = this.#filter.asObservable();
 
-	#userDefinedProperties = new UmbArrayState<UmbCollectionColumnConfiguration>([], (x) => x);
+	#userDefinedProperties = new UmbArrayState<UmbCollectionColumnConfiguration>([], (x) => x.alias);
 	public readonly userDefinedProperties = this.#userDefinedProperties.asObservable();
 
-	repository?: UmbCollectionRepository;
+	#viewLayouts = new UmbArrayState<UmbCollectionLayoutConfiguration>([], (x) => x.collectionView);
+	public readonly viewLayouts = this.#viewLayouts.asObservable();
+
+	public readonly pagination = new UmbPaginationManager();
+	public readonly selection = new UmbSelectionManager(this);
+	public readonly view = new UmbCollectionViewManager(this);
+
+	#defaultViewAlias: string;
 
 	#initResolver?: () => void;
 	#initialized = false;
@@ -42,28 +59,72 @@ export class UmbDefaultCollectionContext<
 		this.#initialized ? resolve() : (this.#initResolver = resolve);
 	});
 
-	public readonly pagination = new UmbPaginationManager();
-	public readonly selection = new UmbSelectionManager(this);
-	public readonly view;
-
 	constructor(host: UmbControllerHost, defaultViewAlias: string) {
 		super(host, UMB_DEFAULT_COLLECTION_CONTEXT);
 
-		// listen for page changes on the pagination manager
-		this.pagination.addEventListener(UmbChangeEvent.TYPE, this.#onPageChange);
+		this.#defaultViewAlias = defaultViewAlias;
 
-		this.view = new UmbCollectionViewManager(this, { defaultViewAlias: defaultViewAlias });
+		this.pagination.addEventListener(UmbChangeEvent.TYPE, this.#onPageChange);
 	}
 
-	// TODO: find a generic way to do this
+	#configured = false;
+
+	#configure() {
+		if (!this.#config) return;
+
+		this.selection.setMultiple(true);
+
+		if (this.#config.pageSize) {
+			this.pagination.setPageSize(this.#config.pageSize);
+		}
+
+		this.#filter.setValue({
+			...this.#config,
+			...this.#filter.getValue(),
+			skip: 0,
+			take: this.#config.pageSize,
+		});
+
+		this.#userDefinedProperties.setValue(this.#config?.userDefinedProperties ?? []);
+
+		const viewManagerConfig: UmbCollectionViewManagerConfig = { defaultViewAlias: this.#defaultViewAlias };
+
+		if (this.#config.layouts && this.#config.layouts.length > 0) {
+			this.#viewLayouts.setValue(this.#config.layouts);
+			const aliases = this.#config.layouts.map((layout) => layout.collectionView);
+			viewManagerConfig.manifestFilter = (manifest) => aliases.includes(manifest.alias);
+		}
+
+		this.view.setConfig(viewManagerConfig);
+
+		this.#configured = true;
+	}
+
 	#checkIfInitialized() {
-		if (this.repository) {
+		if (this.#repository) {
 			this.#initialized = true;
 			this.#initResolver?.();
 		}
 	}
 
-	#config: UmbCollectionConfiguration = { pageSize: 50 };
+	#observeRepository(repositoryAlias: string) {
+		new UmbExtensionApiInitializer<ManifestRepository<UmbCollectionRepository>>(
+			this,
+			umbExtensionsRegistry,
+			repositoryAlias,
+			[this._host],
+			(permitted, ctrl) => {
+				this.#repository = permitted ? ctrl.api : undefined;
+				this.#checkIfInitialized();
+			},
+		);
+	}
+
+	#onPageChange = (event: UmbChangeEvent) => {
+		const target = event.target as UmbPaginationManager;
+		const skipFilter = { skip: target.getSkip() } as Partial<FilterModelType>;
+		this.setFilter(skipFilter);
+	};
 
 	/**
 	 * Sets the configuration for the collection.
@@ -72,7 +133,6 @@ export class UmbDefaultCollectionContext<
 	 */
 	public setConfig(config: UmbCollectionConfiguration) {
 		this.#config = config;
-		this.#configure();
 	}
 
 	public getConfig() {
@@ -108,10 +168,13 @@ export class UmbDefaultCollectionContext<
 	 */
 	public async requestCollection() {
 		await this.#init;
-		if (!this.repository) throw new Error(`Missing repository for ${this.#manifest}`);
+
+		if (!this.#configured) this.#configure();
+
+		if (!this.#repository) throw new Error(`Missing repository for ${this.#manifest}`);
 
 		const filter = this.#filter.getValue();
-		const { data } = await this.repository.requestCollection(filter);
+		const { data } = await this.#repository.requestCollection(filter);
 
 		if (data) {
 			this.#items.setValue(data.items);
@@ -130,35 +193,24 @@ export class UmbDefaultCollectionContext<
 		this.requestCollection();
 	}
 
-	#configure() {
-		this.selection.setMultiple(true);
-		this.pagination.setPageSize(this.#config.pageSize!);
-		this.#filter.setValue({
-			...this.#config,
-			...this.#filter.getValue(),
-			skip: 0,
-			take: this.#config.pageSize,
-		});
-		this.#userDefinedProperties.setValue(this.#config.userDefinedProperties ?? []);
+	public getLastSelectedView(unique: string | undefined): string | undefined {
+		if (!unique) return;
+
+		const layouts = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) ?? '{}') ?? {};
+		if (!layouts) return;
+
+		return layouts[unique];
 	}
 
-	#onPageChange = (event: UmbChangeEvent) => {
-		const target = event.target as UmbPaginationManager;
-		const skipFilter = { skip: target.getSkip() } as Partial<FilterModelType>;
-		this.setFilter(skipFilter);
-	};
+	public setLastSelectedView(unique: string | undefined, viewAlias: string) {
+		if (!unique) return;
 
-	#observeRepository(repositoryAlias: string) {
-		new UmbExtensionApiInitializer<ManifestRepository<UmbCollectionRepository>>(
-			this,
-			umbExtensionsRegistry,
-			repositoryAlias,
-			[this._host],
-			(permitted, ctrl) => {
-				this.repository = permitted ? ctrl.api : undefined;
-				this.#checkIfInitialized();
-			},
-		);
+		const layouts = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) ?? '{}') ?? {};
+		if (!layouts) return;
+
+		layouts[unique] = viewAlias;
+
+		localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(layouts));
 	}
 }
 

--- a/src/packages/core/components/icon/icon.element.ts
+++ b/src/packages/core/components/icon/icon.element.ts
@@ -34,7 +34,13 @@ export class UmbIconElement extends UmbLitElement {
 	@property({ type: String })
 	public set name(value: string | undefined) {
 		const [icon, alias] = value ? value.split(' ') : [];
-		if (alias) this.#setColorStyle(alias);
+
+		if (alias) {
+			this.#setColorStyle(alias);
+		} else {
+			this._color = undefined;
+		}
+
 		this._icon = icon;
 	}
 	public get name(): string | undefined {

--- a/src/packages/core/property-editor/uis/collection-view/property-editor-ui-collection-view.element.ts
+++ b/src/packages/core/property-editor/uis/collection-view/property-editor-ui-collection-view.element.ts
@@ -56,6 +56,7 @@ export class UmbPropertyEditorUICollectionViewElement extends UmbLitElement impl
 	): UmbCollectionConfiguration {
 		return {
 			allowedEntityBulkActions: config?.getValueByAlias<UmbCollectionBulkActionPermissions>('bulkActionPermissions'),
+			layouts: config?.getValueByAlias('layouts'),
 			orderBy: config?.getValueByAlias('orderBy') ?? 'updateDate',
 			orderDirection: config?.getValueByAlias('orderDirection') ?? 'asc',
 			pageSize: Number(config?.getValueByAlias('pageSize')) ?? 50,

--- a/src/packages/documents/documents/collection/document-collection-toolbar.element.ts
+++ b/src/packages/documents/documents/collection/document-collection-toolbar.element.ts
@@ -1,11 +1,11 @@
-import type { UmbDocumentCollectionContext } from './document-collection.context.js';
 import { css, html, customElement } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UMB_DEFAULT_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
+import type { UmbDefaultCollectionContext } from '@umbraco-cms/backoffice/collection';
 
 @customElement('umb-document-collection-toolbar')
 export class UmbDocumentCollectionToolbarElement extends UmbLitElement {
-	#collectionContext?: UmbDocumentCollectionContext;
+	#collectionContext?: UmbDefaultCollectionContext;
 
 	#inputTimer?: NodeJS.Timeout;
 	#inputTimerAmount = 500;
@@ -14,7 +14,7 @@ export class UmbDocumentCollectionToolbarElement extends UmbLitElement {
 		super();
 
 		this.consumeContext(UMB_DEFAULT_COLLECTION_CONTEXT, (instance) => {
-			this.#collectionContext = instance as UmbDocumentCollectionContext;
+			this.#collectionContext = instance;
 		});
 	}
 

--- a/src/packages/documents/documents/collection/document-collection.context.ts
+++ b/src/packages/documents/documents/collection/document-collection.context.ts
@@ -9,6 +9,5 @@ export class UmbDocumentCollectionContext extends UmbDefaultCollectionContext<
 > {
 	constructor(host: UmbControllerHost) {
 		super(host, UMB_DOCUMENT_TABLE_COLLECTION_VIEW_ALIAS);
-
 	}
 }


### PR DESCRIPTION
Wired up the final pieces for the configuration of the Collection View layouts.

**Testing notes**: If a Collection has a data-type configuration with layout options, then they will be mapped to the `collectionView` manifests that are allowed on that Collection, (e.g. the manifest matches the condition), and the custom icon, label and order will be displayed.

If there is no layout configuration for the Collection, it will default to the `collectionView` manifests for that Collection (e.g. that match the condition).