### PR TITLE
Bugfix: Upload files with no extensions

### DIFF
--- a/src/packages/core/components/input-upload-field/input-upload-field.element.ts
+++ b/src/packages/core/components/input-upload-field/input-upload-field.element.ts
@@ -125,7 +125,7 @@ export class UmbInputUploadFieldElement extends UUIFormControlMixin(UmbLitElemen
 
 	#setExtensions(value: Array<string>) {
 		// TODO: The dropzone uui component does not support file extensions without a dot. Remove this when it does.
-		this.extensions = value.map((extension) => {
+		this.extensions = value?.map((extension) => {
 			return `.${extension}`;
 		});
 	}


### PR DESCRIPTION
## Description

This fixes a bug where when no file extensions were set, the file upload field wouldn't show up.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)