### PR TITLE
Bugfix: Create a document when no blueprint available

### DIFF
--- a/src/packages/documents/documents/entity-actions/create/document-create-options-modal.element.ts
+++ b/src/packages/documents/documents/entity-actions/create/document-create-options-modal.element.ts
@@ -78,7 +78,7 @@ export class UmbDocumentCreateOptionsModalElement extends UmbModalBaseElement<
 			history.pushState(
 				null,
 				'',
-				`section/content/workspace/document/create/parent/${this.data?.parent.entityType}/${this.data?.parent.unique ?? 'null'}/${documentTypeUnique}/${blueprintUnique}`,
+				`section/content/workspace/document/create/parent/${this.data?.parent.entityType}/${this.data?.parent.unique ?? 'null'}/${documentTypeUnique}/blueprint/${blueprintUnique}`,
 			);
 		}
 		this._submitModal();
@@ -90,9 +90,8 @@ export class UmbDocumentCreateOptionsModalElement extends UmbModalBaseElement<
 
 		/** TODO: Fix this to use the correct endpoint when it becomes available */
 		const { data } = await this.#documentBlueprintItemRepository.requestItems([]);
-		if (!data?.length) return;
 
-		this._availableBlueprints = data.filter((blueprint) => blueprint.documentType.unique === documentTypeUnique);
+		this._availableBlueprints = data?.filter((blueprint) => blueprint.documentType.unique === documentTypeUnique) ?? [];
 
 		if (!this._availableBlueprints.length) {
 			this.#onNavigate(documentTypeUnique);

--- a/src/packages/documents/documents/workspace/document-workspace.context.ts
+++ b/src/packages/documents/documents/workspace/document-workspace.context.ts
@@ -160,7 +160,7 @@ export class UmbDocumentWorkspaceContext
 
 		this.routes.setRoutes([
 			{
-				path: 'create/parent/:entityType/:parentUnique/:documentTypeUnique/:blueprintUnique',
+				path: 'create/parent/:entityType/:parentUnique/:documentTypeUnique/blueprint/:blueprintUnique',
 				component: () => import('./document-workspace-editor.element.js'),
 				setup: async (_component, info) => {
 					const parentEntityType = info.match.params.entityType;
@@ -248,8 +248,7 @@ export class UmbDocumentWorkspaceContext
 		this.resetState();
 		this.#parent.setValue(parent);
 
-		/**TODO Explore bug: A way to make blueprintUnique undefined/null when no unique is given, rather than setting it to invariant */
-		if (blueprintUnique && blueprintUnique.toLowerCase() !== 'invariant') {
+		if (blueprintUnique) {
 			const { data } = await this.#blueprintRepository.requestByUnique(blueprintUnique);
 
 			this.#getDataPromise = this.repository.createScaffold({


### PR DESCRIPTION
## Description
Fixed a bug where you could not create a new document when no blueprints were available for the picked document type.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

