### PR TITLE
Fix: unset extensionsController when destroyed

### DIFF
--- a/src/packages/core/components/extension-slot/extension-slot.element.ts
+++ b/src/packages/core/components/extension-slot/extension-slot.element.ts
@@ -102,6 +102,7 @@ export class UmbExtensionSlotElement extends UmbLitElement {
 	disconnectedCallback(): void {
 		this.#attached = false;
 		this.#extensionsController?.destroy();
+		this.#extensionsController = undefined;
 		super.disconnectedCallback();
 	}
 

--- a/src/packages/core/components/extension-with-api-slot/extension-with-api-slot.element.ts
+++ b/src/packages/core/components/extension-with-api-slot/extension-with-api-slot.element.ts
@@ -149,6 +149,7 @@ export class UmbExtensionWithApiSlotElement extends UmbLitElement {
 	disconnectedCallback(): void {
 		this.#attached = false;
 		this.#extensionsController?.destroy();
+		this.#extensionsController = undefined;
 		super.disconnectedCallback();
 	}
 


### PR DESCRIPTION
Fixing a JS error where extensionsController has been destroy but is still set as a property.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
