### PR TITLE
Chore: Replace `super.value` in Picker callbacks

### DIFF
--- a/src/packages/core/section/components/input-section/input-section.element.ts
+++ b/src/packages/core/section/components/input-section/input-section.element.ts
@@ -91,7 +91,7 @@ export class UmbInputSectionElement extends FormControlMixin(UmbLitElement) {
 			() => !!this.max && this.#pickerContext.getSelection().length > this.max,
 		);
 
-		this.observe(this.#pickerContext.selection, (selection) => (super.value = selection.join(',')));
+		this.observe(this.#pickerContext.selection, (selection) => (this.value = selection.join(',')));
 		this.observe(this.#pickerContext.selectedItems, (selectedItems) => (this._items = selectedItems));
 	}
 

--- a/src/packages/data-type/components/data-type-input/data-type-input.element.ts
+++ b/src/packages/data-type/components/data-type-input/data-type-input.element.ts
@@ -89,7 +89,7 @@ export class UmbDataTypeInputElement extends FormControlMixin(UmbLitElement) {
 			() => !!this.max && this.#pickerContext.getSelection().length > this.max,
 		);
 
-		this.observe(this.#pickerContext.selection, (selection) => (super.value = selection.join(',')));
+		this.observe(this.#pickerContext.selection, (selection) => (this.value = selection.join(',')));
 		this.observe(this.#pickerContext.selectedItems, (selectedItems) => (this._items = selectedItems));
 	}
 

--- a/src/packages/documents/document-types/components/input-document-type/input-document-type.element.ts
+++ b/src/packages/documents/document-types/components/input-document-type/input-document-type.element.ts
@@ -121,7 +121,7 @@ export class UmbInputDocumentTypeElement extends FormControlMixin(UmbLitElement)
 			() => !!this.max && this.#pickerContext.getSelection().length > this.max,
 		);
 
-		this.observe(this.#pickerContext.selection, (selection) => (super.value = selection.join(',')));
+		this.observe(this.#pickerContext.selection, (selection) => (this.value = selection.join(',')));
 		this.observe(this.#pickerContext.selectedItems, (selectedItems) => (this._items = selectedItems));
 	}
 

--- a/src/packages/documents/documents/components/input-document/input-document.element.ts
+++ b/src/packages/documents/documents/components/input-document/input-document.element.ts
@@ -120,7 +120,7 @@ export class UmbInputDocumentElement extends FormControlMixin(UmbLitElement) {
 				this._editDocumentPath = routeBuilder({});
 			});
 
-		this.observe(this.#pickerContext.selection, (selection) => (super.value = selection.join(',')));
+		this.observe(this.#pickerContext.selection, (selection) => (this.value = selection.join(',')));
 		this.observe(this.#pickerContext.selectedItems, (selectedItems) => (this._items = selectedItems));
 	}
 

--- a/src/packages/language/components/input-language/input-language.element.ts
+++ b/src/packages/language/components/input-language/input-language.element.ts
@@ -92,7 +92,7 @@ export class UmbInputLanguageElement extends FormControlMixin(UmbLitElement) {
 			() => !!this.max && this.#pickerContext.getSelection().length > this.max,
 		);
 
-		this.observe(this.#pickerContext.selection, (selection) => (super.value = selection.join(',')));
+		this.observe(this.#pickerContext.selection, (selection) => (this.value = selection.join(',')));
 		this.observe(this.#pickerContext.selectedItems, (selectedItems) => (this._items = selectedItems));
 	}
 

--- a/src/packages/media/media-types/components/input-media-type/input-media-type.element.ts
+++ b/src/packages/media/media-types/components/input-media-type/input-media-type.element.ts
@@ -89,7 +89,7 @@ export class UmbInputMediaTypeElement extends FormControlMixin(UmbLitElement) {
 			() => !!this.max && this.#pickerContext.getSelection().length > this.max,
 		);
 
-		this.observe(this.#pickerContext.selection, (selection) => (super.value = selection.join(',')));
+		this.observe(this.#pickerContext.selection, (selection) => (this.value = selection.join(',')));
 		this.observe(this.#pickerContext.selectedItems, (selectedItems) => (this._items = selectedItems));
 	}
 

--- a/src/packages/media/media/components/input-media/input-media.element.ts
+++ b/src/packages/media/media/components/input-media/input-media.element.ts
@@ -120,7 +120,7 @@ export class UmbInputMediaElement extends FormControlMixin(UmbLitElement) {
 				this._editMediaPath = routeBuilder({});
 			});
 
-		this.observe(this.#pickerContext.selection, (selection) => (super.value = selection.join(',')));
+		this.observe(this.#pickerContext.selection, (selection) => (this.value = selection.join(',')));
 		this.observe(this.#pickerContext.selectedItems, (selectedItems) => (this._items = selectedItems));
 
 		this.addValidator(

--- a/src/packages/members/member-group/components/input-member-group/input-member-group.element.ts
+++ b/src/packages/members/member-group/components/input-member-group/input-member-group.element.ts
@@ -122,7 +122,7 @@ export class UmbInputMemberGroupElement extends FormControlMixin(UmbLitElement) 
 				this._editMemberGroupPath = routeBuilder({});
 			});
 
-		this.observe(this.#pickerContext.selection, (selection) => (super.value = selection.join(',')));
+		this.observe(this.#pickerContext.selection, (selection) => (this.value = selection.join(',')));
 		this.observe(this.#pickerContext.selectedItems, (selectedItems) => {
 			this._items = selectedItems;
 		});

--- a/src/packages/members/member-type/components/input-member-type/input-member-type.element.ts
+++ b/src/packages/members/member-type/components/input-member-type/input-member-type.element.ts
@@ -89,7 +89,7 @@ export class UmbInputMemberTypeElement extends FormControlMixin(UmbLitElement) {
 			() => !!this.max && this.#pickerContext.getSelection().length > this.max,
 		);
 
-		this.observe(this.#pickerContext.selection, (selection) => (super.value = selection.join(',')));
+		this.observe(this.#pickerContext.selection, (selection) => (this.value = selection.join(',')));
 		this.observe(this.#pickerContext.selectedItems, (selectedItems) => (this._items = selectedItems));
 	}
 

--- a/src/packages/members/member/components/input-member/input-member.element.ts
+++ b/src/packages/members/member/components/input-member/input-member.element.ts
@@ -121,7 +121,7 @@ export class UmbInputMemberElement extends FormControlMixin(UmbLitElement) {
 				this._editMemberPath = routeBuilder({});
 			});
 
-		this.observe(this.#pickerContext.selection, (selection) => (super.value = selection.join(',')));
+		this.observe(this.#pickerContext.selection, (selection) => (this.value = selection.join(',')));
 		this.observe(this.#pickerContext.selectedItems, (selectedItems) => {
 			this._items = selectedItems;
 		});

--- a/src/packages/static-file/components/input-static-file/input-static-file.element.ts
+++ b/src/packages/static-file/components/input-static-file/input-static-file.element.ts
@@ -90,7 +90,7 @@ export class UmbInputStaticFileElement extends FormControlMixin(UmbLitElement) {
 			() => !!this.max && this.#pickerContext.getSelection().length > this.max,
 		);
 
-		this.observe(this.#pickerContext.selection, (selection) => (super.value = selection.join(',')));
+		this.observe(this.#pickerContext.selection, (selection) => (this.value = selection.join(',')));
 		this.observe(this.#pickerContext.selectedItems, (selectedItems) => (this._items = selectedItems));
 	}
 

--- a/src/packages/templating/stylesheets/components/stylesheet-input/stylesheet-input.element.ts
+++ b/src/packages/templating/stylesheets/components/stylesheet-input/stylesheet-input.element.ts
@@ -89,7 +89,7 @@ export class UmbStylesheetInputElement extends FormControlMixin(UmbLitElement) {
 			() => !!this.max && this.#pickerContext.getSelection().length > this.max,
 		);
 
-		this.observe(this.#pickerContext.selection, (selection) => (super.value = selection.join(',')));
+		this.observe(this.#pickerContext.selection, (selection) => (this.value = selection.join(',')));
 		this.observe(this.#pickerContext.selectedItems, (selectedItems) => (this._items = selectedItems));
 	}
 

--- a/src/packages/user/user-group/components/input-user-group/user-group-input.element.ts
+++ b/src/packages/user/user-group/components/input-user-group/user-group-input.element.ts
@@ -91,7 +91,7 @@ export class UmbUserGroupInputElement extends FormControlMixin(UmbLitElement) {
 
 		this.observe(
 			this.#pickerContext.selection,
-			(selection) => (super.value = selection.join(',')),
+			(selection) => (this.value = selection.join(',')),
 			'umbUserGroupInputSelectionObserver',
 		);
 		this.observe(

--- a/src/packages/user/user/components/user-input/user-input.element.ts
+++ b/src/packages/user/user/components/user-input/user-input.element.ts
@@ -93,7 +93,7 @@ export class UmbUserInputElement extends FormControlMixin(UmbLitElement) {
 
 		this.observe(
 			this.#pickerContext.selection,
-			(selection) => (super.value = selection.join(',')),
+			(selection) => (this.value = selection.join(',')),
 			'umbUserInputSelectionObserver',
 		);
 		this.observe(


### PR DESCRIPTION
The `super` context does not exist within a callback.

This has been exclusively within the various Picker input components for the `selection` callback.