### PR TITLE
Bugfix: Fixed sorting of Collection configuration editors (on new data-types)

### DIFF
--- a/src/packages/property-editors/collection-view/config/column/column-configuration.element.ts
+++ b/src/packages/property-editors/collection-view/config/column/column-configuration.element.ts
@@ -30,9 +30,9 @@ export class UmbPropertyEditorUICollectionViewColumnConfigurationElement
 	});
 
 	@property({ type: Array })
-	public set value(value: Array<UmbCollectionColumnConfiguration>) {
-		this.#value = value;
-		this.#sorter.setModel(value);
+	public set value(value: Array<UmbCollectionColumnConfiguration> | undefined) {
+		this.#value = value ?? [];
+		this.#sorter.setModel(this.#value);
 	}
 	public get value(): Array<UmbCollectionColumnConfiguration> {
 		return this.#value;
@@ -92,7 +92,10 @@ export class UmbPropertyEditorUICollectionViewColumnConfigurationElement
 	}
 
 	render() {
-		return html`${this.#renderColumns()} ${this.#renderInput()}`;
+		return html`
+			<div id="layout-wrapper">${this.#renderColumns()}</div>
+			${this.#renderInput()}
+		`;
 	}
 
 	#renderInput() {
@@ -106,15 +109,11 @@ export class UmbPropertyEditorUICollectionViewColumnConfigurationElement
 
 	#renderColumns() {
 		if (!this.value) return nothing;
-		return html`
-			<div id="layout-wrapper">
-				${repeat(
-					this.value,
-					(column) => column.alias,
-					(column) => this.#renderColumn(column),
-				)}
-			</div>
-		`;
+		return repeat(
+			this.value,
+			(column) => column.alias,
+			(column) => this.#renderColumn(column),
+		);
 	}
 
 	#renderColumn(column: UmbCollectionColumnConfiguration) {

--- a/src/packages/property-editors/collection-view/config/layout/layout-configuration.element.ts
+++ b/src/packages/property-editors/collection-view/config/layout/layout-configuration.element.ts
@@ -53,9 +53,9 @@ export class UmbPropertyEditorUICollectionViewLayoutConfigurationElement
 	});
 
 	@property({ type: Array })
-	public set value(value: Array<UmbCollectionLayoutConfiguration>) {
-		this.#value = value;
-		this.#sorter.setModel(value);
+	public set value(value: Array<UmbCollectionLayoutConfiguration> | undefined) {
+		this.#value = value ?? [];
+		this.#sorter.setModel(this.#value);
 	}
 	public get value(): Array<UmbCollectionLayoutConfiguration> {
 		return this.#value;
@@ -132,7 +132,10 @@ export class UmbPropertyEditorUICollectionViewLayoutConfigurationElement
 	}
 
 	render() {
-		return html`${this.#renderLayouts()} ${this.#renderInput()}`;
+		return html`
+			<div id="layout-wrapper">${this.#renderLayouts()}</div>
+			${this.#renderInput()}
+		`;
 	}
 
 	#renderInput() {
@@ -141,15 +144,11 @@ export class UmbPropertyEditorUICollectionViewLayoutConfigurationElement
 
 	#renderLayouts() {
 		if (!this.value) return nothing;
-		return html`
-			<div id="layout-wrapper">
-				${repeat(
-					this.value,
-					(layout) => this.#getUnique(layout),
-					(layout, index) => this.#renderLayout(layout, index),
-				)}
-			</div>
-		`;
+		return repeat(
+			this.value,
+			(layout) => this.#getUnique(layout),
+			(layout, index) => this.#renderLayout(layout, index),
+		);
 	}
 
 	#renderLayout(layout: UmbCollectionLayoutConfiguration, index: number) {


### PR DESCRIPTION
## Description

When a new Collection View data-type is created, the Columns and Layout fields are empty, which exposed a bug with the sorting feature. This PR rectifies the bug.

/cc @elit0451 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
