### PR TITLE
Bugfix: Reinitialize Extensions when constructor args changes

### DIFF
--- a/src/packages/core/components/extension-with-api-slot/extension-with-api-slot.element.ts
+++ b/src/packages/core/components/extension-with-api-slot/extension-with-api-slot.element.ts
@@ -46,7 +46,7 @@ export class UmbExtensionWithApiSlotElement extends UmbLitElement {
 		if (value === this.#type) return;
 		this.#type = value;
 		if (this.#attached) {
-			this._observeExtensions();
+			this.#observeExtensions();
 		}
 	}
 	#type?: string | string[] | undefined;
@@ -68,7 +68,7 @@ export class UmbExtensionWithApiSlotElement extends UmbLitElement {
 		if (value === this.#filter) return;
 		this.#filter = value;
 		if (this.#attached) {
-			this._observeExtensions();
+			this.#observeExtensions();
 		}
 	}
 	#filter: (manifest: any) => boolean = () => true;
@@ -107,8 +107,9 @@ export class UmbExtensionWithApiSlotElement extends UmbLitElement {
 		return this.#constructorArgs;
 	}
 	set apiArgs(newVal: Array<unknown> | UmbApiConstructorArgumentsMethodType<any> | undefined) {
-		// TODO, compare changes since last time. only reset the ones that changed. This might be better done by the controller is self:
+		if (newVal === this.#constructorArgs) return;
 		this.#constructorArgs = newVal;
+		this.#observeExtensions();
 	}
 	#constructorArgs?: Array<unknown> | UmbApiConstructorArgumentsMethodType<any> = [];
 
@@ -146,11 +147,11 @@ export class UmbExtensionWithApiSlotElement extends UmbLitElement {
 
 	connectedCallback(): void {
 		super.connectedCallback();
-		this._observeExtensions();
+		this.#observeExtensions();
 		this.#attached = true;
 	}
 
-	private _observeExtensions(): void {
+	#observeExtensions(): void {
 		this.#extensionsController?.destroy();
 		if (this.#type) {
 			this.#extensionsController = new UmbExtensionsElementAndApiInitializer(


### PR DESCRIPTION
## Description

This PR fixes the problem where entity actions didn't run on the current entity if the context menu isn't closed between actions.

The problem was that the extensions weren't reinitialized when there were new constructor args. It would have been better to be able to also set the values on the API, but it is currently not supported by the API. In the end we need to make this update if the args should change over time.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## How to test?

* Make sure that an entity action is run on the correct entity unique. One way to do it is:
  * Open the context menu for a tree item
  * Try to delete the item and notice the name of the item in the delete dialog
  * Cancel the delete dialog
  * Open the context menu for another tree item without closing it
  * Try to delete the item and notice that the name has changed to the new tree item.
