### PR TITLE
Chore: Packages Marketplace URL

### DIFF
--- a/src/packages/packages/package-section/views/market-place/packages-market-place-section-view.element.ts
+++ b/src/packages/packages/package-section/views/market-place/packages-market-place-section-view.element.ts
@@ -1,23 +1,44 @@
-import { css, html, customElement, property } from '@umbraco-cms/backoffice/external/lit';
+import { css, html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { UmbPackageRepository } from '@umbraco-cms/backoffice/package';
 import type { UmbSectionViewElement } from '@umbraco-cms/backoffice/extension-registry';
 
 @customElement('umb-packages-market-place-section-view')
 export class UmbPackagesMarketPlaceSectionViewElement extends UmbLitElement implements UmbSectionViewElement {
-	// TODO: This URL comes from the server
-	// Was previously found in 'Umbraco.Sys.ServerVariables.umbracoUrls.marketplaceUrl'
-	@property()
-	marketplaceUrl = 'https://marketplace.umbraco.com/?umbversion=11.1.0&style=backoffice';
+	@state()
+	private _marketplaceUrl?: string;
+
+	#packageRepository = new UmbPackageRepository(this);
+
+	constructor() {
+		super();
+
+		this.#getMarketplaceUrl();
+	}
+
+	async #getMarketplaceUrl() {
+		const configuration = await this.#packageRepository.configuration();
+		this.observe(
+			configuration,
+			(configuration) => {
+				this._marketplaceUrl = configuration.marketplaceUrl;
+			},
+			'_observeConfiguration',
+		);
+	}
 
 	render() {
-		return html` <div id="container">
-			<iframe
-				src="${this.marketplaceUrl}"
-				title="Umbraco Marketplace"
-				allowfullscreen
-				allow="geolocation; autoplay; clipboard-write; encrypted-media">
-			</iframe>
-		</div>`;
+		if (!this._marketplaceUrl) return html`<div id="loader"><uui-loader></uui-loader></div>`;
+		return html`
+			<div id="container">
+				<iframe
+					src=${this._marketplaceUrl}
+					title="Umbraco Marketplace"
+					allowfullscreen
+					allow="geolocation; autoplay; clipboard-write; encrypted-media">
+				</iframe>
+			</div>
+		`;
 	}
 
 	static styles = [
@@ -25,6 +46,13 @@ export class UmbPackagesMarketPlaceSectionViewElement extends UmbLitElement impl
 			:host {
 				height: 100%;
 				display: block;
+			}
+
+			#loader {
+				height: 100%;
+				display: flex;
+				align-items: center;
+				justify-content: center;
 			}
 
 			#container {

--- a/src/packages/packages/package/repository/package.store.ts
+++ b/src/packages/packages/package/repository/package.store.ts
@@ -1,11 +1,14 @@
 import type { UmbPackage } from '../../types.js';
 import { ReplaySubject } from '@umbraco-cms/backoffice/external/rxjs';
+import { UmbArrayState, UmbObjectState } from '@umbraco-cms/backoffice/observable-api';
 import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
-import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbStoreBase } from '@umbraco-cms/backoffice/store';
-import type { PackageMigrationStatusResponseModel } from '@umbraco-cms/backoffice/external/backend-api';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import type { ManifestBase } from '@umbraco-cms/backoffice/extension-api';
-import { UmbArrayState } from '@umbraco-cms/backoffice/observable-api';
+import type {
+	PackageConfigurationResponseModel,
+	PackageMigrationStatusResponseModel,
+} from '@umbraco-cms/backoffice/external/backend-api';
 
 export const UMB_PACKAGE_STORE_TOKEN = new UmbContextToken<UmbPackageStore>('UmbPackageStore');
 
@@ -15,6 +18,8 @@ export const UMB_PACKAGE_STORE_TOKEN = new UmbContextToken<UmbPackageStore>('Umb
  * @extends {UmbStoreBase}
  */
 export class UmbPackageStore extends UmbStoreBase {
+	#configuration = new UmbObjectState<PackageConfigurationResponseModel>({ marketplaceUrl: '' });
+
 	/**
 	 * Array of packages with extensions
 	 * @private
@@ -25,6 +30,8 @@ export class UmbPackageStore extends UmbStoreBase {
 	#extensions = new UmbArrayState<ManifestBase>([], (e) => e.alias);
 
 	#migrations = new UmbArrayState<PackageMigrationStatusResponseModel>([], (e) => e.packageName);
+
+	configuration = this.#configuration.asObservable();
 
 	/**
 	 * Observable of packages with extensions
@@ -62,6 +69,10 @@ export class UmbPackageStore extends UmbStoreBase {
 
 	appendMigrations(migrations: PackageMigrationStatusResponseModel[]) {
 		this.#migrations.append(migrations);
+	}
+
+	setConfiguration(configuration: PackageConfigurationResponseModel) {
+		this.#configuration.setValue(configuration);
 	}
 }
 

--- a/src/packages/packages/package/repository/sources/package.server.data.ts
+++ b/src/packages/packages/package/repository/sources/package.server.data.ts
@@ -1,6 +1,6 @@
+import { tryExecuteAndNotify } from '@umbraco-cms/backoffice/resources';
 import { PackageResource } from '@umbraco-cms/backoffice/external/backend-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
-import { tryExecuteAndNotify } from '@umbraco-cms/backoffice/resources';
 
 /**
  * Data source for packages from the server
@@ -15,6 +15,14 @@ export class UmbPackageServerDataSource {
 	 */
 	getRootItems() {
 		return tryExecuteAndNotify(this.host, PackageResource.getPackageManifest());
+	}
+
+	/**
+	 * Get the package configuration from the server
+	 * @memberof UmbPackageServerDataSource
+	 */
+	getPackageConfiguration() {
+		return tryExecuteAndNotify(this.host, PackageResource.getPackageConfiguration());
 	}
 
 	/**


### PR DESCRIPTION
Wires up the Packages configuration from the Management API, to populate the Packages Marketplace URL.
Adds a loader to `umb-packages-market-place-section-view` whilst the request is loading.
