### PR TITLE
Feature: Media Entity Picker property-editor UI

### DIFF
--- a/src/mocks/data/data-type/data-type.data.ts
+++ b/src/mocks/data/data-type/data-type.data.ts
@@ -605,7 +605,7 @@ export const data: Array<UmbMockDataTypeModel> = [
 		name: 'Media Picker',
 		id: 'dt-mediaPicker',
 		parent: null,
-		editorAlias: 'Umbraco.MediaPicker',
+		editorAlias: 'Umbraco.MediaPicker3',
 		editorUiAlias: 'Umb.PropertyEditorUi.MediaPicker',
 		hasChildren: false,
 		isFolder: false,

--- a/src/packages/core/components/input-entity/input-entity.element.ts
+++ b/src/packages/core/components/input-entity/input-entity.element.ts
@@ -23,26 +23,30 @@ export class UmbInputEntityElement extends UUIFormControlMixin(UmbLitElement, ''
 	}
 	@property({ type: Number })
 	public set min(value: number) {
+		this.#min = value;
 		if (this.#pickerContext) {
 			this.#pickerContext.min = value;
 		}
 	}
 	public get min(): number {
-		return this.#pickerContext?.min ?? 0;
+		return this.#min;
 	}
+	#min: number = 0;
 
 	@property({ type: String, attribute: 'min-message' })
 	minMessage = 'This field need more items';
 
 	@property({ type: Number })
 	public set max(value: number) {
+		this.#max = value;
 		if (this.#pickerContext) {
 			this.#pickerContext.max = value;
 		}
 	}
 	public get max(): number {
-		return this.#pickerContext?.max ?? Infinity;
+		return this.#max;
 	}
+	#max: number = Infinity;
 
 	@property({ attribute: false })
 	getIcon?: (item: any) => string;
@@ -101,6 +105,9 @@ export class UmbInputEntityElement extends UUIFormControlMixin(UmbLitElement, ''
 
 	async #observePickerContext() {
 		if (!this.#pickerContext) return;
+
+		this.#pickerContext.min = this.min;
+		this.#pickerContext.max = this.max;
 
 		this.observe(
 			this.#pickerContext.selection,

--- a/src/packages/core/property-editor/schemas/Umbraco.MediaPicker.ts
+++ b/src/packages/core/property-editor/schemas/Umbraco.MediaPicker.ts
@@ -29,7 +29,8 @@ export const manifest: ManifestPropertyEditorSchema = {
 				{
 					alias: 'startNodeId',
 					label: 'Start node',
-					propertyEditorUiAlias: 'Umb.PropertyEditorUi.MediaPicker',
+					propertyEditorUiAlias: 'Umb.PropertyEditorUi.MediaEntityPicker',
+					config: [{ alias: 'validationLimit', value: { min: 0, max: 1 } }],
 				},
 				{
 					alias: 'enableLocalFocalPoint',

--- a/src/packages/core/property-editor/schemas/Umbraco.RichText.ts
+++ b/src/packages/core/property-editor/schemas/Umbraco.RichText.ts
@@ -12,7 +12,7 @@ export const manifest: ManifestPropertyEditorSchema = {
 					alias: 'mediaParentId',
 					label: 'Image Upload Folder',
 					description: 'Choose the upload location of pasted images',
-					propertyEditorUiAlias: 'Umb.PropertyEditorUi.MediaPicker',
+					propertyEditorUiAlias: 'Umb.PropertyEditorUi.MediaEntityPicker',
 					config: [{ alias: 'validationLimit', value: { min: 0, max: 1 } }],
 				},
 				{

--- a/src/packages/media/media/property-editors/index.ts
+++ b/src/packages/media/media/property-editors/index.ts
@@ -1,3 +1,4 @@
 export * from './image-cropper/index.js';
 export * from './image-crops-configuration/index.js';
+export * from './media-entity-picker/index.js';
 export * from './media-picker/index.js';

--- a/src/packages/media/media/property-editors/manifests.ts
+++ b/src/packages/media/media/property-editors/manifests.ts
@@ -1,5 +1,6 @@
-import { manifest as mediaPicker } from '../../../media/media/property-editors/media-picker/manifests.js';
-import { manifest as imageCropsConfiguration } from '../../../media/media/property-editors/image-crops-configuration/manifests.js';
-import { manifest as imageCropper } from '../../../media/media/property-editors/image-cropper/manifests.js';
+import { manifest as imageCropper } from './image-cropper/manifests.js';
+import { manifest as imageCropsConfiguration } from './image-crops-configuration/manifests.js';
+import { manifest as mediaEntityPicker } from './media-entity-picker/manifests.js';
+import { manifest as mediaPicker } from './media-picker/manifests.js';
 
-export const manifests = [mediaPicker, imageCropsConfiguration, imageCropper];
+export const manifests = [imageCropper, imageCropsConfiguration, mediaEntityPicker, mediaPicker];

--- a/src/packages/media/media/property-editors/media-entity-picker/index.ts
+++ b/src/packages/media/media/property-editors/media-entity-picker/index.ts
@@ -1,0 +1,1 @@
+export * from './property-editor-ui-media-entity-picker.element.js';

--- a/src/packages/media/media/property-editors/media-entity-picker/manifests.ts
+++ b/src/packages/media/media/property-editors/media-entity-picker/manifests.ts
@@ -1,0 +1,13 @@
+import type { ManifestPropertyEditorUi } from '@umbraco-cms/backoffice/extension-registry';
+
+export const manifest: ManifestPropertyEditorUi = {
+	type: 'propertyEditorUi',
+	alias: 'Umb.PropertyEditorUi.MediaEntityPicker',
+	name: 'Media Entity Picker Property Editor UI',
+	element: () => import('./property-editor-ui-media-entity-picker.element.js'),
+	meta: {
+		label: 'Media Entity Picker',
+		icon: 'icon-picture',
+		group: 'pickers',
+	},
+};

--- a/src/packages/media/media/property-editors/media-entity-picker/property-editor-ui-media-entity-picker.element.ts
+++ b/src/packages/media/media/property-editors/media-entity-picker/property-editor-ui-media-entity-picker.element.ts
@@ -1,0 +1,65 @@
+import { UmbMediaPickerContext } from '../../components/input-media/input-media.context.js';
+import { html, customElement, property } from '@umbraco-cms/backoffice/external/lit';
+import { splitStringToArray } from '@umbraco-cms/backoffice/utils';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { UmbPropertyValueChangeEvent } from '@umbraco-cms/backoffice/property-editor';
+import type { NumberRangeValueType } from '@umbraco-cms/backoffice/models';
+import type { UmbInputEntityElement } from '@umbraco-cms/backoffice/components';
+import type { UmbMediaItemModel } from '@umbraco-cms/backoffice/media';
+import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
+import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extension-registry';
+
+@customElement('umb-property-editor-ui-media-entity-picker')
+export class UmbPropertyEditorUIMediaEntityPickerElement extends UmbLitElement implements UmbPropertyEditorUiElement {
+	#min: number = 0;
+	#max: number = Infinity;
+
+	@property({ attribute: false })
+	public set value(value: string | null | undefined) {
+		this.#selection = value ? (Array.isArray(value) ? value : splitStringToArray(value)) : [];
+	}
+	public get value() {
+		return this.#selection.length > 0 ? this.#selection.join(',') : null;
+	}
+
+	#selection: Array<string> = [];
+
+	public set config(config: UmbPropertyEditorConfigCollection | undefined) {
+		if (!config) return;
+
+		const minMax = config?.getValueByAlias<NumberRangeValueType>('validationLimit');
+		if (!minMax) return;
+
+		this.#min = minMax.min ?? 0;
+		this.#max = minMax.max ?? Infinity;
+	}
+	public get config() {
+		return undefined;
+	}
+
+	#onChange(event: { target: UmbInputEntityElement }) {
+		this.value = event.target.selection?.join(',') ?? null;
+		this.dispatchEvent(new UmbPropertyValueChangeEvent());
+	}
+
+	render() {
+		return html`
+			<umb-input-entity
+				.getIcon=${(item: UmbMediaItemModel) => item.mediaType.icon ?? 'icon-picture'}
+				.min=${this.#min}
+				.max=${this.#max}
+				.pickerContext=${UmbMediaPickerContext}
+				.selection=${this.#selection}
+				@change=${this.#onChange}>
+			</umb-input-entity>
+		`;
+	}
+}
+
+export default UmbPropertyEditorUIMediaEntityPickerElement;
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-property-editor-ui-media-entity-picker': UmbPropertyEditorUIMediaEntityPickerElement;
+	}
+}


### PR DESCRIPTION
## Description

I'd noticed that both the Media Picker and RTE data-type configurations were using the new Media Picker property-editor UI to set the Start Node field, however that UI is intended for selecting media items with support for crops and focal points, e.g. more meta-data than just the media's unique ID.

This PR adds a new "Media Entity Picker" property-editor UI, with support for only selecting the Media entity unique ID.

The Media Picker and RTE data-type configurations have been updated.

This PR aligns with https://github.com/umbraco/Umbraco-CMS/pull/16042, but is not dependent on it, so can be merged in separately.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
