### PR TITLE
Bugfix: Composition Modal when document type isNew

### DIFF
--- a/src/packages/core/content-type/modals/composition-picker/composition-picker-modal.element.ts
+++ b/src/packages/core/content-type/modals/composition-picker/composition-picker-modal.element.ts
@@ -24,7 +24,7 @@ export class UmbCompositionPickerModalElement extends UmbModalBaseElement<
 > {
 	// TODO: Loosen this from begin specific to Document Types, so we can have a general interface for composition repositories. [NL]
 	#compositionRepository?: UmbDocumentTypeCompositionRepository;
-	#unique?: string;
+	#unique: string | null = null;
 	#init?: Promise<void>;
 
 	@state()
@@ -50,26 +50,24 @@ export class UmbCompositionPickerModalElement extends UmbModalBaseElement<
 		this._selection = this.data?.selection ?? [];
 		this.modalContext?.setValue({ selection: this._selection });
 
+		const isNew = this.data!.isNew;
+		this.#unique = !isNew ? this.data!.unique : null;
+
 		this.#requestReference();
+		this.#requestAvailableCompositions();
 	}
 
 	async #requestReference() {
 		await this.#init;
-		this.#unique = this.data?.unique;
 		if (!this.#unique || !this.#compositionRepository) return;
 
 		const { data } = await this.#compositionRepository.getReferences(this.#unique);
-
 		this._references = data ?? [];
-
-		if (!this._references.length) {
-			this.#requestAvailableCompositions();
-		}
 	}
 
 	async #requestAvailableCompositions() {
 		await this.#init;
-		if (!this.#unique || !this.#compositionRepository) return;
+		if (!this.#compositionRepository) return;
 
 		const isElement = this.data?.isElement;
 		const currentPropertyAliases = this.data?.currentPropertyAliases;

--- a/src/packages/core/content-type/modals/composition-picker/composition-picker-modal.token.ts
+++ b/src/packages/core/content-type/modals/composition-picker/composition-picker-modal.token.ts
@@ -4,10 +4,10 @@ import { UmbModalToken } from '@umbraco-cms/backoffice/modal';
 export interface UmbCompositionPickerModalData {
 	compositionRepositoryAlias: string;
 	selection: Array<string>;
-	unique: string;
-	//Do we really need to send this to the server - Why isn't unique enough?
+	unique: string | null;
 	isElement: boolean;
 	currentPropertyAliases: Array<string>;
+	isNew: boolean;
 }
 
 export interface UmbCompositionPickerModalValue {

--- a/src/packages/core/content-type/workspace/views/design/content-type-design-editor.element.ts
+++ b/src/packages/core/content-type/workspace/views/design/content-type-design-editor.element.ts
@@ -333,6 +333,7 @@ export class UmbContentTypeDesignEditorElement extends UmbLitElement implements 
 			selection: contentTypes.map((contentType) => contentType.unique).filter((id) => id !== unique),
 			isElement: ownerContentType.isElement,
 			currentPropertyAliases: [],
+			isNew: this.#workspaceContext.getIsNew()!,
 		};
 
 		const modalManagerContext = await this.getContext(UMB_MODAL_MANAGER_CONTEXT);

--- a/src/packages/documents/document-types/types.ts
+++ b/src/packages/documents/document-types/types.ts
@@ -15,8 +15,7 @@ export type UmbDocumentTypeCleanupModel = {
 };
 
 export interface UmbDocumentTypeCompositionRequestModel {
-	unique: string;
-	//Do we really need to send this to the server - Why isn't unique enough?
+	unique: string | null;
 	isElement: boolean;
 	currentPropertyAliases: Array<string>;
 	currentCompositeUniques: Array<string>;


### PR DESCRIPTION
## Description

Fixes an error when opening the composition modal while the document type is still not saved.
Issue & details can be found here https://github.com/umbraco/Umbraco-CMS/issues/16091

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)