### PR TITLE
Bugfix: Language isocode and fallback picker

### DIFF
--- a/src/packages/language/components/input-language/input-language.element.ts
+++ b/src/packages/language/components/input-language/input-language.element.ts
@@ -122,6 +122,7 @@ export class UmbInputLanguageElement extends UUIFormControlMixin(UmbLitElement, 
 	#openPicker() {
 		this.#pickerContext.openPicker({
 			filter: this.filter,
+			multiple: this.max > 1 ? true : false,
 		});
 	}
 

--- a/src/packages/language/modals/language-picker/language-picker-modal.element.ts
+++ b/src/packages/language/modals/language-picker/language-picker-modal.element.ts
@@ -21,6 +21,10 @@ export class UmbLanguagePickerModalElement extends UmbModalBaseElement<
 		this.#selectionManager.setSelectable(true);
 		this.#selectionManager.setMultiple(this.data?.multiple ?? false);
 		this.#selectionManager.setSelection(this.value?.selection ?? []);
+
+		this.observe(this.#selectionManager.selection, (selection) => {
+			this.value = { selection };
+		});
 	}
 
 	async firstUpdated() {
@@ -37,7 +41,6 @@ export class UmbLanguagePickerModalElement extends UmbModalBaseElement<
 	}
 
 	#submit() {
-		this.value = { selection: this.#selectionManager.getSelection() };
 		this.modalContext?.submit();
 	}
 
@@ -57,7 +60,7 @@ export class UmbLanguagePickerModalElement extends UmbModalBaseElement<
 							selectable
 							@selected=${() => this.#selectionManager.select(item.unique)}
 							@deselected=${() => this.#selectionManager.deselect(item.unique)}
-							?selected=${this.#selectionManager.isSelected(item.unique)}>
+							?selected=${this.value.selection.includes(item.unique)}>
 							<uui-icon slot="icon" name="icon-globe"></uui-icon>
 						</uui-menu-item>
 					`,

--- a/src/packages/language/repository/detail/language-detail.server.data-source.ts
+++ b/src/packages/language/repository/detail/language-detail.server.data-source.ts
@@ -41,7 +41,7 @@ export class UmbLanguageServerDataSource implements UmbDetailDataSource<UmbLangu
 			isDefault: false,
 			isMandatory: false,
 			name: '',
-			unique: UmbId.new(), // Creating a temporary unique until the culture is selected
+			unique: '',
 			...preset,
 		};
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes a bug where the iso code showed up as a guid
Closes issue: https://github.com/umbraco/Umbraco-CMS/issues/16090

Fixes a bug where the fallback language picker would always allow to pick multiple languages.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
