### PR TITLE
Chore: minor corrections for form control

### DIFF
--- a/src/packages/core/components/input-number-range/input-number-range.element.ts
+++ b/src/packages/core/components/input-number-range/input-number-range.element.ts
@@ -9,7 +9,7 @@ function getNumberOrUndefined(value: string) {
 }
 
 @customElement('umb-input-number-range')
-export class UmbInputNumberRangeElement extends UmbFormControlMixin(UmbLitElement, undefined) {
+export class UmbInputNumberRangeElement extends UmbFormControlMixin<string>(UmbLitElement, '') {
 	@property({ type: String, attribute: 'min-label' })
 	minLabel = 'Low value';
 

--- a/src/packages/core/components/input-number-range/input-number-range.element.ts
+++ b/src/packages/core/components/input-number-range/input-number-range.element.ts
@@ -9,7 +9,7 @@ function getNumberOrUndefined(value: string) {
 }
 
 @customElement('umb-input-number-range')
-export class UmbInputNumberRangeElement extends UmbFormControlMixin<string | undefined, typeof UmbLitElement>(
+export class UmbInputNumberRangeElement extends UmbFormControlMixin<string | undefined, typeof UmbLitElement, ''>(
 	UmbLitElement,
 	'',
 ) {

--- a/src/packages/core/components/input-number-range/input-number-range.element.ts
+++ b/src/packages/core/components/input-number-range/input-number-range.element.ts
@@ -9,7 +9,10 @@ function getNumberOrUndefined(value: string) {
 }
 
 @customElement('umb-input-number-range')
-export class UmbInputNumberRangeElement extends UmbFormControlMixin<string>(UmbLitElement, '') {
+export class UmbInputNumberRangeElement extends UmbFormControlMixin<string | undefined, typeof UmbLitElement>(
+	UmbLitElement,
+	'',
+) {
 	@property({ type: String, attribute: 'min-label' })
 	minLabel = 'Low value';
 

--- a/src/packages/core/components/multiple-text-string-input/input-multiple-text-string.element.ts
+++ b/src/packages/core/components/multiple-text-string-input/input-multiple-text-string.element.ts
@@ -10,7 +10,10 @@ import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
  * @element umb-input-multiple-text-string
  */
 @customElement('umb-input-multiple-text-string')
-export class UmbInputMultipleTextStringElement extends UmbFormControlMixin(UmbLitElement) {
+export class UmbInputMultipleTextStringElement extends UmbFormControlMixin<undefined | string, typeof UmbLitElement>(
+	UmbLitElement,
+	undefined,
+) {
 	#sorter = new UmbSorterController(this, {
 		getUniqueOfElement: (element) => {
 			return element.getAttribute('data-sort-entry-id');

--- a/src/packages/core/property-editor/uis/number-range/property-editor-ui-number-range.element.ts
+++ b/src/packages/core/property-editor/uis/number-range/property-editor-ui-number-range.element.ts
@@ -14,7 +14,7 @@ import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
  */
 @customElement('umb-property-editor-ui-number-range')
 export class UmbPropertyEditorUINumberRangeElement
-	extends UmbFormControlMixin<NumberRangeValueType>(UmbLitElement, undefined)
+	extends UmbFormControlMixin<NumberRangeValueType | undefined, typeof UmbLitElement>(UmbLitElement, undefined)
 	implements UmbPropertyEditorUiElement
 {
 	@property({ type: Object })

--- a/src/packages/core/validation/controllers/bind-validation-message-to-form-control.controller.ts
+++ b/src/packages/core/validation/controllers/bind-validation-message-to-form-control.controller.ts
@@ -13,9 +13,9 @@ export class UmbBindValidationMessageToFormControl extends UmbControllerBase {
 
 	#context?: typeof UMB_VALIDATION_CONTEXT.TYPE;
 
-	#control: UmbFormControlMixinInterface<unknown, unknown>;
+	#control: UmbFormControlMixinInterface<unknown>;
 
-	#controlValidator?: ReturnType<UmbFormControlMixinInterface<unknown, unknown>['addValidator']>;
+	#controlValidator?: ReturnType<UmbFormControlMixinInterface<unknown>['addValidator']>;
 	#messages: Array<UmbValidationMessage> = [];
 	#isValid = false;
 
@@ -38,7 +38,7 @@ export class UmbBindValidationMessageToFormControl extends UmbControllerBase {
 		}
 	}
 
-	constructor(host: UmbControllerHost, formControl: UmbFormControlMixinInterface<unknown, unknown>, dataPath: string) {
+	constructor(host: UmbControllerHost, formControl: UmbFormControlMixinInterface<unknown>, dataPath: string) {
 		super(host, ctrlSymbol);
 		this.#control = formControl;
 		this.consumeContext(UMB_VALIDATION_CONTEXT, (context) => {

--- a/src/packages/core/validation/controllers/form-control-validator.controller.ts
+++ b/src/packages/core/validation/controllers/form-control-validator.controller.ts
@@ -12,12 +12,12 @@ export class UmbFormControlValidator extends UmbControllerBase implements UmbVal
 
 	#context?: typeof UMB_VALIDATION_CONTEXT.TYPE;
 
-	#control: UmbFormControlMixinInterface<unknown, unknown>;
+	#control: UmbFormControlMixinInterface<unknown>;
 	readonly controllerAlias: UmbControllerAlias;
 
 	#isValid = true;
 
-	constructor(host: UmbControllerHost, formControl: UmbFormControlMixinInterface<unknown, unknown>, dataPath?: string) {
+	constructor(host: UmbControllerHost, formControl: UmbFormControlMixinInterface<unknown>, dataPath?: string) {
 		super(host);
 		this.#dataPath = dataPath;
 		this.consumeContext(UMB_VALIDATION_CONTEXT, (context) => {

--- a/src/packages/core/validation/mixins/form-control.mixin.ts
+++ b/src/packages/core/validation/mixins/form-control.mixin.ts
@@ -334,7 +334,8 @@ export const UmbFormControlMixin = <
 		}
 
 		updated(changedProperties: Map<string | number | symbol, unknown>) {
-			super.updated(changedProperties);
+			// @ts-expect-error We don't know if we are extending a lit-element:
+			super.updated?.(changedProperties);
 			this._runValidators();
 		}
 

--- a/src/packages/core/validation/mixins/form-control.mixin.ts
+++ b/src/packages/core/validation/mixins/form-control.mixin.ts
@@ -33,14 +33,14 @@ interface UmbFormControlValidatorConfig {
 	checkMethod: () => boolean;
 }
 
-export interface UmbFormControlMixinInterface<ValueType, DefaultValueType> extends HTMLElement {
+export interface UmbFormControlMixinInterface<ValueType> extends HTMLElement {
 	addValidator: (flagKey: FlagTypes, getMessageMethod: () => string, checkMethod: () => boolean) => void;
 	removeValidator: (obj: UmbFormControlValidatorConfig) => void;
 	//static formAssociated: boolean;
 	//protected getFormElement(): HTMLElement | undefined | null; // allows for null as it makes it simpler to just implement a querySelector as that might return null. [NL]
 	focusFirstInvalidElement(): void;
-	get value(): ValueType | DefaultValueType;
-	set value(newValue: ValueType | DefaultValueType);
+	get value(): ValueType;
+	set value(newValue: ValueType);
 	formResetCallback(): void;
 	checkValidity(): boolean;
 	get validationMessage(): string;
@@ -50,9 +50,9 @@ export interface UmbFormControlMixinInterface<ValueType, DefaultValueType> exten
 	pristine: boolean;
 }
 
-export declare abstract class UmbFormControlMixinElement<ValueType, DefaultValueType>
+export declare abstract class UmbFormControlMixinElement<ValueType>
 	extends LitElement
-	implements UmbFormControlMixinInterface<ValueType, DefaultValueType>
+	implements UmbFormControlMixinInterface<ValueType>
 {
 	protected _internals: ElementInternals;
 	protected _runValidators(): void;
@@ -63,8 +63,8 @@ export declare abstract class UmbFormControlMixinElement<ValueType, DefaultValue
 	//static formAssociated: boolean;
 	protected getFormElement(): HTMLElement | undefined | null;
 	focusFirstInvalidElement(): void;
-	get value(): ValueType | DefaultValueType;
-	set value(newValue: ValueType | DefaultValueType);
+	get value(): ValueType;
+	set value(newValue: ValueType);
 	formResetCallback(): void;
 	checkValidity(): boolean;
 	get validationMessage(): string;
@@ -80,14 +80,10 @@ export declare abstract class UmbFormControlMixinElement<ValueType, DefaultValue
  * @param {Object} superClass - superclass to be extended.
  * @mixin
  */
-export const UmbFormControlMixin = <
-	ValueType = FormDataEntryValue | FormData,
+export function UmbFormControlMixin<
+	ValueType = FormData | FormDataEntryValue,
 	T extends HTMLElementConstructor<LitElement> = HTMLElementConstructor<LitElement>,
-	DefaultValueType = undefined,
->(
-	superClass: T,
-	defaultValue: DefaultValueType = undefined as DefaultValueType,
-) => {
+>(superClass: T, defaultValue: ValueType = undefined as ValueType) {
 	abstract class UmbFormControlMixinClass extends superClass {
 		/**
 		 * This is a static class field indicating that the element is can be used inside a native form and participate in its events.
@@ -105,10 +101,10 @@ export const UmbFormControlMixin = <
 		 * @default ''
 		 */
 		@property({ reflect: false }) // Do not 'reflect' as the attribute value is used as fallback. [NL]
-		get value(): ValueType | DefaultValueType {
+		get value(): ValueType {
 			return this.#value;
 		}
-		set value(newValue: ValueType | DefaultValueType) {
+		set value(newValue: ValueType) {
 			this.#value = newValue;
 			this._runValidators();
 		}
@@ -135,7 +131,7 @@ export const UmbFormControlMixin = <
 		}
 		private _pristine: boolean = true;
 
-		#value: ValueType | DefaultValueType = defaultValue;
+		#value: ValueType = defaultValue;
 		protected _internals: ElementInternals;
 		#form: HTMLFormElement | null = null;
 		#validators: UmbFormControlValidatorConfig[] = [];
@@ -358,11 +354,11 @@ export const UmbFormControlMixin = <
 			this.value = this.getInitialValue() ?? this.getDefaultValue();
 		}
 
-		protected getDefaultValue(): DefaultValueType {
+		protected getDefaultValue(): ValueType {
 			return defaultValue;
 		}
-		protected getInitialValue(): ValueType | DefaultValueType {
-			return this.getAttribute('value') as ValueType | DefaultValueType;
+		protected getInitialValue(): ValueType {
+			return this.getAttribute('value') as ValueType;
 		}
 
 		public checkValidity() {
@@ -387,8 +383,5 @@ export const UmbFormControlMixin = <
 			return this._internals?.validationMessage;
 		}
 	}
-	return UmbFormControlMixinClass as unknown as HTMLElementConstructor<
-		UmbFormControlMixinElement<ValueType, DefaultValueType>
-	> &
-		T;
-};
+	return UmbFormControlMixinClass as unknown as HTMLElementConstructor<UmbFormControlMixinElement<ValueType>> & T;
+}

--- a/src/packages/core/validation/mixins/form-control.mixin.ts
+++ b/src/packages/core/validation/mixins/form-control.mixin.ts
@@ -82,7 +82,7 @@ export declare abstract class UmbFormControlMixinElement<ValueType, DefaultValue
  */
 export const UmbFormControlMixin = <
 	ValueType = FormDataEntryValue | FormData,
-	T extends HTMLElementConstructor<HTMLElement> = HTMLElementConstructor<HTMLElement>,
+	T extends HTMLElementConstructor<LitElement> = HTMLElementConstructor<LitElement>,
 	DefaultValueType = undefined,
 >(
 	superClass: T,

--- a/src/packages/core/validation/mixins/form-control.mixin.ts
+++ b/src/packages/core/validation/mixins/form-control.mixin.ts
@@ -84,7 +84,7 @@ export function UmbFormControlMixin<
 	ValueType = FormData | FormDataEntryValue,
 	T extends HTMLElementConstructor<LitElement> = HTMLElementConstructor<LitElement>,
 	DefaultValueType extends ValueType = ValueType,
->(superClass: T, defaultValue: DefaultValueType = undefined as DefaultValueType) {
+>(superClass: T, defaultValue?: DefaultValueType) {
 	abstract class UmbFormControlMixinClass extends superClass {
 		/**
 		 * This is a static class field indicating that the element is can be used inside a native form and participate in its events.

--- a/src/packages/core/validation/mixins/form-control.mixin.ts
+++ b/src/packages/core/validation/mixins/form-control.mixin.ts
@@ -82,7 +82,7 @@ export declare abstract class UmbFormControlMixinElement<ValueType, DefaultValue
  */
 export const UmbFormControlMixin = <
 	ValueType = FormDataEntryValue | FormData,
-	T extends HTMLElementConstructor<LitElement> = HTMLElementConstructor<LitElement>,
+	T extends HTMLElementConstructor<HTMLElement> = HTMLElementConstructor<HTMLElement>,
 	DefaultValueType = undefined,
 >(
 	superClass: T,

--- a/src/packages/core/validation/mixins/form-control.mixin.ts
+++ b/src/packages/core/validation/mixins/form-control.mixin.ts
@@ -83,7 +83,8 @@ export declare abstract class UmbFormControlMixinElement<ValueType>
 export function UmbFormControlMixin<
 	ValueType = FormData | FormDataEntryValue,
 	T extends HTMLElementConstructor<LitElement> = HTMLElementConstructor<LitElement>,
->(superClass: T, defaultValue: ValueType = undefined as ValueType) {
+	DefaultValueType extends ValueType = ValueType,
+>(superClass: T, defaultValue: DefaultValueType = undefined as DefaultValueType) {
 	abstract class UmbFormControlMixinClass extends superClass {
 		/**
 		 * This is a static class field indicating that the element is can be used inside a native form and participate in its events.
@@ -354,7 +355,7 @@ export function UmbFormControlMixin<
 			this.value = this.getInitialValue() ?? this.getDefaultValue();
 		}
 
-		protected getDefaultValue(): ValueType {
+		protected getDefaultValue(): DefaultValueType {
 			return defaultValue;
 		}
 		protected getInitialValue(): ValueType {

--- a/src/packages/core/validation/mixins/form-control.mixin.ts
+++ b/src/packages/core/validation/mixins/form-control.mixin.ts
@@ -83,7 +83,7 @@ export declare abstract class UmbFormControlMixinElement<ValueType>
 export function UmbFormControlMixin<
 	ValueType = FormData | FormDataEntryValue,
 	T extends HTMLElementConstructor<LitElement> = HTMLElementConstructor<LitElement>,
-	DefaultValueType extends ValueType = ValueType,
+	DefaultValueType = undefined,
 >(superClass: T, defaultValue?: DefaultValueType) {
 	abstract class UmbFormControlMixinClass extends superClass {
 		/**
@@ -102,10 +102,10 @@ export function UmbFormControlMixin<
 		 * @default ''
 		 */
 		@property({ reflect: false }) // Do not 'reflect' as the attribute value is used as fallback. [NL]
-		get value(): ValueType {
+		get value(): ValueType | DefaultValueType {
 			return this.#value;
 		}
-		set value(newValue: ValueType) {
+		set value(newValue: ValueType | DefaultValueType) {
 			this.#value = newValue;
 			this._runValidators();
 		}
@@ -132,7 +132,7 @@ export function UmbFormControlMixin<
 		}
 		private _pristine: boolean = true;
 
-		#value: ValueType = defaultValue;
+		#value: ValueType | DefaultValueType = defaultValue as unknown as DefaultValueType;
 		protected _internals: ElementInternals;
 		#form: HTMLFormElement | null = null;
 		#validators: UmbFormControlValidatorConfig[] = [];
@@ -356,10 +356,10 @@ export function UmbFormControlMixin<
 		}
 
 		protected getDefaultValue(): DefaultValueType {
-			return defaultValue;
+			return defaultValue as DefaultValueType;
 		}
-		protected getInitialValue(): ValueType {
-			return this.getAttribute('value') as ValueType;
+		protected getInitialValue(): ValueType | DefaultValueType {
+			return this.getAttribute('value') as ValueType | DefaultValueType;
 		}
 
 		public checkValidity() {
@@ -384,5 +384,8 @@ export function UmbFormControlMixin<
 			return this._internals?.validationMessage;
 		}
 	}
-	return UmbFormControlMixinClass as unknown as HTMLElementConstructor<UmbFormControlMixinElement<ValueType>> & T;
+	return UmbFormControlMixinClass as unknown as HTMLElementConstructor<
+		UmbFormControlMixinElement<ValueType | DefaultValueType>
+	> &
+		T;
 }

--- a/src/packages/core/validation/mixins/form-control.mixin.ts
+++ b/src/packages/core/validation/mixins/form-control.mixin.ts
@@ -27,7 +27,7 @@ type FlagTypes =
 	| 'valid';
 
 // Acceptable as an internal interface/type, BUT if exposed externally this should be turned into a public interface in a separate file.
-interface UmbFormControlValidationConfig {
+interface UmbFormControlValidatorConfig {
 	flagKey: FlagTypes;
 	getMessageMethod: () => string;
 	checkMethod: () => boolean;
@@ -35,7 +35,7 @@ interface UmbFormControlValidationConfig {
 
 export interface UmbFormControlMixinInterface<ValueType, DefaultValueType> extends HTMLElement {
 	addValidator: (flagKey: FlagTypes, getMessageMethod: () => string, checkMethod: () => boolean) => void;
-	removeValidator: (obj: UmbFormControlValidationConfig) => void;
+	removeValidator: (obj: UmbFormControlValidatorConfig) => void;
 	//static formAssociated: boolean;
 	//protected getFormElement(): HTMLElement | undefined | null; // allows for null as it makes it simpler to just implement a querySelector as that might return null. [NL]
 	focusFirstInvalidElement(): void;
@@ -57,7 +57,7 @@ export declare abstract class UmbFormControlMixinElement<ValueType, DefaultValue
 	protected _internals: ElementInternals;
 	protected _runValidators(): void;
 	addValidator: (flagKey: FlagTypes, getMessageMethod: () => string, checkMethod: () => boolean) => void;
-	removeValidator: (obj: UmbFormControlValidationConfig) => void;
+	removeValidator: (obj: UmbFormControlValidatorConfig) => void;
 	protected addFormControlElement(element: UmbNativeFormControlElement): void;
 
 	//static formAssociated: boolean;
@@ -138,7 +138,7 @@ export const UmbFormControlMixin = <
 		#value: ValueType | DefaultValueType = defaultValue;
 		protected _internals: ElementInternals;
 		#form: HTMLFormElement | null = null;
-		#validators: UmbFormControlValidationConfig[] = [];
+		#validators: UmbFormControlValidatorConfig[] = [];
 		#formCtrlElements: UmbNativeFormControlElement[] = [];
 
 		constructor(...args: any[]) {
@@ -208,7 +208,7 @@ export const UmbFormControlMixin = <
 			flagKey: FlagTypes,
 			getMessageMethod: () => string,
 			checkMethod: () => boolean,
-		): UmbFormControlValidationConfig {
+		): UmbFormControlValidatorConfig {
 			const validator = {
 				flagKey: flagKey,
 				getMessageMethod: getMessageMethod,
@@ -221,9 +221,9 @@ export const UmbFormControlMixin = <
 		/**
 		 * Remove validation from this form control.
 		 * @method removeValidator
-		 * @param {UmbFormControlValidationConfig} validator - The specific validation configuration to remove.
+		 * @param {UmbFormControlValidatorConfig} validator - The specific validation configuration to remove.
 		 */
-		removeValidator(validator: UmbFormControlValidationConfig) {
+		removeValidator(validator: UmbFormControlValidatorConfig) {
 			const index = this.#validators.indexOf(validator);
 			if (index !== -1) {
 				this.#validators.splice(index, 1);
@@ -251,7 +251,7 @@ export const UmbFormControlMixin = <
 			}
 		}
 
-		private _customValidityObject?: UmbFormControlValidationConfig;
+		private _customValidityObject?: UmbFormControlValidatorConfig;
 
 		/**
 		 * @method setCustomValidity

--- a/src/packages/core/validation/mixins/form-control.mixin.ts
+++ b/src/packages/core/validation/mixins/form-control.mixin.ts
@@ -334,8 +334,7 @@ export const UmbFormControlMixin = <
 		}
 
 		updated(changedProperties: Map<string | number | symbol, unknown>) {
-			// @ts-expect-error We don't know if we are extending a lit-element:
-			super.updated?.(changedProperties);
+			super.updated(changedProperties);
 			this._runValidators();
 		}
 

--- a/src/packages/umbraco-news/umbraco-news-dashboard.element.ts
+++ b/src/packages/umbraco-news/umbraco-news-dashboard.element.ts
@@ -41,13 +41,14 @@ export class UmbUmbracoNewsDashboardElement extends UmbLitElement {
 						</p>
 						<uui-button
 							look="primary"
+							target="_blank"
 							href="https://our.umbraco.com/?utm_source=core&utm_medium=dashboard&utm_content=image&utm_campaign=our"
 							label="Visit Our Umbraco"></uui-button>
 					</div>
 				</uui-box>
 				${this.#infoLinks.map(
 					(link) => html`
-						<a class="info-link" href=${link.href}>
+						<a class="info-link" target="_blank" href=${link.href}>
 							<h3 class="uui-h5">${link.name}</h3>
 							<p>${link.description}</p>
 						</a>
@@ -71,6 +72,7 @@ export class UmbUmbracoNewsDashboardElement extends UmbLitElement {
 			#our-umbraco {
 				grid-column-start: 1;
 				grid-column-end: -1;
+				margin-bottom: var(--uui-size-space-4);
 			}
 			#info-links {
 				display: grid;


### PR DESCRIPTION
Contains this:
* Removed DefaultValueType generic type for a simpler implementation.
* Corrected implementations that did set one generic, when setting one generic all of them has to be defined, so before the superClassType was missing.
* Simple small type rename.