### PR TITLE
Feat: bind server feedback with validation system

### DIFF
--- a/src/packages/core/property/property-layout/property-layout.element.ts
+++ b/src/packages/core/property/property-layout/property-layout.element.ts
@@ -56,6 +56,16 @@ export class UmbPropertyLayoutElement extends LitElement {
 	@property({ type: Boolean, reflect: true })
 	public invalid?: boolean;
 
+	/**
+	 * @description Describe why the property is invalid.
+	 * @type {boolean}
+	 * @attr
+	 * @default undefined
+	 */
+	@property({ type: String, attribute: 'invalid-message' })
+	public invalidMessage?: string;
+	// TODO: put the invalidMessage in some hover tooltip or something. [NL]
+
 	render() {
 		// TODO: Only show alias on label if user has access to DocumentType within settings:
 		return html`

--- a/src/packages/core/property/property/property.element.ts
+++ b/src/packages/core/property/property/property.element.ts
@@ -109,8 +109,10 @@ export class UmbPropertyElement extends UmbLitElement {
 	@property({ type: String, attribute: false })
 	public set dataPath(dataPath: string | undefined) {
 		this.#dataPath = dataPath;
-		new UmbObserveValidationStateController(this, dataPath, (invalid) => {
-			this._invalid = invalid;
+		new UmbObserveValidationStateController(this, dataPath, (feedback) => {
+			// TODO: Join in a pretty way, and localized way(how to join one or more items varies depending on the language. [NL]
+			// TODO: Also wrap in a general localized message, like "Contains these errors: ..."; [NL]
+			this._validationMessage = feedback.length > 0 ? feedback.map((x) => x.message).join(', ') : undefined;
 		});
 	}
 	public get dataPath(): string | undefined {
@@ -125,7 +127,7 @@ export class UmbPropertyElement extends UmbLitElement {
 	private _element?: ManifestPropertyEditorUi['ELEMENT_TYPE'];
 
 	@state()
-	private _invalid?: boolean;
+	private _validationMessage?: string;
 
 	@state()
 	private _alias?: string;
@@ -276,7 +278,8 @@ export class UmbPropertyElement extends UmbLitElement {
 				alias="${ifDefined(this._alias)}"
 				label="${ifDefined(this._label)}"
 				description="${ifDefined(this._description)}"
-				?invalid=${this._invalid}>
+				?invalid=${this._validationMessage !== undefined}
+				.invalidMessage=${this._validationMessage}>
 				${this._renderPropertyActionMenu()}
 				${this._variantDifference
 					? html`<uui-tag look="secondary" slot="description">${this._variantDifference}</uui-tag>`

--- a/src/packages/core/validation/context/server-model-validation.context.ts
+++ b/src/packages/core/validation/context/server-model-validation.context.ts
@@ -50,19 +50,21 @@ export class UmbServerModelValidationContext
 			this.#validatePromiseResolve = resolve;
 		});
 
+		// Store this state of the data for translator look ups:
+		this.#data = data;
 		// Ask the server for validation...
 		const { error } = await requestPromise;
 
-		// Store this state of the data for translator look ups:
-		this.#data = data;
+		this.#isValid = error ? false : true;
 
-		// We are missing some typing here, but we will just go wild: [NL]
-		const readErrorBody = (error as any).body;
-		Object.keys(readErrorBody.errors).forEach((path) => {
-			this.#serverFeedback.push({ path, messages: readErrorBody.errors[path] });
-		});
+		if (!this.#isValid) {
+			// We are missing some typing here, but we will just go wild with 'as any': [NL]
+			const readErrorBody = (error as any).body;
+			Object.keys(readErrorBody.errors).forEach((path) => {
+				this.#serverFeedback.push({ path, messages: readErrorBody.errors[path] });
+			});
+		}
 
-		this.#isValid = data ? true : false;
 		this.#validatePromiseResolve?.();
 		this.#validatePromiseResolve = undefined;
 

--- a/src/packages/core/validation/context/server-model-validation.context.ts
+++ b/src/packages/core/validation/context/server-model-validation.context.ts
@@ -72,9 +72,8 @@ export class UmbServerModelValidationContext
 
 	#executeTranslatorsOnFeedback = (feedback: ServerFeedbackEntry) => {
 		return this.#translators.flatMap((translator) => {
-			if (translator.match(feedback.path)) {
-				const newPath = translator.translate(feedback.path);
-
+			let newPath: string | undefined;
+			if ((newPath = translator.translate(feedback.path))) {
 				// TODO: I might need to restructure this part for adjusting existing feedback with a part-translation.
 				// Detect if some part is unhandled?
 				// If so only make a partial translation on the feedback, add a message for the handled part.

--- a/src/packages/core/validation/context/validation-messages.manager.ts
+++ b/src/packages/core/validation/context/validation-messages.manager.ts
@@ -34,7 +34,7 @@ export class UmbValidationMessagesManager {
 		return this.#messages.getValue().length !== 0;
 	}
 
-	/*messagesOf(path: string): Observable<Array<UmbValidationMessage>> {
+	messagesOfPathAndDescendant(path: string): Observable<Array<UmbValidationMessage>> {
 		// Find messages that starts with the given path, if the path is longer then require a dot or [ as the next character. using a more performant way than Regex:
 		return this.#messages.asObservablePart((msgs) =>
 			msgs.filter(
@@ -43,7 +43,7 @@ export class UmbValidationMessagesManager {
 					(x.path.length === path.length || x.path[path.length] === '.' || x.path[path.length] === '['),
 			),
 		);
-	}*/
+	}
 
 	messagesOfTypeAndPath(type: UmbValidationMessageType, path: string): Observable<Array<UmbValidationMessage>> {
 		// Find messages that matches the given type and path.

--- a/src/packages/core/validation/controllers/observe-validation-state.controller.ts
+++ b/src/packages/core/validation/controllers/observe-validation-state.controller.ts
@@ -1,4 +1,5 @@
 import { UMB_VALIDATION_CONTEXT } from '../context/validation.context-token.js';
+import type { UmbValidationMessage } from '../context/validation-messages.manager.js';
 import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
@@ -6,11 +7,15 @@ const CtrlSymbol = Symbol();
 const ObserveSymbol = Symbol();
 
 export class UmbObserveValidationStateController extends UmbControllerBase {
-	constructor(host: UmbControllerHost, dataPath: string | undefined, callback: (invalid: boolean) => void) {
+	constructor(
+		host: UmbControllerHost,
+		dataPath: string | undefined,
+		callback: (messages: Array<UmbValidationMessage>) => void,
+	) {
 		super(host, CtrlSymbol);
 		if (dataPath) {
 			this.consumeContext(UMB_VALIDATION_CONTEXT, (context) => {
-				this.observe(context.messages.hasMessagesOfPathAndDescendant(dataPath), callback, ObserveSymbol);
+				this.observe(context.messages.messagesOfPathAndDescendant(dataPath), callback, ObserveSymbol);
 			});
 		}
 	}

--- a/src/packages/core/validation/translators/validation-message-translator.interface.ts
+++ b/src/packages/core/validation/translators/validation-message-translator.interface.ts
@@ -1,4 +1,3 @@
 export interface UmbValidationMessageTranslator {
-	match(message: string): boolean;
-	translate(message: string): string;
+	translate(message: string): undefined | string;
 }

--- a/src/packages/core/validation/translators/variant-values-validation-message-translator.controller.ts
+++ b/src/packages/core/validation/translators/variant-values-validation-message-translator.controller.ts
@@ -17,15 +17,24 @@ export class UmbVariantValuesValidationMessageTranslator
 		this.#context = context;
 	}
 
-	match(message: string): boolean {
-		//return message.startsWith('values[');
-		// regex match, which starts with "$.values[" and then a number and then continues:
-		return message.indexOf('$.values[') === 0;
-	}
-	translate(path: string): string {
-		// retrieve the number from the message values index:
-		const index = parseInt(path.substring(9, path.indexOf(']')));
-		//
+	translate(path: string) {
+		if (path.indexOf('$.values[') !== 0) {
+			// No translation anyway.
+			return;
+		}
+		const pathEnd = path.indexOf(']');
+		if (pathEnd === -1) {
+			// No translation anyway.
+			return;
+		}
+		// retrieve the number from the message values index: [NL]
+		const index = parseInt(path.substring(9, pathEnd));
+
+		if (isNaN(index)) {
+			// No translation anyway.
+			return;
+		}
+		// Get the data from the validation request, the context holds that for us: [NL]
 		const data = this.#context.getData();
 
 		const specificValue = data.values[index];

--- a/src/packages/documents/documents/repository/validation/document-validation.repository.ts
+++ b/src/packages/documents/documents/repository/validation/document-validation.repository.ts
@@ -24,9 +24,7 @@ export class UmbDocumentValidationRepository extends UmbRepositoryBase {
 	async validateCreate(model: DetailModelType, parentUnique: string | null) {
 		if (!model) throw new Error('Data is missing');
 
-		const { data, error } = await this.#validationDataSource.validateCreate(model, parentUnique);
-
-		return { data, error };
+		return this.#validationDataSource.validateCreate(model, parentUnique);
 	}
 
 	/**
@@ -39,8 +37,6 @@ export class UmbDocumentValidationRepository extends UmbRepositoryBase {
 		if (!model) throw new Error('Data is missing');
 		if (!model.unique) throw new Error('Unique is missing');
 
-		const { data, error } = await this.#validationDataSource.validateUpdate(model);
-
-		return { data, error };
+		return this.#validationDataSource.validateUpdate(model);
 	}
 }

--- a/src/packages/documents/documents/repository/validation/document-validation.server.data-source.ts
+++ b/src/packages/documents/documents/repository/validation/document-validation.server.data-source.ts
@@ -45,18 +45,12 @@ export class UmbDocumentValidationServerDataSource {
 		};
 
 		// Maybe use: tryExecuteAndNotify
-		const { data, error } = await tryExecute(
+		return tryExecute(
 			//this.#host,
 			DocumentService.postDocumentValidate({
 				requestBody,
 			}),
 		);
-
-		if (data) {
-			return { data };
-		}
-
-		return { error };
 	}
 
 	/**
@@ -75,18 +69,12 @@ export class UmbDocumentValidationServerDataSource {
 		};
 
 		// Maybe use: tryExecuteAndNotify
-		const { data, error } = await tryExecute(
+		return tryExecute(
 			//this.#host,
 			DocumentService.putDocumentByIdValidate({
 				id: model.unique,
 				requestBody,
 			}),
 		);
-
-		if (!error) {
-			return { data };
-		}
-
-		return { error };
 	}
 }

--- a/src/packages/documents/documents/workspace/document-workspace.context.ts
+++ b/src/packages/documents/documents/workspace/document-workspace.context.ts
@@ -54,6 +54,7 @@ import {
 	UmbVariantValuesValidationMessageTranslator,
 } from '@umbraco-cms/backoffice/validation';
 import { UmbDocumentBlueprintDetailRepository } from '@umbraco-cms/backoffice/document-blueprint';
+import { UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
 
 type EntityType = UmbDocumentDetailModel;
 export class UmbDocumentWorkspaceContext
@@ -649,6 +650,13 @@ export class UmbDocumentWorkspaceContext
 			async () => {
 				// If data of the selection is not valid Then just save:
 				await this.#performSaveOrCreate(saveData);
+				// Notifying that the save was successful, but we did not publish, which is what we want to symbolize here. [NL]
+				const notificationContext = await this.getContext(UMB_NOTIFICATION_CONTEXT);
+				// TODO: Get rid of the save notification.
+				// TODO: Translate this message [NL]
+				notificationContext.peek('danger', {
+					data: { message: 'Document was not published, but we saved it for you.' },
+				});
 				// Reject even thought the save was successful, but we did not publish, which is what we want to symbolize here. [NL]
 				return await Promise.reject();
 			},


### PR DESCRIPTION
Simple first version of server validation binding to the client validation system.

This means properties of a Document can get the validation, but anything more complex than such is not enriched, only the property will know if it contains a validation error.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
