### PR TITLE
Bugfix: Date Picker server-time offset refactor

### DIFF
--- a/src/packages/core/components/input-date/input-date.element.ts
+++ b/src/packages/core/components/input-date/input-date.element.ts
@@ -1,8 +1,8 @@
-import { UmbConfigRepository } from '../../repository/config/config.repository.js';
-import { html, ifDefined, customElement, property, state } from '@umbraco-cms/backoffice/external/lit';
-import type { UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
-import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
+import { html, customElement, property } from '@umbraco-cms/backoffice/external/lit';
+import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
+import type { UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
 
 @customElement('umb-input-date')
 export class UmbInputDateElement extends UUIFormControlMixin(UmbLitElement, '') {
@@ -22,12 +22,6 @@ export class UmbInputDateElement extends UUIFormControlMixin(UmbLitElement, '') 
 	@property({ type: String })
 	displayValue?: string;
 
-	@property({ type: Boolean })
-	offsetTime = false;
-
-	@state()
-	private _offsetValue = 0;
-
 	@property({ type: String })
 	min?: string;
 
@@ -37,42 +31,25 @@ export class UmbInputDateElement extends UUIFormControlMixin(UmbLitElement, '') 
 	@property({ type: Number })
 	step?: number;
 
-	private _configRepository = new UmbConfigRepository(this);
-
-	constructor() {
-		super();
-	}
-
 	connectedCallback(): void {
 		super.connectedCallback();
-		this.offsetTime ? this.#getOffset() : (this.displayValue = this.#UTCToLocal(this.value as string));
-	}
-
-	async #getOffset() {
-		const data = await this._configRepository.getServertimeOffset();
-		if (!data) return;
-		this._offsetValue = data.offset;
 
 		if (!this.value) return;
-		this.displayValue = this.#valueToServerOffset(this.value as string, true);
+		this.displayValue = this.#UTCToLocal(this.value as string);
 	}
 
-	#localToUTC(d: string) {
+	#localToUTC(date: string) {
 		if (this.type === 'time') {
-			return new Date(`${new Date().toJSON().slice(0, 10)} ${d}`).toISOString().slice(11, 16);
+			return new Date(`${new Date().toJSON().slice(0, 10)} ${date}`).toISOString().slice(11, 16);
 		} else {
-			const date = new Date(d);
-			const isoDate = date.toISOString();
-			return `${isoDate.substring(0, 10)}T${isoDate.substring(11, 19)}Z`;
+			return new Date(date).toJSON();
 		}
 	}
 
 	#UTCToLocal(d: string) {
 		if (this.type === 'time') {
 			const local = new Date(`${new Date().toJSON().slice(0, 10)} ${d}Z`)
-				.toLocaleTimeString(undefined, {
-					hourCycle: 'h23',
-				})
+				.toLocaleTimeString(undefined, { hourCycle: 'h23' })
 				.slice(0, 5);
 			return local;
 		} else {
@@ -89,58 +66,25 @@ export class UmbInputDateElement extends UUIFormControlMixin(UmbLitElement, '') 
 		}
 	}
 
-	#dateToString(date: Date) {
-		return `${date.getFullYear()}-${('0' + (date.getMonth() + 1)).slice(-2)}-${('0' + date.getDate()).slice(-2)}T${(
-			'0' + date.getHours()
-		).slice(-2)}:${('0' + date.getMinutes()).slice(-2)}:${('0' + date.getSeconds()).slice(-2)}`;
-	}
+	#onChange(event: UUIInputEvent) {
+		const newValue = event.target.value as string;
+		if (!newValue) return;
 
-	#valueToServerOffset(d: string, utc = false) {
-		if (this.type === 'time') {
-			const newDate = new Date(`${new Date().toJSON().slice(0, 10)} ${d}`);
-			const dateOffset = new Date(
-				newDate.setTime(newDate.getTime() + (utc ? this._offsetValue * -1 : this._offsetValue) * 60 * 1000),
-			);
-			const time = dateOffset
-				.toLocaleTimeString(undefined, {
-					hourCycle: 'h23',
-				})
-				.slice(0, 5);
-			return time;
-		} else {
-			const newDate = new Date(d.replace('Z', ''));
-			const dateOffset = new Date(
-				newDate.setTime(newDate.getTime() + (utc ? this._offsetValue * -1 : this._offsetValue) * 60 * 1000),
-			);
-			return this.type === 'datetime-local'
-				? this.#dateToString(dateOffset)
-				: this.#dateToString(dateOffset).slice(0, 10);
-		}
-	}
-
-	#onChange(e: UUIInputEvent) {
-		e.stopPropagation();
-		const picked = e.target.value as string;
-		if (!picked) {
-			this.value = '';
-			this.displayValue = '';
-			return;
-		}
-		this.value = this.offsetTime ? this.#valueToServerOffset(picked) : this.#localToUTC(picked);
-		this.displayValue = picked;
-		this.dispatchEvent(new CustomEvent('change'));
+		this.value = this.#localToUTC(newValue);
+		this.displayValue = newValue;
+		this.dispatchEvent(new UmbChangeEvent());
 	}
 
 	render() {
 		return html`<uui-input
 			id="datetime"
 			label="Pick a date or time"
-			.type="${this.type}"
-			@change="${this.#onChange}"
-			min="${ifDefined(this.min)}"
-			max="${ifDefined(this.max)}"
-			.step="${this.step}"
-			.value="${this.displayValue?.replace('Z', '')}">
+			.min=${this.min}
+			.max=${this.max}
+			.step=${this.step}
+			.type=${this.type}
+			.value="${this.displayValue?.replace('Z', '')}"
+			@change=${this.#onChange}>
 		</uui-input>`;
 	}
 }

--- a/src/packages/core/property-editor/schemas/Umbraco.DateTime.ts
+++ b/src/packages/core/property-editor/schemas/Umbraco.DateTime.ts
@@ -1,36 +1,10 @@
 import type { ManifestPropertyEditorSchema } from '@umbraco-cms/backoffice/extension-registry';
 
-// TODO: We won't include momentjs anymore so we need to find a way to handle date formats
 export const manifest: ManifestPropertyEditorSchema = {
 	type: 'propertyEditorSchema',
 	name: 'Date/Time',
 	alias: 'Umbraco.DateTime',
 	meta: {
 		defaultPropertyEditorUiAlias: 'Umb.PropertyEditorUi.DatePicker',
-		settings: {
-			properties: [
-				{
-					alias: 'offsetTime',
-					label: 'Offset time',
-					description:
-						'When enabled the time displayed will be offset with the servers timezone, this is useful for scenarios like scheduled publishing when an editor is in a different timezone than the hosted server',
-					propertyEditorUiAlias: 'Umb.PropertyEditorUi.Toggle',
-					config: [
-						{
-							alias: 'labelOff',
-							value: 'Adjust to local time',
-						},
-						{
-							alias: 'labelOn',
-							value: 'Adjust to local time',
-						},
-						{
-							alias: 'showLabels',
-							value: true,
-						},
-					],
-				},
-			],
-		},
 	},
 };

--- a/src/packages/core/property-editor/uis/date-picker/property-editor-ui-date-picker.element.ts
+++ b/src/packages/core/property-editor/uis/date-picker/property-editor-ui-date-picker.element.ts
@@ -1,43 +1,15 @@
-import type { UmbPropertyEditorConfigCollection } from '../../index.js';
 import { UmbPropertyValueChangeEvent } from '../../index.js';
-import { html, customElement, property, state } from '@umbraco-cms/backoffice/external/lit';
-import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbPropertyEditorConfigCollection } from '../../index.js';
+import { html, customElement, property, state, ifDefined } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { UmbInputDateElement } from '@umbraco-cms/backoffice/components';
+import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extension-registry';
 
 /**
  * @element umb-property-editor-ui-date-picker
  */
 @customElement('umb-property-editor-ui-date-picker')
 export class UmbPropertyEditorUIDatePickerElement extends UmbLitElement implements UmbPropertyEditorUiElement {
-	private _value?: Date;
-	private _valueString?: string;
-
-	@property()
-	set value(value: string | undefined) {
-		if (value) {
-			const d = new Date(value);
-			this._value = d;
-			this._valueString = `${d.getFullYear()}-${
-				d.getMonth() + 1
-			}-${d.getDate()}T${d.getHours()}:${d.getMinutes()}:${d.getSeconds()}`;
-		} else {
-			this._value = undefined;
-			this._valueString = undefined;
-		}
-	}
-	get value() {
-		return this._valueString;
-	}
-
-	private _onInput(e: InputEvent) {
-		const dateField = e.target as HTMLInputElement;
-		this.value = dateField.value;
-		this.dispatchEvent(new UmbPropertyValueChangeEvent());
-	}
-
-	private _format?: string;
-
 	@state()
 	private _inputType: UmbInputDateElement['type'] = 'datetime-local';
 
@@ -50,29 +22,34 @@ export class UmbPropertyEditorUIDatePickerElement extends UmbLitElement implemen
 	@state()
 	private _step?: number;
 
-	private _offsetTime?: boolean;
+	@property()
+	set value(value: string | undefined) {
+		if (value) {
+			// NOTE: If the `value` contains a space, then it doesn't contain the timezone, so may not be parsed as UTC. [LK]
+			const datetime = !value.includes(' ') ? value : value + ' +00';
+			this.#value = new Date(datetime).toJSON();
+		}
+	}
+	get value() {
+		return this.#value;
+	}
+	#value?: string;
 
 	public set config(config: UmbPropertyEditorConfigCollection | undefined) {
 		if (!config) return;
 		const oldVal = this._inputType;
 
 		// Format string prevalue/config
-		this._format = config.getValueByAlias('format');
-		const pickTime = this._format?.includes('H') || this._format?.includes('m');
-		if (pickTime) {
-			this._inputType = 'datetime-local';
-		} else {
-			this._inputType = 'date';
-		}
+		const format = config.getValueByAlias<string>('format');
+		const hasTime = format?.includes('H') || format?.includes('m');
+		this._inputType = hasTime ? 'datetime-local' : 'date';
 
 		// Based on the type of format string change the UUI-input type
 		const timeFormatPattern = /^h{1,2}:m{1,2}(:s{1,2})?\s?a?$/gim;
-		if (this._format?.toLowerCase().match(timeFormatPattern)) {
+		if (format?.toLowerCase().match(timeFormatPattern)) {
 			this._inputType = 'time';
 		}
 
-		//TODO:
-		this._offsetTime = config.getValueByAlias('offsetTime');
 		this._min = config.getValueByAlias('min');
 		this._max = config.getValueByAlias('max');
 		this._step = config.getValueByAlias('step');
@@ -80,16 +57,22 @@ export class UmbPropertyEditorUIDatePickerElement extends UmbLitElement implemen
 		this.requestUpdate('_inputType', oldVal);
 	}
 
+	#onChange(event: CustomEvent & { target: HTMLInputElement }) {
+		this.value = event.target.value;
+		this.dispatchEvent(new UmbPropertyValueChangeEvent());
+	}
+
 	render() {
-		return html`<umb-input-date
-			.type=${this._inputType}
-			@input=${this._onInput}
-			.datetime=${this._valueString}
-			.min=${this._min}
-			.max=${this._max}
-			.step=${this._step}
-			.offsetTime=${this._offsetTime || false}
-			label="Pick a date or time"></umb-input-date>`;
+		return html`
+			<umb-input-date
+				value="${ifDefined(this.value)}"
+				.min=${this._min}
+				.max=${this._max}
+				.step=${this._step}
+				.type=${this._inputType}
+				@change=${this.#onChange}>
+			</umb-input-date>
+		`;
 	}
 }
 


### PR DESCRIPTION
## Description

Refactors the Date Picker property-editor and input.  The server-time offset has been deemed no longer required, as the underlying value is stored in UTC format.

Also fixed a bug where the value wasn't being wired up and persisted to the server.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
