### PR TITLE
Bugfix: Picker inputs, updated to use `UmbUniqueTreeItemModel`

### DIFF
--- a/src/packages/core/components/input-entity/input-entity.element.ts
+++ b/src/packages/core/components/input-entity/input-entity.element.ts
@@ -4,7 +4,7 @@ import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import type { UmbPickerInputContext } from '@umbraco-cms/backoffice/picker-input';
-import type { UmbUniqueTreeItemModel } from '@umbraco-cms/backoffice/tree';
+import type { UmbUniqueItemModel } from '@umbraco-cms/backoffice/models';
 
 @customElement('umb-input-entity')
 export class UmbInputEntityElement extends UUIFormControlMixin(UmbLitElement, '') {
@@ -66,7 +66,7 @@ export class UmbInputEntityElement extends UUIFormControlMixin(UmbLitElement, ''
 	}
 
 	@state()
-	private _items?: Array<UmbUniqueTreeItemModel>;
+	private _items?: Array<UmbUniqueItemModel>;
 
 	constructor() {
 		super();
@@ -142,7 +142,7 @@ export class UmbInputEntityElement extends UUIFormControlMixin(UmbLitElement, ''
 		`;
 	}
 
-	#renderItem(item: UmbUniqueTreeItemModel) {
+	#renderItem(item: UmbUniqueItemModel) {
 		if (!item.unique) return;
 		const icon = this.getIcon?.(item) ?? item.icon ?? '';
 		return html`

--- a/src/packages/core/components/input-entity/input-entity.element.ts
+++ b/src/packages/core/components/input-entity/input-entity.element.ts
@@ -1,18 +1,10 @@
-import {
-	css,
-	html,
-	customElement,
-	property,
-	state,
-	repeat,
-	ifDefined,
-	when,
-} from '@umbraco-cms/backoffice/external/lit';
+import { css, html, customElement, property, state, repeat, when } from '@umbraco-cms/backoffice/external/lit';
 import { splitStringToArray } from '@umbraco-cms/backoffice/utils';
 import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import type { UmbPickerInputContext } from '@umbraco-cms/backoffice/picker-input';
+import type { UmbUniqueTreeItemModel } from '@umbraco-cms/backoffice/tree';
 
 @customElement('umb-input-entity')
 export class UmbInputEntityElement extends UUIFormControlMixin(UmbLitElement, '') {
@@ -74,8 +66,7 @@ export class UmbInputEntityElement extends UUIFormControlMixin(UmbLitElement, ''
 	}
 
 	@state()
-	// TODO: [LK] Find out if we can have a common interface for tree-picker entities, (rather than use `any`).
-	private _items?: Array<any>;
+	private _items?: Array<UmbUniqueTreeItemModel>;
 
 	constructor() {
 		super();
@@ -151,11 +142,11 @@ export class UmbInputEntityElement extends UUIFormControlMixin(UmbLitElement, ''
 		`;
 	}
 
-	#renderItem(item: any) {
+	#renderItem(item: UmbUniqueTreeItemModel) {
 		if (!item.unique) return;
-		const icon = this.getIcon?.(item) ?? item.icon;
+		const icon = this.getIcon?.(item) ?? item.icon ?? '';
 		return html`
-			<uui-ref-node name=${ifDefined(item.name)}>
+			<uui-ref-node name=${item.name}>
 				${when(icon, () => html`<umb-icon slot="icon" name=${icon}></umb-icon>`)}
 				<uui-action-bar slot="actions">
 					<uui-button

--- a/src/packages/core/models/index.ts
+++ b/src/packages/core/models/index.ts
@@ -30,3 +30,9 @@ export interface UmbReferenceByUniqueAndType {
 	type: string;
 	unique: string;
 }
+
+export interface UmbUniqueItemModel {
+	unique: string;
+	name: string;
+	icon?: string;
+}

--- a/src/packages/members/member-type/components/input-member-type/input-member-type.element.ts
+++ b/src/packages/members/member-type/components/input-member-type/input-member-type.element.ts
@@ -1,9 +1,10 @@
 import { UmbMemberTypePickerContext } from './input-member-type.context.js';
 import { css, html, customElement, property, state, ifDefined, repeat } from '@umbraco-cms/backoffice/external/lit';
+import { splitStringToArray } from '@umbraco-cms/backoffice/utils';
 import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { MemberTypeItemResponseModel } from '@umbraco-cms/backoffice/external/backend-api';
-import { splitStringToArray } from '@umbraco-cms/backoffice/utils';
+import type { UmbUniqueTreeItemModel } from '@umbraco-cms/backoffice/tree';
 
 @customElement('umb-input-member-type')
 export class UmbInputMemberTypeElement extends UUIFormControlMixin(UmbLitElement, '') {
@@ -70,7 +71,7 @@ export class UmbInputMemberTypeElement extends UUIFormControlMixin(UmbLitElement
 	}
 
 	@state()
-	private _items?: Array<MemberTypeItemResponseModel>;
+	private _items?: Array<UmbUniqueTreeItemModel>;
 
 	#pickerContext = new UmbMemberTypePickerContext(this);
 
@@ -113,7 +114,7 @@ export class UmbInputMemberTypeElement extends UUIFormControlMixin(UmbLitElement
 			<uui-ref-list
 				>${repeat(
 					this._items,
-					(item) => item.id,
+					(item) => item.unique,
 					(item) => this.#renderItem(item),
 				)}</uui-ref-list
 			>
@@ -133,14 +134,14 @@ export class UmbInputMemberTypeElement extends UUIFormControlMixin(UmbLitElement
 		`;
 	}
 
-	#renderItem(item: MemberTypeItemResponseModel) {
-		if (!item.id) return;
+	#renderItem(item: UmbUniqueTreeItemModel) {
+		if (!item.unique) return;
 		return html`
 			<uui-ref-node-document-type name=${ifDefined(item.name)}>
 				${this.#renderIcon(item)}
 				<uui-action-bar slot="actions">
 					<uui-button
-						@click=${() => this.#pickerContext.requestRemoveItem(item.id!)}
+						@click=${() => this.#pickerContext.requestRemoveItem(item.unique!)}
 						label="Remove Member Type ${item.name}"
 						>${this.localize.term('general_remove')}</uui-button
 					>
@@ -149,7 +150,7 @@ export class UmbInputMemberTypeElement extends UUIFormControlMixin(UmbLitElement
 		`;
 	}
 
-	#renderIcon(item: MemberTypeItemResponseModel) {
+	#renderIcon(item: UmbUniqueTreeItemModel) {
 		if (!item.icon) return;
 		return html`<umb-icon slot="icon" name=${item.icon}></umb-icon>`;
 	}

--- a/src/packages/members/member-type/components/input-member-type/input-member-type.element.ts
+++ b/src/packages/members/member-type/components/input-member-type/input-member-type.element.ts
@@ -1,10 +1,10 @@
 import { UmbMemberTypePickerContext } from './input-member-type.context.js';
-import { css, html, customElement, property, state, ifDefined, repeat } from '@umbraco-cms/backoffice/external/lit';
+import { css, html, customElement, property, state, repeat, when } from '@umbraco-cms/backoffice/external/lit';
 import { splitStringToArray } from '@umbraco-cms/backoffice/utils';
 import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import type { MemberTypeItemResponseModel } from '@umbraco-cms/backoffice/external/backend-api';
-import type { UmbUniqueTreeItemModel } from '@umbraco-cms/backoffice/tree';
+import type { UmbUniqueItemModel } from '@umbraco-cms/backoffice/models';
+
 
 @customElement('umb-input-member-type')
 export class UmbInputMemberTypeElement extends UUIFormControlMixin(UmbLitElement, '') {
@@ -71,7 +71,7 @@ export class UmbInputMemberTypeElement extends UUIFormControlMixin(UmbLitElement
 	}
 
 	@state()
-	private _items?: Array<UmbUniqueTreeItemModel>;
+	private _items?: Array<UmbUniqueItemModel>;
 
 	#pickerContext = new UmbMemberTypePickerContext(this);
 
@@ -134,11 +134,11 @@ export class UmbInputMemberTypeElement extends UUIFormControlMixin(UmbLitElement
 		`;
 	}
 
-	#renderItem(item: UmbUniqueTreeItemModel) {
+	#renderItem(item: UmbUniqueItemModel) {
 		if (!item.unique) return;
 		return html`
-			<uui-ref-node-document-type name=${ifDefined(item.name)}>
-				${this.#renderIcon(item)}
+			<uui-ref-node-document-type name=${item.name}>
+				${when(item.icon, () => html`<umb-icon slot="icon" name=${item.icon!}></umb-icon>`)}
 				<uui-action-bar slot="actions">
 					<uui-button
 						@click=${() => this.#pickerContext.requestRemoveItem(item.unique!)}
@@ -148,11 +148,6 @@ export class UmbInputMemberTypeElement extends UUIFormControlMixin(UmbLitElement
 				</uui-action-bar>
 			</uui-ref-node-document-type>
 		`;
-	}
-
-	#renderIcon(item: UmbUniqueTreeItemModel) {
-		if (!item.icon) return;
-		return html`<umb-icon slot="icon" name=${item.icon}></umb-icon>`;
 	}
 
 	static styles = [


### PR DESCRIPTION
## Description

Straddling between chore and bugfix, I'd noticed that an issue in the MemberType picker where the `MemberTypeItemResponseModel` had bled through, whereas the `UmbUniqueTreeItemModel` could be used. Which also solved an issue I had with the Entity picker input component.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
