### PR TITLE
Corrects "minimum" to "maximum" in the integer and decimal property editors

### DIFF
--- a/src/packages/core/property-editor/schemas/Umbraco.Decimal.ts
+++ b/src/packages/core/property-editor/schemas/Umbraco.Decimal.ts
@@ -17,7 +17,7 @@ export const manifest: ManifestPropertyEditorSchema = {
 				{
 					alias: 'max',
 					label: 'Maximum',
-					description: 'Enter the minimum amount of number to be entered',
+					description: 'Enter the maximum amount of number to be entered',
 					propertyEditorUiAlias: 'Umb.PropertyEditorUi.Decimal',
 				},
 				{

--- a/src/packages/core/property-editor/schemas/Umbraco.Integer.ts
+++ b/src/packages/core/property-editor/schemas/Umbraco.Integer.ts
@@ -17,7 +17,7 @@ export const manifest: ManifestPropertyEditorSchema = {
 				{
 					alias: 'max',
 					label: 'Maximum',
-					description: 'Enter the minimum amount of number to be entered',
+					description: 'Enter the maximum amount of number to be entered',
 					propertyEditorUiAlias: 'Umb.PropertyEditorUi.Number',
 				},
 				{


### PR DESCRIPTION
Corrects two typos in the numeric property editors. 

## Description

Currently the `Decimal` and `Numeric` property editors say on the `Maximum` property "enter the minimum amount...". This change updates to "enter the **maximum** amount..."


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ✅ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

Just a typo

## How to test?
Open a property editor for `Numeric` or `Decimal`, check the `Maximum` property text now describes `Maximum` instead of `Minimum`

## Screenshots (if appropriate)
![Screenshot 2024-04-18 at 14 30 41](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/7046713/61c730d6-75bb-466e-9de1-696502e36a99)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ✅] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
