### PR TITLE
Feature: Document Collection: Adds `contentTypeAlias` to the column property values

### DIFF
--- a/src/packages/documents/documents/collection/repository/document-collection.server.data-source.ts
+++ b/src/packages/documents/documents/collection/repository/document-collection.server.data-source.ts
@@ -37,6 +37,7 @@ export class UmbDocumentCollectionServerDataSource implements UmbCollectionDataS
 
 				const model: UmbDocumentCollectionItemModel = {
 					unique: item.id,
+					contentTypeAlias: item.documentType.alias,
 					createDate: new Date(variant.createDate),
 					creator: item.creator,
 					icon: item.documentType.icon,

--- a/src/packages/documents/documents/collection/types.ts
+++ b/src/packages/documents/documents/collection/types.ts
@@ -11,6 +11,7 @@ export interface UmbDocumentCollectionFilterModel extends UmbCollectionFilterMod
 
 export interface UmbDocumentCollectionItemModel {
 	unique: string;
+	contentTypeAlias: string;
 	createDate: Date;
 	creator?: string | null;
 	icon: string;

--- a/src/packages/documents/documents/collection/views/index.ts
+++ b/src/packages/documents/documents/collection/views/index.ts
@@ -4,6 +4,8 @@ export { UMB_DOCUMENT_GRID_COLLECTION_VIEW_ALIAS, UMB_DOCUMENT_TABLE_COLLECTION_
 
 export function getPropertyValueByAlias(sortOrder: number, item: UmbDocumentCollectionItemModel, alias: string) {
 	switch (alias) {
+		case 'contentTypeAlias':
+			return item.contentTypeAlias;
 		case 'createDate':
 			return item.createDate.toLocaleString();
 		case 'creator':


### PR DESCRIPTION
I'd spotted that the `contentTypeAlias` value was missing from the Document Collection table view, so have now wired it up.