### PR TITLE
Bugfix: Color Picker prefix hex values with a hash

### DIFF
--- a/src/packages/core/components/input-color/input-color.element.ts
+++ b/src/packages/core/components/input-color/input-color.element.ts
@@ -1,7 +1,7 @@
 import { html, customElement, property, map, nothing } from '@umbraco-cms/backoffice/external/lit';
-import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import type { UmbSwatchDetails } from '@umbraco-cms/backoffice/models';
 import type { UUIColorSwatchesEvent } from '@umbraco-cms/backoffice/external/uui';
 
@@ -11,25 +11,24 @@ import type { UUIColorSwatchesEvent } from '@umbraco-cms/backoffice/external/uui
  */
 @customElement('umb-input-color')
 export class UmbInputColorElement extends UUIFormControlMixin(UmbLitElement, '') {
-	@property({ type: Boolean })
-	showLabels = false;
-
-	@property({ type: Array })
-	swatches?: UmbSwatchDetails[];
-
 	protected getFormElement() {
 		return undefined;
 	}
 
+	@property({ type: Boolean })
+	showLabels = false;
+
+	@property({ type: Array })
+	swatches?: Array<UmbSwatchDetails>;
+
 	#onChange(event: UUIColorSwatchesEvent) {
-		event.stopPropagation();
 		this.value = event.target.value;
 		this.dispatchEvent(new UmbChangeEvent());
 	}
 
 	render() {
 		return html`
-			<uui-color-swatches label="Color picker" value="#${this.value ?? ''}" @change=${this.#onChange}>
+			<uui-color-swatches label="Color picker" value=${this.value ?? ''} @change=${this.#onChange}>
 				${this.#renderColors()}
 			</uui-color-swatches>
 		`;
@@ -40,10 +39,7 @@ export class UmbInputColorElement extends UUIFormControlMixin(UmbLitElement, '')
 		return map(
 			this.swatches,
 			(swatch) => html`
-				<uui-color-swatch
-					label="${swatch.label}"
-					value="#${swatch.value}"
-					.showLabel=${this.showLabels}></uui-color-swatch>
+				<uui-color-swatch label=${swatch.label} value=${swatch.value} .showLabel=${this.showLabels}></uui-color-swatch>
 			`,
 		);
 	}


### PR DESCRIPTION
## Description

This PR fixes a bug introduced in PR #1443, where the color hex value is prefixed with a hash inside the `umb-input-color` component. The reason behind this was that the data-type configuration for the Color Picker property-editor did not prefix the color hex values with a hash, _(this may or may not be a bug in the `umb-property-editor-ui-color-swatches-editor` component)_.

In order to keep the `umb-input-color` component "pure", the logic has been moved to the Color Picker property-editor itself, by ensuring the `"items"` configuration (color swatches) and the `value` are prefixed with a hash.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
