### PR TITLE
Fixes issue with RTE query string links #1674 and ensures #1169

### DIFF
--- a/src/packages/tiny-mce/plugins/tiny-mce-linkpicker.plugin.ts
+++ b/src/packages/tiny-mce/plugins/tiny-mce-linkpicker.plugin.ts
@@ -72,7 +72,7 @@ export default class UmbTinyMceLinkPickerPlugin extends UmbTinyMcePluginBase {
 
 		if (this.#anchorElement.href.includes('localLink:')) {
 			const href = this.#anchorElement.getAttribute('href')!;
-			currentTarget.unique = href.split('localLink:')[1].slice(0, -1);
+			currentTarget.unique = href.substring(href.indexOf(":") + 1, href.indexOf("}"));
 		} else if (this.#anchorElement.host.length) {
 			currentTarget.url = this.#anchorElement.protocol ? this.#anchorElement.protocol + '//' : undefined;
 			currentTarget.url += this.#anchorElement.host + this.#anchorElement.pathname;
@@ -122,7 +122,9 @@ export default class UmbTinyMceLinkPickerPlugin extends UmbTinyMcePluginBase {
 			a.title = name;
 		}
 
-		if (this.#linkPickerData?.link.queryString?.startsWith('#')) {
+		if (this.#linkPickerData?.link.queryString?.startsWith('#') || 
+			this.#linkPickerData?.link.queryString?.startsWith('?')) 
+		{
 			a['data-anchor'] = this.#linkPickerData?.link.queryString;
 			a.href += this.#linkPickerData?.link.queryString;
 		}


### PR DESCRIPTION
This PR fixes a bug that would ignore any query string value added to the anchor/query input of the link picker in the RTE.

Main issue is described here: https://github.com/umbraco/Umbraco.CMS.Backoffice/issues/1674

It also ensures that a bugfix from v13 is applied: https://github.com/umbraco/Umbraco.CMS.Backoffice/issues/1169

I do think that it would be good to maybe extract (or at least export) some functions for the logic here so that it can be tested but I'm not sure how to approach this so I started with this PR to fix the bug.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

## How to test?
Create a RTE and insert links, try:

* Adding query string like this: `?foo=bar`
* Adding query string like this: `?foo=bar&lroem=ipsum`
* Adding anchor like this: `#something` 

## Screenshots

### Before:

![umb-rte-link-query-strings](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/1782524/ec8bcceb-4fae-4f90-97a4-fe1e4df3c16b)

### After
![umb-rte-query-fixed](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/1782524/d5c65a0e-5a1f-48a9-9130-9132fc06b973)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
