### PR TITLE
Bugfix: Collection View configuration fixes empty inputs

### DIFF
--- a/src/packages/core/property-editor/uis/collection-view/config/column/column-configuration.element.ts
+++ b/src/packages/core/property-editor/uis/collection-view/config/column/column-configuration.element.ts
@@ -1,5 +1,5 @@
 import type { UmbCollectionColumnConfiguration } from '../../../../../collection/types.js';
-import { html, customElement, property, repeat, css, state, nothing, when } from '@umbraco-cms/backoffice/external/lit';
+import { html, customElement, property, repeat, css, state, nothing } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbPropertyValueChangeEvent } from '@umbraco-cms/backoffice/property-editor';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
@@ -16,7 +16,6 @@ export class UmbPropertyEditorUICollectionViewColumnConfigurationElement
 	extends UmbLitElement
 	implements UmbPropertyEditorUiElement
 {
-
 	// TODO: [LK] Add sorting.
 
 	@property({ type: Array })
@@ -74,15 +73,11 @@ export class UmbPropertyEditorUICollectionViewColumnConfigurationElement
 	}
 
 	render() {
-		if (!this.value) return nothing;
+		return html`${this.#renderColumns()} ${this.#renderInput()}`;
+	}
+
+	#renderInput() {
 		return html`
-			<div id="layout-wrapper">
-				${repeat(
-					this.value,
-					(column) => column.alias,
-					(column) => this.#renderField(column),
-				)}
-			</div>
 			<umb-input-content-type-property
 				document-types
 				media-types
@@ -90,7 +85,20 @@ export class UmbPropertyEditorUICollectionViewColumnConfigurationElement
 		`;
 	}
 
-	#renderField(column: UmbCollectionColumnConfiguration) {
+	#renderColumns() {
+		if (!this.value) return nothing;
+		return html`
+			<div id="layout-wrapper">
+				${repeat(
+					this.value,
+					(column) => column.alias,
+					(column) => this.#renderColumn(column),
+				)}
+			</div>
+		`;
+	}
+
+	#renderColumn(column: UmbCollectionColumnConfiguration) {
 		return html`
 			<div class="layout-item">
 				<uui-icon name="icon-navigation"></uui-icon>

--- a/src/packages/core/property-editor/uis/collection-view/config/layout/layout-configuration.element.ts
+++ b/src/packages/core/property-editor/uis/collection-view/config/layout/layout-configuration.element.ts
@@ -51,6 +51,8 @@ export class UmbPropertyEditorUICollectionViewLayoutConfigurationElement
 	#onAdd(event: { target: UmbInputManifestElement }) {
 		const manifest = event.target.value;
 
+		// TODO: [LK] Disallow duplicate `collectionView` aliases selections. [LK]
+
 		this.value = [
 			...(this.value ?? []),
 			{
@@ -97,6 +99,14 @@ export class UmbPropertyEditorUICollectionViewLayoutConfigurationElement
 	}
 
 	render() {
+		return html`${this.#renderLayouts()} ${this.#renderInput()}`;
+	}
+
+	#renderInput() {
+		return html`<umb-input-manifest extension-type="collectionView" @change=${this.#onAdd}></umb-input-manifest>`;
+	}
+
+	#renderLayouts() {
 		if (!this.value) return nothing;
 		return html`
 			<div id="layout-wrapper">
@@ -106,7 +116,6 @@ export class UmbPropertyEditorUICollectionViewLayoutConfigurationElement
 					(layout, index) => this.#renderLayout(layout, index),
 				)}
 			</div>
-			<umb-input-manifest extension-type="collectionView" @change=${this.#onAdd}></umb-input-manifest>
 		`;
 	}
 


### PR DESCRIPTION
## Description

For new/empty Collection View configurations, the fields for Columns and Layout did not show a "Choose" input (add button).

This PR fixes that.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
