### PR TITLE
Bugfix: Member Picker property-editor, `max` = 1

### DIFF
--- a/src/packages/members/member/components/input-member/input-member.element.ts
+++ b/src/packages/members/member/components/input-member/input-member.element.ts
@@ -1,6 +1,6 @@
 import type { UmbMemberItemModel } from '../../repository/index.js';
 import { UmbMemberPickerContext } from './input-member.context.js';
-import { css, html, customElement, property, state, repeat } from '@umbraco-cms/backoffice/external/lit';
+import { css, customElement, html, nothing, property, repeat, state } from '@umbraco-cms/backoffice/external/lit';
 import { splitStringToArray } from '@umbraco-cms/backoffice/utils';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
@@ -164,7 +164,7 @@ export class UmbInputMemberElement extends UUIFormControlMixin(UmbLitElement, ''
 	}
 
 	#renderItems() {
-		if (!this._items) return;
+		if (!this._items) return nothing;
 		return html`
 			<uui-ref-list>
 				${repeat(
@@ -177,7 +177,7 @@ export class UmbInputMemberElement extends UUIFormControlMixin(UmbLitElement, ''
 	}
 
 	#renderAddButton() {
-		if (this.max === 1 && this.selection.length >= this.max) return;
+		if (this.max === 1 && this.selection.length >= this.max) return nothing;
 		return html`<uui-button
 			id="btn-add"
 			look="placeholder"
@@ -186,7 +186,7 @@ export class UmbInputMemberElement extends UUIFormControlMixin(UmbLitElement, ''
 	}
 
 	#renderItem(item: UmbMemberItemModel) {
-		if (!item.unique) return;
+		if (!item.unique) return nothing;
 		return html`
 			<uui-ref-node name=${item.name} id=${item.unique}>
 				<uui-action-bar slot="actions">
@@ -198,7 +198,7 @@ export class UmbInputMemberElement extends UUIFormControlMixin(UmbLitElement, ''
 	}
 
 	#renderOpenButton(item: UmbMemberItemModel) {
-		if (!this.showOpenButton) return;
+		if (!this.showOpenButton) return nothing;
 		return html`
 			<uui-button
 				href="${this._editMemberPath}edit/${item.unique}"

--- a/src/packages/members/member/property-editor/member-picker/property-editor-ui-member-picker.element.ts
+++ b/src/packages/members/member/property-editor/member-picker/property-editor-ui-member-picker.element.ts
@@ -1,7 +1,6 @@
-import { html, customElement, property, state } from '@umbraco-cms/backoffice/external/lit';
+import { html, customElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbPropertyValueChangeEvent } from '@umbraco-cms/backoffice/property-editor';
-import type { NumberRangeValueType } from '@umbraco-cms/backoffice/models';
 import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
 import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extension-registry';
 import type { UmbInputMemberElement } from '@umbraco-cms/backoffice/member';
@@ -14,19 +13,8 @@ export class UmbPropertyEditorUIMemberPickerElement extends UmbLitElement implem
 	@property()
 	public value?: string;
 
-	public set config(config: UmbPropertyEditorConfigCollection | undefined) {
-		if (!config) return;
-
-		const minMax = config?.getValueByAlias<NumberRangeValueType>('validationLimit');
-		this.min = minMax?.min ?? 0;
-		this.max = minMax?.max ?? Infinity;
-	}
-
-	@state()
-	min = 0;
-
-	@state()
-	max = Infinity;
+	@property({ attribute: false })
+	public config?: UmbPropertyEditorConfigCollection;
 
 	#onChange(event: CustomEvent & { target: UmbInputMemberElement }) {
 		this.value = event.target.value;
@@ -35,11 +23,7 @@ export class UmbPropertyEditorUIMemberPickerElement extends UmbLitElement implem
 
 	render() {
 		return html`
-			<umb-input-member
-				.min=${this.min}
-				.max=${this.max}
-				.value=${this.value ?? ''}
-				@change=${this.#onChange}></umb-input-member>
+			<umb-input-member min="0" max="1" .value=${this.value ?? ''} @change=${this.#onChange}></umb-input-member>
 		`;
 	}
 }

--- a/src/packages/user/user/components/user-input/user-input.element.ts
+++ b/src/packages/user/user/components/user-input/user-input.element.ts
@@ -154,7 +154,7 @@ export class UmbUserInputElement extends UUIFormControlMixin(UmbLitElement, '') 
 	}
 
 	#renderItem(item: UmbUserItemModel) {
-		if (!item.unique) return;
+		if (!item.unique) return nothing;
 		return html`
 			<uui-ref-node-user name=${item.name} id=${item.unique}>
 				<uui-action-bar slot="actions">

--- a/src/packages/user/user/property-editor/user-picker/property-editor-ui-user-picker.element.ts
+++ b/src/packages/user/user/property-editor/user-picker/property-editor-ui-user-picker.element.ts
@@ -17,12 +17,14 @@ export class UmbPropertyEditorUIUserPickerElement extends UmbLitElement implemen
 	public config?: UmbPropertyEditorConfigCollection;
 
 	#onChange(event: CustomEvent & { target: UmbUserInputElement }) {
-		this.value = event.target.selection.join(',');
+		this.value = event.target.value;
 		this.dispatchEvent(new UmbPropertyValueChangeEvent());
 	}
 
 	render() {
-		return html`<umb-user-input max="1" .value=${this.value ?? ''} @change=${this.#onChange}></umb-user-input>`;
+		return html`
+			<umb-user-input min="0" max="1" .value=${this.value ?? ''} @change=${this.#onChange}></umb-user-input>
+		`;
 	}
 }
 


### PR DESCRIPTION
## Description

Corrected the Member Picker property-editor to have a maximum of 1 selectable item, for backwards-compatibility with previous Umbraco versions.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
