### PR TITLE
Bugifx: correct display of document tree item invariant name

### DIFF
--- a/src/packages/documents/documents/tree/tree-item/document-tree-item.element.ts
+++ b/src/packages/documents/documents/tree/tree-item/document-tree-item.element.ts
@@ -45,8 +45,17 @@ export class UmbDocumentTreeItemElement extends UmbTreeItemElementBase<UmbDocume
 		return this.item?.variants.find((x) => x.culture === culture);
 	}
 
+	#isInvariant() {
+		const firstVariant = this.item?.variants[0];
+		return firstVariant?.culture === null && firstVariant?.segment === null;
+	}
+
 	// TODO: we should move the fallback name logic to a helper class. It will be used in multiple places
 	#getLabel() {
+		if (this.#isInvariant()) {
+			return this._item?.variants[0].name;
+		}
+
 		const fallbackName = this.#getVariant(this._defaultCulture)?.name ?? this._item?.variants[0].name ?? 'Unknown';
 		return this._variant?.name ?? `(${fallbackName})`;
 	}


### PR DESCRIPTION
## Description

Removes the parentheses around invariant document names. It will also show for variant documents where the variant doesn't have a name.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

