### PR TITLE
fix: Block Type Modals removing url when done.

### DIFF
--- a/src/packages/block/block-type/components/input-block-type/input-block-type.element.ts
+++ b/src/packages/block/block-type/components/input-block-type/input-block-type.element.ts
@@ -119,7 +119,7 @@ export class UmbInputBlockTypeElement<
 				.name=${block.label}
 				.iconColor=${block.iconColor}
 				.backgroundColor=${block.backgroundColor}
-				.href="${this.workspacePath}/edit/${block.contentElementTypeKey}"
+				.href="${this.workspacePath}edit/${block.contentElementTypeKey}"
 				.contentElementTypeKey=${block.contentElementTypeKey}>
 				<uui-action-bar slot="actions">
 					<uui-button @click=${() => this.#onRequestDelete(block)} label="Remove block">


### PR DESCRIPTION
Url was not constructed correctly, making it hard for the modal context to remove the path when closed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
