### PR TITLE
Feature: Umbraco version number (header logo modal)

### DIFF
--- a/src/apps/backoffice/components/backoffice-header-logo.element.ts
+++ b/src/apps/backoffice/components/backoffice-header-logo.element.ts
@@ -1,0 +1,73 @@
+import { UMB_BACKOFFICE_CONTEXT } from '../backoffice.context.js';
+import { css, html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
+
+@customElement('umb-backoffice-header-logo')
+export class UmbBackofficeHeaderLogoElement extends UmbLitElement {
+	@state()
+	private _version?: string;
+
+	constructor() {
+		super();
+
+		this.consumeContext(UMB_BACKOFFICE_CONTEXT, (context) => {
+			this.observe(
+				context.version,
+				(version) => {
+					if (!version) return;
+					this._version = version;
+				},
+				'_observeVersion',
+			);
+		});
+	}
+
+	render() {
+		return html`
+			<uui-button id="logo" look="primary" label="Umbraco" compact popovertarget="logo-popover">
+				<img src="/umbraco/backoffice/assets/umbraco_logomark_white.svg" alt="Umbraco" />
+			</uui-button>
+			<uui-popover-container id="logo-popover" placement="bottom-start">
+				<umb-popover-layout>
+					<div id="modal">
+						<img src="/umbraco/backoffice/assets/umbraco_logo_blue.svg" alt="Umbraco" loading="lazy" />
+						<span>${this._version}</span>
+						<a href="https://umbraco.com" target="_blank" rel="noopener">Umbraco.com</a>
+					</div>
+				</umb-popover-layout>
+			</uui-popover-container>
+		`;
+	}
+
+	static styles = [
+		UmbTextStyles,
+		css`
+			#logo {
+				--uui-button-padding-top-factor: 1;
+				--uui-button-padding-bottom-factor: 0.5;
+				margin-right: var(--uui-size-space-2);
+				--uui-button-background-color: transparent;
+			}
+
+			#logo > img {
+				height: var(--uui-size-10);
+				width: var(--uui-size-10);
+			}
+
+			#modal {
+				padding: var(--uui-size-space-6);
+				display: flex;
+				flex-direction: column;
+				align-items: center;
+				gap: var(--uui-size-space-3);
+			}
+		`,
+	];
+}
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-backoffice-header-logo': UmbBackofficeHeaderLogoElement;
+	}
+}

--- a/src/apps/backoffice/components/backoffice-header.element.ts
+++ b/src/apps/backoffice/components/backoffice-header.element.ts
@@ -1,4 +1,3 @@
-import type { CSSResultGroup } from '@umbraco-cms/backoffice/external/lit';
 import { css, html, customElement } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 
@@ -7,17 +6,14 @@ export class UmbBackofficeHeaderElement extends UmbLitElement {
 	render() {
 		return html`
 			<div id="appHeader">
-				<uui-button id="logo" look="primary" label="Umbraco" compact>
-					<img src="/umbraco/backoffice/assets/umbraco_logomark_white.svg" alt="Umbraco" />
-				</uui-button>
-
+				<umb-backoffice-header-logo></umb-backoffice-header-logo>
 				<umb-backoffice-header-sections id="sections"></umb-backoffice-header-sections>
 				<umb-backoffice-header-apps></umb-backoffice-header-apps>
 			</div>
 		`;
 	}
 
-	static styles: CSSResultGroup = [
+	static styles = [
 		css`
 			:host {
 				width: 100%;
@@ -29,18 +25,6 @@ export class UmbBackofficeHeaderElement extends UmbLitElement {
 				align-items: center;
 				justify-content: space-between;
 				padding: 0 var(--uui-size-space-5);
-			}
-
-			#logo {
-				--uui-button-padding-top-factor: 1;
-				--uui-button-padding-bottom-factor: 0.5;
-				margin-right: var(--uui-size-space-2);
-				--uui-button-background-color: transparent;
-			}
-
-			#logo img {
-				height: var(--uui-size-10);
-				width: var(--uui-size-10);
 			}
 
 			#sections {

--- a/src/apps/backoffice/components/index.ts
+++ b/src/apps/backoffice/components/index.ts
@@ -1,4 +1,5 @@
 export * from './backoffice-header-apps.element.js';
+export * from './backoffice-header-logo.element.js';
 export * from './backoffice-header-sections.element.js';
 export * from './backoffice-header.element.js';
 export * from './backoffice-main.element.js';


### PR DESCRIPTION
## Description

Adds the header logo modal, that contains the Umbraco logo, version number and link to the umbraco.com website.

![Screenshot of proposed Umbraco version number modal](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/209066/ffb5e672-9eda-41da-b318-073ed767caba)

For this initial implementation, I chose to use `tryExecute` directly inside the `UmbBackofficeContext`. Ideally, I assume this would be separated out to its own repository, but I was unsure of the naming (and which package it should reside?).

The ad-hoc SemVer regex parser is there to remove the unwanted bits of the version number, namely the build suffix as it starts to look a overwhelming, but we can adjust this as required.

I'm happy to restructure this PR as needed.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
