### PR TITLE
Bugfix: Logviewer: removes the `decodeURIComponent`

### DIFF
--- a/src/packages/log-viewer/workspace/logviewer-workspace.context.ts
+++ b/src/packages/log-viewer/workspace/logviewer-workspace.context.ts
@@ -124,11 +124,7 @@ export class UmbLogViewerWorkspaceContext extends UmbControllerBase implements U
 
 	onChangeState = () => {
 		const searchQuery = query();
-		let sanitizedQuery = '';
-		if (searchQuery.lq) {
-			sanitizedQuery = decodeURIComponent(searchQuery.lq);
-		}
-		this.setFilterExpression(sanitizedQuery);
+		this.setFilterExpression(searchQuery.lq);
 
 		let validLogLevels: LogLevelModel[] = [];
 		if (searchQuery.loglevels) {


### PR DESCRIPTION
## Description

In the Log Viewer's Saved searches, any queries clicked on that contained a percentage sign `%` would throw an malformed URI error, this was because the value was being double-decoded, (since the router-slot `query()` function we're using already handles the URL decoding).

This PR removes the extra `decodeURIComponent` call, so clicking on the saved searches (that contain percentage signs) now work.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
