### PR TITLE
Fixed issue in profiling dashboard leading to the checkbox always bei…

### DIFF
--- a/src/packages/settings/dashboards/performance-profiling/dashboard-performance-profiling.element.ts
+++ b/src/packages/settings/dashboards/performance-profiling/dashboard-performance-profiling.element.ts
@@ -28,8 +28,8 @@ export class UmbDashboardPerformanceProfilingElement extends UmbLitElement {
 	private async _getProfilingStatus() {
 		const { data } = await tryExecuteAndNotify(this, ProfilingResource.getProfilingStatus());
 
-		if (!data || !data.enabled) return;
-		this._profilingStatus = data.enabled;
+		if (!data) return;
+		this._profilingStatus = data.enabled ?? false;
 	}
 
 	private async _changeProfilingStatus() {


### PR DESCRIPTION
Fixed an issue, where the profiling dashboard did always show the status as on when loaded, even when the server said disabled.