### PR TITLE
Bugfix: Fix media uploads that had wrong file extensions

### DIFF
--- a/src/packages/core/components/input-upload-field/input-upload-field.element.ts
+++ b/src/packages/core/components/input-upload-field/input-upload-field.element.ts
@@ -45,7 +45,12 @@ export class UmbInputUploadFieldElement extends UUIFormControlMixin(UmbLitElemen
 	 * @default undefined
 	 */
 	@property({ type: Array })
-	fileExtensions?: Array<string>;
+	set fileExtensions(value: Array<string>) {
+		this.#setExtensions(value);
+	}
+	get fileExtensions(): Array<string> | undefined {
+		return this.extensions;
+	}
 
 	/**
 	 * @description Allows the user to upload multiple files.
@@ -105,11 +110,6 @@ export class UmbInputUploadFieldElement extends UUIFormControlMixin(UmbLitElemen
 		});
 	}
 
-	connectedCallback(): void {
-		super.connectedCallback();
-		this.#setExtensions();
-	}
-
 	async #setFilePaths() {
 		await this.#serverUrlPromise;
 
@@ -124,11 +124,9 @@ export class UmbInputUploadFieldElement extends UUIFormControlMixin(UmbLitElemen
 		});
 	}
 
-	#setExtensions() {
-		if (!this.fileExtensions?.length) return;
-
+	#setExtensions(value: Array<string>) {
 		// TODO: The dropzone uui component does not support file extensions without a dot. Remove this when it does.
-		this.extensions = this.fileExtensions.map((extension) => {
+		this.extensions = value.map((extension) => {
 			return `.${extension}`;
 		});
 	}

--- a/src/packages/core/property-editor/uis/upload-field/property-editor-ui-upload-field.element.ts
+++ b/src/packages/core/property-editor/uis/upload-field/property-editor-ui-upload-field.element.ts
@@ -15,9 +15,7 @@ export class UmbPropertyEditorUIUploadFieldElement extends UmbLitElement impleme
 	public set config(config: UmbPropertyEditorConfigCollection | undefined) {
 		if (!config) return;
 
-		this._fileExtensions = config
-			.getValueByAlias<{ id: number; value: string }[]>('fileExtensions')
-			?.map((ext) => ext.value);
+		this._fileExtensions = config.getValueByAlias<Array<string>>('fileExtensions');
 
 		this._multiple = config.getValueByAlias('multiple');
 	}


### PR DESCRIPTION
## Description
Fixed a bug that sat the file extensions to .undefined rather than the given file extension.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
