### PR TITLE
Bugfix: Document Picker sorting

### DIFF
--- a/src/packages/core/property-editor/uis/tree-picker/property-editor-ui-tree-picker.element.ts
+++ b/src/packages/core/property-editor/uis/tree-picker/property-editor-ui-tree-picker.element.ts
@@ -1,11 +1,11 @@
 import { html, customElement, property, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import { UmbPropertyValueChangeEvent } from '@umbraco-cms/backoffice/property-editor';
 import { UmbDynamicRootRepository } from '@umbraco-cms/backoffice/dynamic-root';
+import { UmbPropertyValueChangeEvent } from '@umbraco-cms/backoffice/property-editor';
 import { UMB_ENTITY_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/workspace';
+import type { UmbInputTreeElement } from '@umbraco-cms/backoffice/tree';
 import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
 import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extension-registry';
-import type { UmbInputTreeElement } from '@umbraco-cms/backoffice/tree';
 import type { UmbTreePickerSource } from '@umbraco-cms/backoffice/components';
 
 /**
@@ -26,7 +26,7 @@ export class UmbPropertyEditorUITreePickerElement extends UmbLitElement implemen
 	min = 0;
 
 	@state()
-	max = 0;
+	max = Infinity;
 
 	@state()
 	allowedContentTypeIds?: string | null;
@@ -42,20 +42,21 @@ export class UmbPropertyEditorUITreePickerElement extends UmbLitElement implemen
 	#dynamicRootRepository = new UmbDynamicRootRepository(this);
 
 	public set config(config: UmbPropertyEditorConfigCollection | undefined) {
-		const startNode: UmbTreePickerSource | undefined = config?.getValueByAlias('startNode');
+		if (!config) return;
+
+		const startNode = config.getValueByAlias<UmbTreePickerSource>('startNode');
 		if (startNode) {
 			this.type = startNode.type;
 			this.startNodeId = startNode.id;
 			this.#dynamicRoot = startNode.dynamicRoot;
 		}
 
-		this.min = Number(config?.getValueByAlias('minNumber')) || 0;
-		this.max = Number(config?.getValueByAlias('maxNumber')) || 0;
+		this.min = Number(config.getValueByAlias('minNumber')) || 0;
+		this.max = Number(config.getValueByAlias('maxNumber')) || Infinity;
 
-		this.type = config?.getValueByAlias('type') ?? 'content';
-		this.allowedContentTypeIds = config?.getValueByAlias('filter');
-		this.showOpenButton = config?.getValueByAlias('showOpenButton');
-		this.ignoreUserStartNodes = config?.getValueByAlias('ignoreUserStartNodes');
+		this.allowedContentTypeIds = config.getValueByAlias('filter');
+		this.showOpenButton = config.getValueByAlias('showOpenButton');
+		this.ignoreUserStartNodes = config.getValueByAlias('ignoreUserStartNodes');
 	}
 
 	connectedCallback() {
@@ -79,9 +80,8 @@ export class UmbPropertyEditorUITreePickerElement extends UmbLitElement implemen
 		}
 	}
 
-	#onChange(e: CustomEvent) {
-		const input = e.target as UmbInputTreeElement;
-		this.value = input.items;
+	#onChange(event: CustomEvent & { target: UmbInputTreeElement }) {
+		this.value = event.target.items;
 		this.dispatchEvent(new UmbPropertyValueChangeEvent());
 	}
 

--- a/src/packages/documents/documents/components/input-document/input-document.element.ts
+++ b/src/packages/documents/documents/components/input-document/input-document.element.ts
@@ -1,11 +1,11 @@
 import type { UmbDocumentTreeItemModel } from '../../tree/types.js';
 import { UmbDocumentPickerContext } from './input-document.context.js';
-import { css, html, customElement, property, state, ifDefined, repeat } from '@umbraco-cms/backoffice/external/lit';
-import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
-import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { css, html, customElement, property, state, repeat } from '@umbraco-cms/backoffice/external/lit';
 import { splitStringToArray } from '@umbraco-cms/backoffice/utils';
-import { UMB_WORKSPACE_MODAL, UmbModalRouteRegistrationController } from '@umbraco-cms/backoffice/modal';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbSorterController } from '@umbraco-cms/backoffice/sorter';
+import { UMB_WORKSPACE_MODAL, UmbModalRouteRegistrationController } from '@umbraco-cms/backoffice/modal';
+import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import type { UmbDocumentItemModel } from '@umbraco-cms/backoffice/document';
 
 @customElement('umb-input-document')
@@ -93,7 +93,6 @@ export class UmbInputDocumentElement extends UUIFormControlMixin(UmbLitElement, 
 
 	@property()
 	public set value(idsString: string) {
-		// Its with full purpose we don't call super.value, as thats being handled by the observation of the context selection.
 		this.selection = splitStringToArray(idsString);
 	}
 	public get value() {
@@ -167,37 +166,39 @@ export class UmbInputDocumentElement extends UUIFormControlMixin(UmbLitElement, 
 
 	#renderItems() {
 		if (!this._items) return;
-		return html`<uui-ref-list>
-			${repeat(
-				this._items,
-				(item) => item.unique,
-				(item) => this.#renderItem(item),
-			)}
-		</uui-ref-list>`;
+		return html`
+			<uui-ref-list>
+				${repeat(
+					this._items,
+					(item) => item.unique,
+					(item) => this.#renderItem(item),
+				)}
+			</uui-ref-list>
+		`;
 	}
 
 	#renderAddButton() {
 		if (this.max === 1 && this.selection.length >= this.max) return;
-		return html`<uui-button
-			id="add-button"
-			look="placeholder"
-			@click=${this.#openPicker}
-			label=${this.localize.term('general_choose')}></uui-button>`;
+		return html`
+			<uui-button
+				id="btn-add"
+				look="placeholder"
+				@click=${this.#openPicker}
+				label=${this.localize.term('general_choose')}></uui-button>
+		`;
 	}
+
 
 	#renderItem(item: UmbDocumentItemModel) {
 		if (!item.unique) return;
-		// TODO: get correct variant name
-		const name = item.variants[0]?.name;
-
 		return html`
-			<uui-ref-node name=${name} id=${item.unique}>
+			<uui-ref-node name=${item.name} id=${item.unique}>
 				${this.#renderIcon(item)} ${this.#renderIsTrashed(item)}
 				<uui-action-bar slot="actions">
 					${this.#renderOpenButton(item)}
-					<uui-button @click=${() => this.#pickerContext.requestRemoveItem(item.unique)} label="Remove document ${name}"
-						>${this.localize.term('general_remove')}</uui-button
-					>
+					<uui-button
+						@click=${() => this.#pickerContext.requestRemoveItem(item.unique)}
+						label=${this.localize.term('general_remove')}></uui-button>
 				</uui-action-bar>
 			</uui-ref-node>
 		`;
@@ -215,14 +216,10 @@ export class UmbInputDocumentElement extends UUIFormControlMixin(UmbLitElement, 
 
 	#renderOpenButton(item: UmbDocumentItemModel) {
 		if (!this.showOpenButton) return;
-
-		// TODO: get correct variant name
-		const name = item.variants[0]?.name;
-
 		return html`
 			<uui-button
 				href="${this._editDocumentPath}edit/${item.unique}"
-				label="${this.localize.term('general_open')} ${name}">
+				label="${this.localize.term('general_open')} ${item.name}">
 				${this.localize.term('general_open')}
 			</uui-button>
 		`;
@@ -230,7 +227,7 @@ export class UmbInputDocumentElement extends UUIFormControlMixin(UmbLitElement, 
 
 	static styles = [
 		css`
-			#add-button {
+			#btn-add {
 				width: 100%;
 			}
 

--- a/src/packages/documents/documents/components/input-document/input-document.element.ts
+++ b/src/packages/documents/documents/components/input-document/input-document.element.ts
@@ -1,4 +1,3 @@
-import type { UmbDocumentTreeItemModel } from '../../tree/types.js';
 import { UmbDocumentPickerContext } from './input-document.context.js';
 import { css, html, customElement, property, state, repeat } from '@umbraco-cms/backoffice/external/lit';
 import { splitStringToArray } from '@umbraco-cms/backoffice/utils';
@@ -143,7 +142,7 @@ export class UmbInputDocumentElement extends UUIFormControlMixin(UmbLitElement, 
 		return undefined;
 	}
 
-	#pickableFilter: (item: UmbDocumentTreeItemModel) => boolean = (item) => {
+	#pickableFilter: (item: UmbDocumentItemModel) => boolean = (item) => {
 		if (this.allowedContentTypeIds && this.allowedContentTypeIds.length > 0) {
 			return this.allowedContentTypeIds.includes(item.documentType.unique);
 		}
@@ -154,8 +153,6 @@ export class UmbInputDocumentElement extends UUIFormControlMixin(UmbLitElement, 
 		// TODO: Configure the content picker, with `startNodeId` and `ignoreUserStartNodes` [LK]
 		this.#pickerContext.openPicker({
 			hideTreeRoot: true,
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore
 			pickableFilter: this.#pickableFilter,
 		});
 	}

--- a/src/packages/documents/documents/components/input-document/input-document.element.ts
+++ b/src/packages/documents/documents/components/input-document/input-document.element.ts
@@ -12,7 +12,7 @@ import type { UmbDocumentItemModel } from '@umbraco-cms/backoffice/document';
 export class UmbInputDocumentElement extends UUIFormControlMixin(UmbLitElement, '') {
 	#sorter = new UmbSorterController<string>(this, {
 		getUniqueOfElement: (element) => {
-			return element.getAttribute('detail');
+			return element.id;
 		},
 		getUniqueOfModel: (modelEntry) => {
 			return modelEntry;
@@ -166,7 +166,7 @@ export class UmbInputDocumentElement extends UUIFormControlMixin(UmbLitElement, 
 	}
 
 	#renderItems() {
-		if (!this._items?.length) return;
+		if (!this._items) return;
 		return html`<uui-ref-list>
 			${repeat(
 				this._items,
@@ -191,7 +191,7 @@ export class UmbInputDocumentElement extends UUIFormControlMixin(UmbLitElement, 
 		const name = item.variants[0]?.name;
 
 		return html`
-			<uui-ref-node name=${name}>
+			<uui-ref-node name=${name} id=${item.unique}>
 				${this.#renderIcon(item)} ${this.#renderIsTrashed(item)}
 				<uui-action-bar slot="actions">
 					${this.#renderOpenButton(item)}


### PR DESCRIPTION
## Description

Initially fixes the sorting of the selected items in the Document input component, but also does a code sweep tidy-up in other the container Document Picker and Tree Picker property-editors.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
