### PR TITLE
Bugfix: ColorPicker: Regex to ensure hex color hash prefix

### DIFF
--- a/src/packages/core/property-editor/uis/color-picker/property-editor-ui-color-picker.element.ts
+++ b/src/packages/core/property-editor/uis/color-picker/property-editor-ui-color-picker.element.ts
@@ -41,7 +41,8 @@ export class UmbPropertyEditorUIColorPickerElement extends UmbLitElement impleme
 	#ensureHashPrefix(swatch: UmbSwatchDetails): UmbSwatchDetails {
 		return {
 			label: swatch.label,
-			value: swatch.value.startsWith('#') ? swatch.value : `#${swatch.value}`,
+			// hex color regex adapted from: https://stackoverflow.com/a/9682781/12787
+			value: swatch.value.match(/^(?:[0-9a-f]{3}){1,2}$/i) ? `#${swatch.value}` : swatch.value,
 		};
 	}
 


### PR DESCRIPTION
## Description

Following on from a conversation on PR #1606, this PR adds a RegEx to check whether the hex color value is valid (e.g. `0-9a-f` and 3 or 6 characters in length), and doesn't have a hash prefix `#`.  This is to support current usage (pre-v14 migrated data) and accommodate future usage, for those wishing to use alternative CSS value formats.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
