### PR TITLE
`umb-stack` element

### DIFF
--- a/src/packages/core/components/index.ts
+++ b/src/packages/core/components/index.ts
@@ -33,4 +33,5 @@ export * from './multiple-color-picker-input/index.js';
 export * from './multiple-text-string-input/index.js';
 export * from './popover-layout/index.js';
 export * from './ref-item/index.js';
+export * from './stack/index.js';
 export * from './table/index.js';

--- a/src/packages/core/components/stack/index.ts
+++ b/src/packages/core/components/stack/index.ts
@@ -1,0 +1,1 @@
+export * from './stack.element.js';

--- a/src/packages/core/components/stack/stack.element.ts
+++ b/src/packages/core/components/stack/stack.element.ts
@@ -1,0 +1,84 @@
+import { UmbLitElement } from "@umbraco-cms/backoffice/lit-element";
+import { customElement, html, css, property, classMap } from "@umbraco-cms/backoffice/external/lit";
+
+/**
+ *  @element umb-stack
+ *  @description - Element for displaying items in a stack with even spacing between
+ *  @extends LitElement
+ */
+@customElement('umb-stack')
+export class UmbStackElement extends UmbLitElement
+{
+		/**
+			 * Look
+			 * @type {String}
+			 * @memberof UmbStackElement
+			 */
+    @property({ type:String })
+    look: 'compact' | 'default' = 'default';
+
+		/**
+			 * Divide
+			 * @type {Boolean}
+			 * @memberof UmbStackElement
+			 */
+    @property({ type:Boolean })
+    divide: boolean = false;
+
+    render() {
+        return html`<div class=${classMap({ divide: this.divide, compact: this.look === 'compact' })}>
+            <slot></slot>
+        </div>`;
+    }
+
+    static styles = [
+        css`
+            div {
+                display: block;
+                position: relative;
+            }
+
+            ::slotted(*) {
+                position: relative;
+                margin-top: var(--uui-size-space-6);
+            }
+
+            .divide ::slotted(*)::before {
+                content: '';
+                position: absolute;
+                top: calc((var(--uui-size-space-6) / 2) * -1);
+                height: 0;
+                width: 100%;
+                border-top: solid 1px var(--uui-color-divider-standalone);
+            }
+
+            ::slotted(*:first-child) {
+                margin-top: 0;
+            }
+
+            .divide ::slotted(*:first-child)::before {
+                display: none;
+            }
+
+            .compact ::slotted(*) {
+                margin-top: var(--uui-size-space-3);
+            }
+
+            .compact ::slotted(*:first-child) {
+                margin-top: 0;
+            }
+
+            .compact.divide ::slotted(*)::before {
+                display: none;
+            }
+        `
+    ];
+}
+
+export default UmbStackElement;
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-stack': UmbStackElement;
+	}
+}

--- a/src/packages/core/components/stack/stack.stories.ts
+++ b/src/packages/core/components/stack/stack.stories.ts
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/web-components';
+import './stack.element.js';
+import type { UmbStackElement} from './stack.element.js';
+
+const meta: Meta<UmbStackElement> = {
+	title: 'Components/Stack',
+	component: 'umb-stack',
+};
+
+export default meta;
+
+type Story = StoryObj<UmbStackElement>;
+
+export const Default: Story = {
+	args: { },
+};
+
+export const Divide: Story = {
+	args: {
+		divide: true
+	},
+};
+
+export const Compact: Story = {
+	args: {
+		look: 'compact'
+	},
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The PR introduces a new `umb-stack` element. The purpose of this element is to provide consistent spacing between stacks of items.

![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/527305/78fa1016-a6f8-42e7-9a12-3f3a7d9c82b5)

There is a default and a compact mode, as well as a flag to include a dividing line. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

I was finding myself adding the same styles in a lot of places to space items in a list. These were becoming inconsistent and a annoying to copy. I thought it would be good if we had a component that applied the spacing when needed. This should also be useful for things like `umb-property` which is currently struggling to align correctly in places. With this, we can remove any styling from individual elements, and let the stack do the layout.

## How to test?

Create a `umb-stack` element and create any number of items inside of it. These should all be spaced nicely.

```javascript
<umb-stack>
    <div>Item 1</div>
    <div>Item 2</div>
    <div>Item 3</div>
</umb-stack>
```

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
