### PR TITLE
rename our save workspace action api to submit

### DIFF
--- a/src/packages/block/block-grid/components/block-grid-area-config-entry/workspace/manifests.ts
+++ b/src/packages/block/block-grid/components/block-grid-area-config-entry/workspace/manifests.ts
@@ -1,7 +1,7 @@
 import { manifests as workspaceViewManifests } from './views/manifests.js';
 import { UMB_BLOCK_GRID_AREA_TYPE_WORKSPACE_ALIAS } from './index.js';
 import type { ManifestTypes } from '@umbraco-cms/backoffice/extension-registry';
-import { UmbSaveWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
+import { UmbSubmitWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
 
 export const manifests: Array<ManifestTypes> = [
 	...workspaceViewManifests,
@@ -19,7 +19,7 @@ export const manifests: Array<ManifestTypes> = [
 		type: 'workspaceAction',
 		alias: 'Umb.WorkspaceAction.BlockGridAreaType.Save',
 		name: 'Save Block Grid Area Type Workspace Action',
-		api: UmbSaveWorkspaceAction,
+		api: UmbSubmitWorkspaceAction,
 		meta: {
 			label: 'Submit',
 			look: 'primary',

--- a/src/packages/block/block-type/workspace/manifests.ts
+++ b/src/packages/block/block-type/workspace/manifests.ts
@@ -1,7 +1,7 @@
 import { UMB_BLOCK_GRID_TYPE_WORKSPACE_ALIAS } from '../../block-grid/workspace/index.js';
 import { UMB_BLOCK_LIST_TYPE_WORKSPACE_ALIAS } from '../../block-list/workspace/index.js';
 import { UMB_BLOCK_RTE_TYPE_WORKSPACE_ALIAS } from '../../block-rte/workspace/index.js';
-import { UmbSaveWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
+import { UmbSubmitWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
 import type { ManifestWorkspaceActions } from '@umbraco-cms/backoffice/extension-registry';
 
 export const manifests: Array<ManifestWorkspaceActions> = [
@@ -10,7 +10,7 @@ export const manifests: Array<ManifestWorkspaceActions> = [
 		kind: 'default',
 		alias: 'Umb.WorkspaceAction.BlockType.Save',
 		name: 'Save Block Type Workspace Action',
-		api: UmbSaveWorkspaceAction,
+		api: UmbSubmitWorkspaceAction,
 		meta: {
 			label: 'Submit',
 			look: 'primary',

--- a/src/packages/block/block/workspace/manifests.ts
+++ b/src/packages/block/block/workspace/manifests.ts
@@ -1,5 +1,5 @@
 import { UMB_BLOCK_WORKSPACE_ALIAS } from './index.js';
-import { UmbSaveWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
+import { UmbSubmitWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
 import type { ManifestTypes } from '@umbraco-cms/backoffice/extension-registry';
 
 export const manifests: Array<ManifestTypes> = [
@@ -8,7 +8,7 @@ export const manifests: Array<ManifestTypes> = [
 		kind: 'default',
 		alias: 'Umb.WorkspaceAction.Block.Save',
 		name: 'Save Block Type Workspace Action',
-		api: UmbSaveWorkspaceAction,
+		api: UmbSubmitWorkspaceAction,
 		meta: {
 			label: 'Submit',
 			look: 'primary',

--- a/src/packages/core/workspace/components/workspace-action/common/index.ts
+++ b/src/packages/core/workspace/components/workspace-action/common/index.ts
@@ -1,1 +1,1 @@
-export * from './save/index.js';
+export * from './submit/index.js';

--- a/src/packages/core/workspace/components/workspace-action/common/save/index.ts
+++ b/src/packages/core/workspace/components/workspace-action/common/save/index.ts
@@ -1,1 +1,0 @@
-export * from './save.action.js';

--- a/src/packages/core/workspace/components/workspace-action/common/submit/index.ts
+++ b/src/packages/core/workspace/components/workspace-action/common/submit/index.ts
@@ -1,0 +1,1 @@
+export * from './submit.action.js';

--- a/src/packages/core/workspace/components/workspace-action/common/submit/submit.action.ts
+++ b/src/packages/core/workspace/components/workspace-action/common/submit/submit.action.ts
@@ -39,5 +39,6 @@ export class UmbSubmitWorkspaceAction extends UmbWorkspaceActionBase<UmbSubmitta
 
 /*
  * @deprecated Use UmbSubmitWorkspaceAction instead
+ * TODO: Remove as part of RC
  */
 export { UmbSubmitWorkspaceAction as UmbSaveWorkspaceAction };

--- a/src/packages/core/workspace/components/workspace-action/common/submit/submit.action.ts
+++ b/src/packages/core/workspace/components/workspace-action/common/submit/submit.action.ts
@@ -3,7 +3,7 @@ import { UmbWorkspaceActionBase } from '../../workspace-action-base.controller.j
 import { UMB_SUBMITTABLE_WORKSPACE_CONTEXT, type UmbWorkspaceActionArgs } from '@umbraco-cms/backoffice/workspace';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
-export class UmbSaveWorkspaceAction extends UmbWorkspaceActionBase<UmbSubmittableWorkspaceContext> {
+export class UmbSubmitWorkspaceAction extends UmbWorkspaceActionBase<UmbSubmittableWorkspaceContext> {
 	#workspaceContext?: UmbSubmittableWorkspaceContext;
 
 	constructor(host: UmbControllerHost, args: UmbWorkspaceActionArgs<UmbSubmittableWorkspaceContext>) {
@@ -36,3 +36,8 @@ export class UmbSaveWorkspaceAction extends UmbWorkspaceActionBase<UmbSubmittabl
 		return workspaceContext.requestSubmit();
 	}
 }
+
+/*
+ * @deprecated Use UmbSubmitWorkspaceAction instead
+ */
+export { UmbSubmitWorkspaceAction as UmbSaveWorkspaceAction };

--- a/src/packages/data-type/workspace/manifests.ts
+++ b/src/packages/data-type/workspace/manifests.ts
@@ -1,4 +1,4 @@
-import { UmbSaveWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
+import { UmbSubmitWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
 import type {
 	ManifestWorkspaces,
 	ManifestWorkspaceActions,
@@ -63,7 +63,7 @@ const workspaceActions: Array<ManifestWorkspaceActions> = [
 		kind: 'default',
 		alias: 'Umb.WorkspaceAction.DataType.Save',
 		name: 'Save Data Type Workspace Action',
-		api: UmbSaveWorkspaceAction,
+		api: UmbSubmitWorkspaceAction,
 		meta: {
 			label: 'Save',
 			look: 'primary',

--- a/src/packages/dictionary/workspace/manifests.ts
+++ b/src/packages/dictionary/workspace/manifests.ts
@@ -1,5 +1,5 @@
 import { UMB_DICTIONARY_ENTITY_TYPE } from '../entity.js';
-import { UmbSaveWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
+import { UmbSubmitWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
 import type {
 	ManifestWorkspaces,
 	ManifestWorkspaceActions,
@@ -45,7 +45,7 @@ const workspaceActions: Array<ManifestWorkspaceActions> = [
 		alias: 'Umb.WorkspaceAction.Dictionary.Save',
 		name: 'Save Dictionary Workspace Action',
 		weight: 90,
-		api: UmbSaveWorkspaceAction,
+		api: UmbSubmitWorkspaceAction,
 		meta: {
 			label: 'Save',
 			look: 'primary',

--- a/src/packages/documents/document-types/workspace/manifests.ts
+++ b/src/packages/documents/document-types/workspace/manifests.ts
@@ -1,5 +1,5 @@
 import { UMB_DOCUMENT_TYPE_COMPOSITION_REPOSITORY_ALIAS } from '../repository/composition/index.js';
-import { UmbSaveWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
+import { UmbSubmitWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
 import type {
 	ManifestWorkspace,
 	ManifestWorkspaceActions,
@@ -100,7 +100,7 @@ const workspaceActions: Array<ManifestWorkspaceActions> = [
 		kind: 'default',
 		alias: 'Umb.WorkspaceAction.DocumentType.Save',
 		name: 'Save Document Type Workspace Action',
-		api: UmbSaveWorkspaceAction,
+		api: UmbSubmitWorkspaceAction,
 		meta: {
 			label: 'Save',
 			look: 'primary',

--- a/src/packages/documents/documents/workspace/manifests.ts
+++ b/src/packages/documents/documents/workspace/manifests.ts
@@ -3,7 +3,7 @@ import { UmbDocumentSaveAndScheduleWorkspaceAction } from './actions/save-and-sc
 import { UmbDocumentUnpublishWorkspaceAction } from './actions/unpublish.action.js';
 import { UmbDocumentSaveAndPublishWorkspaceAction } from './actions/save-and-publish.action.js';
 import { UmbDocumentPublishWithDescendantsWorkspaceAction } from './actions/publish-with-descendants.action.js';
-import { UmbSaveWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
+import { UmbSubmitWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
 import type {
 	ManifestWorkspaces,
 	ManifestWorkspaceActions,
@@ -89,7 +89,7 @@ const workspaceActions: Array<ManifestWorkspaceActions> = [
 		alias: 'Umb.WorkspaceAction.Document.Save',
 		name: 'Save Document Workspace Action',
 		weight: 80,
-		api: UmbSaveWorkspaceAction,
+		api: UmbSubmitWorkspaceAction,
 		meta: {
 			label: 'Save',
 			look: 'secondary',

--- a/src/packages/language/workspace/language/manifests.ts
+++ b/src/packages/language/workspace/language/manifests.ts
@@ -1,4 +1,4 @@
-import { UmbSaveWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
+import { UmbSubmitWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
 import type {
 	ManifestWorkspaces,
 	ManifestWorkspaceActions,
@@ -43,7 +43,7 @@ const workspaceActions: Array<ManifestWorkspaceActions> = [
 		kind: 'default',
 		alias: 'Umb.WorkspaceAction.Language.Save',
 		name: 'Save Language Workspace Action',
-		api: UmbSaveWorkspaceAction,
+		api: UmbSubmitWorkspaceAction,
 		meta: {
 			look: 'primary',
 			color: 'positive',

--- a/src/packages/media/media-types/workspace/manifests.ts
+++ b/src/packages/media/media-types/workspace/manifests.ts
@@ -4,7 +4,7 @@ import type {
 	ManifestWorkspaceViews,
 } from '@umbraco-cms/backoffice/extension-registry';
 
-import { UmbSaveWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
+import { UmbSubmitWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
 
 export const UMB_MEDIA_TYPE_WORKSPACE_ALIAS = 'Umb.Workspace.MediaType';
 
@@ -63,7 +63,7 @@ const workspaceActions: Array<ManifestWorkspaceActions> = [
 		kind: 'default',
 		alias: 'Umb.WorkspaceAction.MediaType.Save',
 		name: 'Save Media Type Workspace Action',
-		api: UmbSaveWorkspaceAction,
+		api: UmbSubmitWorkspaceAction,
 		meta: {
 			label: 'Save',
 			look: 'primary',

--- a/src/packages/media/media/workspace/manifests.ts
+++ b/src/packages/media/media/workspace/manifests.ts
@@ -1,4 +1,4 @@
-import { UmbSaveWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
+import { UmbSubmitWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
 import type {
 	ManifestWorkspaces,
 	ManifestWorkspaceActions,
@@ -61,7 +61,7 @@ const workspaceActions: Array<ManifestWorkspaceActions> = [
 		kind: 'default',
 		alias: 'Umb.WorkspaceAction.Media.Save',
 		name: 'Save Media Workspace Action',
-		api: UmbSaveWorkspaceAction,
+		api: UmbSubmitWorkspaceAction,
 		meta: {
 			label: 'Save',
 			look: 'primary',

--- a/src/packages/members/member-group/workspace/manifests.ts
+++ b/src/packages/members/member-group/workspace/manifests.ts
@@ -1,5 +1,5 @@
 import { UMB_MEMBER_GROUP_ENTITY_TYPE } from '../entity.js';
-import { UmbSaveWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
+import { UmbSubmitWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
 import type {
 	ManifestWorkspaces,
 	ManifestWorkspaceActions,
@@ -25,7 +25,7 @@ const workspaceActions: Array<ManifestWorkspaceActions> = [
 		kind: 'default',
 		alias: 'Umb.WorkspaceAction.MemberGroup.Save',
 		name: 'Save Member Group Workspace Action',
-		api: UmbSaveWorkspaceAction,
+		api: UmbSubmitWorkspaceAction,
 		meta: {
 			label: 'Save',
 			look: 'primary',

--- a/src/packages/members/member-type/workspace/manifests.ts
+++ b/src/packages/members/member-type/workspace/manifests.ts
@@ -3,7 +3,7 @@ import type {
 	ManifestWorkspaceActions,
 	ManifestWorkspaceView,
 } from '@umbraco-cms/backoffice/extension-registry';
-import { UmbSaveWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
+import { UmbSubmitWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
 
 export const UMB_MEMBER_TYPE_WORKSPACE_ALIAS = 'Umb.Workspace.MemberType';
 
@@ -44,7 +44,7 @@ const workspaceActions: Array<ManifestWorkspaceActions> = [
 		kind: 'default',
 		alias: 'Umb.WorkspaceAction.MemberType.Save',
 		name: 'Save Member Type Workspace Action',
-		api: UmbSaveWorkspaceAction,
+		api: UmbSubmitWorkspaceAction,
 		meta: {
 			label: 'Save',
 			look: 'primary',

--- a/src/packages/members/member/workspace/manifests.ts
+++ b/src/packages/members/member/workspace/manifests.ts
@@ -1,5 +1,5 @@
 import { UMB_MEMBER_ENTITY_TYPE } from '../entity.js';
-import { UmbSaveWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
+import { UmbSubmitWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
 import type {
 	ManifestWorkspaces,
 	ManifestWorkspaceActions,
@@ -25,7 +25,7 @@ const workspaceActions: Array<ManifestWorkspaceActions> = [
 		kind: 'default',
 		alias: 'Umb.WorkspaceAction.Member.Save',
 		name: 'Save Member Workspace Action',
-		api: UmbSaveWorkspaceAction,
+		api: UmbSubmitWorkspaceAction,
 		meta: {
 			label: 'Save',
 			look: 'primary',

--- a/src/packages/templating/partial-views/workspace/manifests.ts
+++ b/src/packages/templating/partial-views/workspace/manifests.ts
@@ -1,4 +1,4 @@
-import { UmbSaveWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
+import { UmbSubmitWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
 import type { ManifestWorkspaces, ManifestWorkspaceActions } from '@umbraco-cms/backoffice/extension-registry';
 
 export const UMB_PARTIAL_VIEW_WORKSPACE_ALIAS = 'Umb.Workspace.PartialView';
@@ -20,7 +20,7 @@ const workspaceActions: Array<ManifestWorkspaceActions> = [
 		kind: 'default',
 		alias: 'Umb.WorkspaceAction.PartialView.Save',
 		name: 'Save Partial View',
-		api: UmbSaveWorkspaceAction,
+		api: UmbSubmitWorkspaceAction,
 		meta: {
 			label: 'Save',
 			look: 'primary',

--- a/src/packages/templating/scripts/workspace/manifests.ts
+++ b/src/packages/templating/scripts/workspace/manifests.ts
@@ -1,5 +1,5 @@
 import { UMB_SCRIPT_ENTITY_TYPE } from '../entity.js';
-import { UmbSaveWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
+import { UmbSubmitWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
 import type { ManifestWorkspaces, ManifestWorkspaceActions } from '@umbraco-cms/backoffice/extension-registry';
 
 export const UMB_SCRIPT_WORKSPACE_ALIAS = 'Umb.Workspace.Script';
@@ -22,7 +22,7 @@ const workspaceActions: Array<ManifestWorkspaceActions> = [
 		kind: 'default',
 		alias: UMB_SAVE_SCRIPT_WORKSPACE_ACTION_ALIAS,
 		name: 'Save Script Workspace Action',
-		api: UmbSaveWorkspaceAction,
+		api: UmbSubmitWorkspaceAction,
 		meta: {
 			label: 'Save',
 			look: 'primary',

--- a/src/packages/templating/stylesheets/workspace/manifests.ts
+++ b/src/packages/templating/stylesheets/workspace/manifests.ts
@@ -3,7 +3,7 @@ import type {
 	ManifestWorkspaceActions,
 	ManifestWorkspaceView,
 } from '@umbraco-cms/backoffice/extension-registry';
-import { UmbSaveWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
+import { UmbSubmitWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
 
 export const UMB_STYLESHEET_WORKSPACE_ALIAS = 'Umb.Workspace.Stylesheet';
 
@@ -62,7 +62,7 @@ const workspaceActions: Array<ManifestWorkspaceActions> = [
 		kind: 'default',
 		alias: 'Umb.WorkspaceAction.Stylesheet.Save',
 		name: 'Save Stylesheet Workspace Action',
-		api: UmbSaveWorkspaceAction,
+		api: UmbSubmitWorkspaceAction,
 		meta: {
 			label: 'Save',
 			look: 'primary',

--- a/src/packages/templating/templates/workspace/manifests.ts
+++ b/src/packages/templating/templates/workspace/manifests.ts
@@ -1,4 +1,4 @@
-import { UmbSaveWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
+import { UmbSubmitWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
 import type {
 	ManifestWorkspaces,
 	ManifestWorkspaceActions,
@@ -26,7 +26,7 @@ const workspaceActions: Array<ManifestWorkspaceActions> = [
 		kind: 'default',
 		alias: 'Umb.WorkspaceAction.Template.Save',
 		name: 'Save Template',
-		api: UmbSaveWorkspaceAction,
+		api: UmbSubmitWorkspaceAction,
 		weight: 70,
 		meta: {
 			look: 'primary',

--- a/src/packages/user/user-group/workspace/manifests.ts
+++ b/src/packages/user/user-group/workspace/manifests.ts
@@ -3,7 +3,7 @@ import type {
 	ManifestWorkspaceActions,
 	ManifestWorkspaceView,
 } from '@umbraco-cms/backoffice/extension-registry';
-import { UmbSaveWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
+import { UmbSubmitWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
 
 const workspace: ManifestWorkspaces = {
 	type: 'workspace',
@@ -23,7 +23,7 @@ const workspaceActions: Array<ManifestWorkspaceActions> = [
 		kind: 'default',
 		alias: 'Umb.WorkspaceAction.UserGroup.Save',
 		name: 'Save User Group Workspace Action',
-		api: UmbSaveWorkspaceAction,
+		api: UmbSubmitWorkspaceAction,
 		meta: {
 			label: 'Save',
 			look: 'primary',

--- a/src/packages/user/user/workspace/manifests.ts
+++ b/src/packages/user/user/workspace/manifests.ts
@@ -1,5 +1,5 @@
 import { UMB_USER_ENTITY_TYPE } from '../entity.js';
-import { UmbSaveWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
+import { UmbSubmitWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
 import type {
 	ManifestWorkspaces,
 	ManifestWorkspaceActions,
@@ -26,7 +26,7 @@ const workspaceActions: Array<ManifestWorkspaceActions> = [
 		kind: 'default',
 		alias: 'Umb.WorkspaceAction.User.Save',
 		name: 'Save User Workspace Action',
-		api: UmbSaveWorkspaceAction,
+		api: UmbSubmitWorkspaceAction,
 		meta: {
 			label: 'Save',
 			look: 'primary',


### PR DESCRIPTION
Rename the save action api to fit with the rest of the code. aka. submit.

This is a little bit breaking but there is a deprecated JSDocs  on it, and it follows along the other PRs. so I dont think we need to mark this one as breaking.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
