### PR TITLE
Bugfix: Remove block circular dependency

### DIFF
--- a/src/packages/block/block/conditions/block-entry-show-content-edit.condition.ts
+++ b/src/packages/block/block/conditions/block-entry-show-content-edit.condition.ts
@@ -1,10 +1,7 @@
 import { UMB_BLOCK_ENTRY_CONTEXT } from '../context/block-entry.context-token.js';
+import type { BlockEntryShowContentEditConditionConfig } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbConditionBase } from '@umbraco-cms/backoffice/extension-registry';
-import type {
-	UmbConditionConfigBase,
-	UmbConditionControllerArguments,
-	UmbExtensionCondition,
-} from '@umbraco-cms/backoffice/extension-api';
+import type { UmbConditionControllerArguments, UmbExtensionCondition } from '@umbraco-cms/backoffice/extension-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
 export class UmbBlockEntryShowContentEditCondition
@@ -30,6 +27,3 @@ export class UmbBlockEntryShowContentEditCondition
 }
 
 export default UmbBlockEntryShowContentEditCondition;
-
-export type BlockEntryShowContentEditConditionConfig =
-	UmbConditionConfigBase<'Umb.Condition.BlockEntryShowContentEdit'>;

--- a/src/packages/block/block/conditions/block-workspace-has-settings.condition.ts
+++ b/src/packages/block/block/conditions/block-workspace-has-settings.condition.ts
@@ -1,10 +1,7 @@
 import { UMB_BLOCK_WORKSPACE_CONTEXT } from '../workspace/block-workspace.context-token.js';
 import { UmbConditionBase } from '@umbraco-cms/backoffice/extension-registry';
-import type {
-	UmbConditionConfigBase,
-	UmbConditionControllerArguments,
-	UmbExtensionCondition,
-} from '@umbraco-cms/backoffice/extension-api';
+import type { BlockWorkspaceHasSettingsConditionConfig } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbConditionControllerArguments, UmbExtensionCondition } from '@umbraco-cms/backoffice/extension-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
 export class UmbBlockWorkspaceHasSettingsCondition
@@ -30,6 +27,3 @@ export class UmbBlockWorkspaceHasSettingsCondition
 }
 
 export default UmbBlockWorkspaceHasSettingsCondition;
-
-export type BlockWorkspaceHasSettingsConditionConfig =
-	UmbConditionConfigBase<'Umb.Condition.BlockWorkspaceHasSettings'>;

--- a/src/packages/block/block/conditions/index.ts
+++ b/src/packages/block/block/conditions/index.ts
@@ -1,2 +1,0 @@
-export type { BlockEntryShowContentEditConditionConfig } from './block-entry-show-content-edit.condition.js';
-export type { BlockWorkspaceHasSettingsConditionConfig } from './block-workspace-has-settings.condition.js';

--- a/src/packages/block/block/index.ts
+++ b/src/packages/block/block/index.ts
@@ -1,4 +1,3 @@
-export * from './conditions/index.js';
 export * from './context/index.js';
 export * from './modals/index.js';
 export * from './types.js';

--- a/src/packages/core/extension-registry/conditions/index.ts
+++ b/src/packages/core/extension-registry/conditions/index.ts
@@ -1,5 +1,4 @@
 export { UmbSwitchCondition } from './switch.condition.js';
 export { UmbConditionBase } from './condition-base.controller.js';
-/*
-export { UmbSectionAliasCondition } from './section-alias.condition.js';
-*/
+
+export type { BlockEntryShowContentEditConditionConfig, BlockWorkspaceHasSettingsConditionConfig } from './types.js';

--- a/src/packages/core/extension-registry/conditions/types.ts
+++ b/src/packages/core/extension-registry/conditions/types.ts
@@ -3,7 +3,6 @@ import type { CollectionBulkActionPermissionConditionConfig } from '../../collec
 import type { UmbSectionUserPermissionConditionConfig } from '../../section/conditions/index.js';
 import type { SectionAliasConditionConfig } from './section-alias.condition.js';
 import type { SwitchConditionConfig } from './switch.condition.js';
-import type { BlockWorkspaceHasSettingsConditionConfig } from '@umbraco-cms/backoffice/block';
 import type {
 	WorkspaceAliasConditionConfig,
 	WorkspaceEntityTypeConditionConfig,
@@ -15,7 +14,16 @@ import type { UmbDocumentUserPermissionConditionConfig } from '@umbraco-cms/back
 Are there any other way we can do this?
 Niels: Sadly I don't see any other solutions currently. But are very open for ideas :-) now that I think about it maybe there is some ability to extend a global type, similar to the 'declare global' trick we use on Elements.
 */
+
+// temp location to avoid circular dependencies
+export type BlockWorkspaceHasSettingsConditionConfig =
+	UmbConditionConfigBase<'Umb.Condition.BlockWorkspaceHasSettings'>;
+
+export type BlockEntryShowContentEditConditionConfig =
+	UmbConditionConfigBase<'Umb.Condition.BlockEntryShowContentEdit'>;
+
 export type ConditionTypes =
+	| BlockEntryShowContentEditConditionConfig
 	| BlockWorkspaceHasSettingsConditionConfig
 	| CollectionAliasConditionConfig
 	| CollectionBulkActionPermissionConditionConfig


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The core package is currently depending on the block package. It uses an import to `@umbraco-cms/backoffice/block` which it cannot. This PR is a temporary solution to solve the block circular dependency.

The PR moves the block condition types from the block package to the extension registry module. It is not the ideal solution but as long as we have the type unions this is the best we can do.

## The result

You will no longer find imports from the core package to the `@umbraco-cms/backoffice/block` module.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

> [!CAUTION]
> Breaking change
> import of `BlockEntryShowContentEditConditionConfig` and `BlockWorkspaceHasSettingsConditionConfig` is moved from `@umbraco-cms/backoffice/block` to `@umbraco-cms/backoffice/extension-registry`;
