### PR TITLE
Feature: Hide entity actions when Tree used inside a Modal

### DIFF
--- a/src/packages/core/tree/default/default-tree.element.ts
+++ b/src/packages/core/tree/default/default-tree.element.ts
@@ -17,6 +17,9 @@ export class UmbDefaultTreeElement extends UmbLitElement {
 	selectionConfiguration: UmbTreeSelectionConfiguration = this._selectionConfiguration;
 
 	@property({ type: Boolean, attribute: false })
+	hideTreeItemActions: boolean = false;
+
+	@property({ type: Boolean, attribute: false })
 	hideTreeRoot: boolean = false;
 
 	@property({ attribute: false })
@@ -94,7 +97,9 @@ export class UmbDefaultTreeElement extends UmbLitElement {
 	#renderTreeRoot() {
 		if (this.hideTreeRoot || this._treeRoot === undefined) return nothing;
 		return html`
-			<umb-tree-item .entityType=${this._treeRoot.entityType} .props=${{ item: this._treeRoot }}></umb-tree-item>
+			<umb-tree-item
+				.entityType=${this._treeRoot.entityType}
+				.props=${{ hideActions: this.hideTreeItemActions, item: this._treeRoot }}></umb-tree-item>
 		`;
 	}
 
@@ -105,7 +110,10 @@ export class UmbDefaultTreeElement extends UmbLitElement {
 				${repeat(
 					this._rootItems,
 					(item, index) => item.name + '___' + index,
-					(item) => html`<umb-tree-item .entityType=${item.entityType} .props=${{ item }}></umb-tree-item>`,
+					(item) =>
+						html`<umb-tree-item
+							.entityType=${item.entityType}
+							.props=${{ hideActions: this.hideTreeItemActions, item }}></umb-tree-item>`,
 				)}
 				${this.#renderPaging()}
 			`;

--- a/src/packages/core/tree/tree-item/tree-item-base/tree-item-element-base.ts
+++ b/src/packages/core/tree/tree-item/tree-item-base/tree-item-element-base.ts
@@ -16,6 +16,9 @@ export abstract class UmbTreeItemElementBase<TreeItemModelType extends UmbTreeIt
 		this.#initTreeItem();
 	}
 
+	@property({ type: Boolean, attribute: false })
+	hideActions: boolean = false;
+
 	@state()
 	private _isActive = false;
 
@@ -162,6 +165,7 @@ export abstract class UmbTreeItemElementBase<TreeItemModelType extends UmbTreeIt
 	}
 
 	#renderActions() {
+		if (this.hideActions) return;
 		return this.#treeItemContext && this._item
 			? html`<umb-entity-actions-bundle
 					slot="actions"
@@ -178,7 +182,10 @@ export abstract class UmbTreeItemElementBase<TreeItemModelType extends UmbTreeIt
 				? repeat(
 						this._childItems,
 						(item, index) => item.name + '___' + index,
-						(item) => html`<umb-tree-item .entityType=${item.entityType} .props=${{ item }}></umb-tree-item>`,
+						(item) =>
+							html`<umb-tree-item
+								.entityType=${item.entityType}
+								.props=${{ hideActions: this.hideActions, item }}></umb-tree-item>`,
 					)
 				: ''}
 		`;

--- a/src/packages/core/tree/tree-picker/tree-picker-modal.element.ts
+++ b/src/packages/core/tree/tree-picker/tree-picker-modal.element.ts
@@ -54,6 +54,7 @@ export class UmbTreePickerModalElement<TreeItemType extends UmbTreeItemModelBase
 					<umb-tree
 						alias=${ifDefined(this.data?.treeAlias)}
 						.props=${{
+							hideTreeItemActions: true,
 							hideTreeRoot: this.data?.hideTreeRoot,
 							selectionConfiguration: this._selectionConfiguration,
 							filter: this.data?.filter,


### PR DESCRIPTION
## Description

@madsrasmussen @nielslyngsoe As discussed recently, a proposed PR.

Adds a flag to the `umb-tree` to hide the tree-item's entity actions. This can be useful when using a tree-picker modal and don't want to enable the user to access the entity actions.

As for whether the the larger feature of "why not?" allow content-managers to run actions within pickers, we can discuss and explore further.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
