### PR TITLE
Fix: use setValue for setValue on modal context

### DIFF
--- a/src/packages/core/modal/context/modal.context.ts
+++ b/src/packages/core/modal/context/modal.context.ts
@@ -122,7 +122,7 @@ export class UmbModalContext<ModalPreset extends object = object, ModalValue = a
 	 * @memberof UmbModalContext
 	 */
 	public setValue(value: ModalValue) {
-		this.#value.update(value);
+		this.#value.setValue(value);
 	}
 
 	/**


### PR DESCRIPTION
Update `setValue` method of Modal Context, to use `setValue` of its value state. This was before using `updateValue` of the state. Meaning it only updated the value, but never set it to the given data. If you still want to partial update your value, you will now have to change your code to use the other method called `updateValue` on the modal context.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
