### PR TITLE
Bugfix: Workspace Breadcrumb: Localizes ancestor names

### DIFF
--- a/src/packages/core/workspace/components/workspace-breadcrumb/workspace-menu-breadcrumb/workspace-menu-breadcrumb.element.ts
+++ b/src/packages/core/workspace/components/workspace-breadcrumb/workspace-menu-breadcrumb/workspace-menu-breadcrumb.element.ts
@@ -1,4 +1,4 @@
-import { html, customElement, state, ifDefined } from '@umbraco-cms/backoffice/external/lit';
+import { html, customElement, state, ifDefined, map } from '@umbraco-cms/backoffice/external/lit';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UMB_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/workspace';
@@ -72,10 +72,11 @@ export class UmbWorkspaceBreadcrumbElement extends UmbLitElement {
 	render() {
 		return html`
 			<uui-breadcrumbs>
-				${this._structure?.map(
+				${map(
+					this._structure,
 					(structureItem) =>
-						html`<uui-breadcrumb-item href="${ifDefined(this.#getHref(structureItem))}"
-							>${structureItem.name}</uui-breadcrumb-item
+						html`<uui-breadcrumb-item href=${ifDefined(this.#getHref(structureItem))}
+							>${this.localize.string(structureItem.name)}</uui-breadcrumb-item
 						>`,
 				)}
 				<uui-breadcrumb-item>${this._name}</uui-breadcrumb-item>


### PR DESCRIPTION
## Description

I'd noticed in the DocumentType and DataType workspaces that the localization key, e.g. `#treeHeaders_dataTypes` was being displayed.

@madsrasmussen I wasn't sure whether the localization should happen further up the chain, or at the point of render? I'm happy to update the PR accordingly.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
