### PR TITLE
Bugfix: Radio Button List: prevent triggering double 'change' event

### DIFF
--- a/src/packages/core/components/input-radio-button-list/input-radio-button-list.element.ts
+++ b/src/packages/core/components/input-radio-button-list/input-radio-button-list.element.ts
@@ -1,8 +1,8 @@
 import { css, html, nothing, repeat, customElement, property } from '@umbraco-cms/backoffice/external/lit';
-import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
+import { UUIFormControlMixin, UUIRadioElement } from '@umbraco-cms/backoffice/external/uui';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import type { UUIBooleanInputEvent } from '@umbraco-cms/backoffice/external/uui';
+import type { UUIRadioEvent } from '@umbraco-cms/backoffice/external/uui';
 
 @customElement('umb-input-radio-button-list')
 export class UmbInputRadioButtonListElement extends UUIFormControlMixin(UmbLitElement, '') {
@@ -23,11 +23,10 @@ export class UmbInputRadioButtonListElement extends UUIFormControlMixin(UmbLitEl
 		return undefined;
 	}
 
-	#onChange(event: UUIBooleanInputEvent) {
+	#onChange(event: UUIRadioEvent) {
 		event.stopPropagation();
-
+		if (!(event.target instanceof UUIRadioElement)) return;
 		this.value = event.target.value;
-
 		this.dispatchEvent(new UmbChangeEvent());
 	}
 
@@ -46,7 +45,7 @@ export class UmbInputRadioButtonListElement extends UUIFormControlMixin(UmbLitEl
 	}
 
 	#renderRadioButton(item: (typeof this.list)[0]) {
-		return html`<uui-radio value="${item.value}" label="${item.label}"></uui-radio>`;
+		return html`<uui-radio value=${item.value} label=${item.label}></uui-radio>`;
 	}
 
 	static styles = [


### PR DESCRIPTION
## Description

Both the `uui-radio-group` and `uui-radio` dispatch a 'change' event, which triggers the `#onChange` method twice.

The `uui-radio` component is the one that contains the changed value, so updated the code to only use that.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
