### PR TITLE
fix: extension-slot life cycle issue

### DIFF
--- a/src/libs/context-api/consume/context-consumer.ts
+++ b/src/libs/context-api/consume/context-consumer.ts
@@ -170,6 +170,7 @@ export class UmbContextConsumer<BaseType = unknown, ResultType extends BaseType 
 
 	public destroy(): void {
 		this.hostDisconnected();
+		this._host = undefined as any;
 		this.#callback = undefined;
 		this.#promise = undefined;
 		this.#promiseResolver = undefined;

--- a/src/libs/extension-api/controller/base-extension-initializer.controller.ts
+++ b/src/libs/extension-api/controller/base-extension-initializer.controller.ts
@@ -176,6 +176,12 @@ export abstract class UmbBaseExtensionInitializer<
 			configsOfThisType.map((conditionConfig) => this.#createConditionController(conditionManifest, conditionConfig)),
 		);
 
+		// If we got destroyed in the mean time, then we don't need to continue:
+		if (!this.#extensionRegistry) {
+			newConditionControllers.forEach((controller) => controller?.destroy());
+			return;
+		}
+
 		const oldLength = this.#conditionControllers.length;
 
 		newConditionControllers

--- a/src/libs/extension-api/controller/base-extensions-initializer.controller.ts
+++ b/src/libs/extension-api/controller/base-extensions-initializer.controller.ts
@@ -186,6 +186,7 @@ export abstract class UmbBaseExtensionsInitializer<
 	hostDisconnected(): void {
 		super.hostDisconnected();
 		if (this.#changeDebounce) {
+			cancelAnimationFrame(this.#changeDebounce);
 			this.#notifyChange();
 		}
 	}

--- a/src/packages/core/components/extension-slot/extension-slot.element.ts
+++ b/src/packages/core/components/extension-slot/extension-slot.element.ts
@@ -43,9 +43,7 @@ export class UmbExtensionSlotElement extends UmbLitElement {
 	public set type(value: string | string[] | undefined) {
 		if (value === this.#type) return;
 		this.#type = value;
-		if (this.#attached) {
-			this._observeExtensions();
-		}
+		this.#observeExtensions();
 	}
 	#type?: string | string[] | undefined;
 
@@ -65,9 +63,7 @@ export class UmbExtensionSlotElement extends UmbLitElement {
 	public set filter(value: (manifest: any) => boolean) {
 		if (value === this.#filter) return;
 		this.#filter = value;
-		if (this.#attached) {
-			this._observeExtensions();
-		}
+		this.#observeExtensions();
 	}
 	#filter: (manifest: any) => boolean = () => true;
 
@@ -100,11 +96,17 @@ export class UmbExtensionSlotElement extends UmbLitElement {
 
 	connectedCallback(): void {
 		super.connectedCallback();
-		this._observeExtensions();
 		this.#attached = true;
+		this.#observeExtensions();
+	}
+	disconnectedCallback(): void {
+		this.#attached = false;
+		this.#extensionsController?.destroy();
+		super.disconnectedCallback();
 	}
 
-	private _observeExtensions(): void {
+	#observeExtensions(): void {
+		if (!this.#attached) return;
 		this.#extensionsController?.destroy();
 		if (this.#type) {
 			this.#extensionsController = new UmbExtensionsElementInitializer(
@@ -128,7 +130,7 @@ export class UmbExtensionSlotElement extends UmbLitElement {
 					this._permitted,
 					(ext) => ext.alias,
 					(ext) => (this.renderMethod ? this.renderMethod(ext) : ext.component),
-			  )
+				)
 			: html`<slot></slot>`;
 	}
 

--- a/src/packages/core/components/extension-with-api-slot/extension-with-api-slot.element.ts
+++ b/src/packages/core/components/extension-with-api-slot/extension-with-api-slot.element.ts
@@ -45,9 +45,7 @@ export class UmbExtensionWithApiSlotElement extends UmbLitElement {
 	public set type(value: string | string[] | undefined) {
 		if (value === this.#type) return;
 		this.#type = value;
-		if (this.#attached) {
-			this.#observeExtensions();
-		}
+		this.#observeExtensions();
 	}
 	#type?: string | string[] | undefined;
 
@@ -67,9 +65,7 @@ export class UmbExtensionWithApiSlotElement extends UmbLitElement {
 	public set filter(value: (manifest: any) => boolean) {
 		if (value === this.#filter) return;
 		this.#filter = value;
-		if (this.#attached) {
-			this.#observeExtensions();
-		}
+		this.#observeExtensions();
 	}
 	#filter: (manifest: any) => boolean = () => true;
 
@@ -147,11 +143,17 @@ export class UmbExtensionWithApiSlotElement extends UmbLitElement {
 
 	connectedCallback(): void {
 		super.connectedCallback();
-		this.#observeExtensions();
 		this.#attached = true;
+		this.#observeExtensions();
+	}
+	disconnectedCallback(): void {
+		this.#attached = false;
+		this.#extensionsController?.destroy();
+		super.disconnectedCallback();
 	}
 
 	#observeExtensions(): void {
+		if (!this.#attached) return;
 		this.#extensionsController?.destroy();
 		if (this.#type) {
 			this.#extensionsController = new UmbExtensionsElementAndApiInitializer(

--- a/src/packages/core/components/extension-with-api-slot/extension-with-api-slot.element.ts
+++ b/src/packages/core/components/extension-with-api-slot/extension-with-api-slot.element.ts
@@ -153,6 +153,7 @@ export class UmbExtensionWithApiSlotElement extends UmbLitElement {
 	}
 
 	#observeExtensions(): void {
+		// We want to be attached before we start observing extensions, cause first at this point we know that we got the right properties. [NL]
 		if (!this.#attached) return;
 		this.#extensionsController?.destroy();
 		if (this.#type) {

--- a/src/packages/core/entity-action/entity-action-list.element.ts
+++ b/src/packages/core/entity-action/entity-action-list.element.ts
@@ -1,5 +1,5 @@
-import { UmbEntityContext } from '@umbraco-cms/backoffice/entity';
 import type { UmbEntityActionArgs } from './types.js';
+import { UmbEntityContext } from '@umbraco-cms/backoffice/entity';
 import { html, customElement, property, state, css } from '@umbraco-cms/backoffice/external/lit';
 import type { ManifestEntityAction, MetaEntityAction } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
@@ -17,9 +17,9 @@ export class UmbEntityActionListElement extends UmbLitElement {
 		this.#generateApiArgs();
 		this.requestUpdate('_props');
 		// Update filter:
-		const oldValue = this._filter;
+		//const oldValue = this._filter;
 		this._filter = (extension: ManifestEntityAction<MetaEntityAction>) => extension.forEntityTypes.includes(value);
-		this.requestUpdate('_filter', oldValue);
+		//this.requestUpdate('_filter', oldValue);
 	}
 
 	@state()

--- a/src/packages/user/user/workspace/user-workspace-editor.element.ts
+++ b/src/packages/user/user/workspace/user-workspace-editor.element.ts
@@ -81,7 +81,7 @@ export class UmbUserWorkspaceEditorElement extends UmbLitElement {
 	}
 
 	#renderRightColumn() {
-		if (!this._user || !this.#workspaceContext) return nothing;
+		if (!this._user) return nothing;
 
 		return html`
 			<umb-user-workspace-avatar></umb-user-workspace-avatar>


### PR DESCRIPTION
Extension-slots require an unknown set of properties to be set before it makes sense for them to start initialising extensions.
This life-cycle has been improved as of this PR. and fixes an issue on the user-workspace.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
