### PR TITLE
Bugfix: Remove History Item circular dependency

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -34,7 +34,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - run: npm ci --no-audit --no-fund --prefer-offline
-      - run: npm run lint
+      - run: npm run lint:errors
       - run: npm run build
       - run: npm run generate:jsonschema:dist
       - run: npx playwright install --with-deps

--- a/src/packages/core/components/history/history-item.element.ts
+++ b/src/packages/core/components/history/history-item.element.ts
@@ -1,35 +1,19 @@
-import { UMB_APP_CONTEXT } from '@umbraco-cms/backoffice/app';
-import { css, html, customElement, property, state } from '@umbraco-cms/backoffice/external/lit';
+import { css, html, customElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 
 @customElement('umb-history-item')
 export class UmbHistoryItemElement extends UmbLitElement {
 	@property({ type: String })
-	src?: string;
-
-	@property({ type: String })
 	name?: string;
 
 	@property({ type: String })
 	detail?: string;
 
-	@state()
-	private _serverUrl?: string;
-
-	constructor() {
-		super();
-		this.consumeContext(UMB_APP_CONTEXT, (instance) => {
-			this._serverUrl = instance.getServerUrl();
-		});
-	}
-
 	render() {
 		return html`
 			<div class="user-info">
-				<uui-avatar
-					.name="${this.name ?? 'Unknown'}"
-					.imgSrc="${this.src ? this._serverUrl + this.src : ''}"></uui-avatar>
+				<slot name="avatar"></slot>
 				<div>
 					<span class="name">${this.name}</span>
 					<span class="detail">${this.detail}</span>
@@ -55,10 +39,12 @@ export class UmbHistoryItemElement extends UmbLitElement {
 				--uui-button-height: calc(var(--uui-size-2) * 4);
 				margin-right: var(--uui-size-2);
 			}
+
 			#actions-container {
 				opacity: 0;
 				transition: opacity 120ms;
 			}
+
 			:host(:hover) #actions-container {
 				opacity: 1;
 			}

--- a/src/packages/documents/documents/workspace/views/info/document-workspace-view-info-history.element.ts
+++ b/src/packages/documents/documents/workspace/views/info/document-workspace-view-info-history.element.ts
@@ -129,10 +129,8 @@ export class UmbDocumentWorkspaceViewInfoHistoryElement extends UmbLitElement {
 							const { text, style } = HistoryTagStyleAndText(item.logType);
 							return html`<umb-history-item
 								.name=${item.userName ?? 'Unknown'}
-								src=${ifDefined(
-									Array.isArray(item.userAvatars) ? item.userAvatars[item.userAvatars.length - 1] : undefined,
-								)}
 								detail=${this.localize.date(item.timestamp, TimeOptions)}>
+								<uui-avatar slot="avatar" .name="${item.userName ?? 'Unknown'}"></uui-avatar>
 								<span class="log-type">
 									<uui-tag look=${style.look} color=${style.color}> ${this.localize.term(text.label)} </uui-tag>
 									${this.localize.term(text.desc, item.parameters)}

--- a/src/packages/media/media/workspace/views/info/media-workspace-view-info-history.element.ts
+++ b/src/packages/media/media/workspace/views/info/media-workspace-view-info-history.element.ts
@@ -106,10 +106,8 @@ export class UmbMediaWorkspaceViewInfoHistoryElement extends UmbLitElement {
 							const { text, style } = HistoryTagStyleAndText(item.logType);
 							return html`<umb-history-item
 								.name=${item.userName ?? 'Unknown'}
-								src=${ifDefined(
-									Array.isArray(item.userAvatars) ? item.userAvatars[item.userAvatars.length - 1] : undefined,
-								)}
 								detail=${this.localize.date(item.timestamp, TimeOptions)}>
+								<uui-avatar slot="avatar" .name="${item.userName ?? 'Unknown'}"></uui-avatar>
 								<span class="log-type">
 									<uui-tag look=${style.look} color=${style.color}> ${this.localize.term(text.label)} </uui-tag>
 									${this.localize.term(text.desc, item.parameters)}

--- a/src/packages/media/media/workspace/views/info/media-workspace-view-info-history.element.ts
+++ b/src/packages/media/media/workspace/views/info/media-workspace-view-info-history.element.ts
@@ -15,6 +15,7 @@ import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import type { AuditLogWithUsernameResponseModel } from '@umbraco-cms/backoffice/external/backend-api';
 import { DirectionModel } from '@umbraco-cms/backoffice/external/backend-api';
+import { UMB_APP_CONTEXT } from '@umbraco-cms/backoffice/app';
 
 @customElement('umb-media-workspace-view-info-history')
 export class UmbMediaWorkspaceViewInfoHistoryElement extends UmbLitElement {
@@ -33,9 +34,16 @@ export class UmbMediaWorkspaceViewInfoHistoryElement extends UmbLitElement {
 	@state()
 	private _currentPage = 1;
 
+	@state()
+	private _serverUrl = '';
+
 	constructor() {
 		super();
 		this.#logRepository = new UmbAuditLogRepository(this);
+
+		this.consumeContext(UMB_APP_CONTEXT, (instance) => {
+			this._serverUrl = instance.getServerUrl();
+		});
 	}
 
 	protected firstUpdated(): void {
@@ -104,10 +112,16 @@ export class UmbMediaWorkspaceViewInfoHistoryElement extends UmbLitElement {
 						(item) => item.timestamp,
 						(item) => {
 							const { text, style } = HistoryTagStyleAndText(item.logType);
+							const avatar = Array.isArray(item.userAvatars) ? item.userAvatars[1] : undefined;
+							// TODO: we need to get the absolute url for the avatars from the server
+							const avatarUrl = avatar ? `${this._serverUrl}${avatar}` : undefined;
 							return html`<umb-history-item
 								.name=${item.userName ?? 'Unknown'}
 								detail=${this.localize.date(item.timestamp, TimeOptions)}>
-								<uui-avatar slot="avatar" .name="${item.userName ?? 'Unknown'}"></uui-avatar>
+								<uui-avatar
+									slot="avatar"
+									.name="${item.userName ?? 'Unknown'}"
+									img-src=${ifDefined(avatarUrl)}></uui-avatar>
 								<span class="log-type">
 									<uui-tag look=${style.look} color=${style.color}> ${this.localize.term(text.label)} </uui-tag>
 									${this.localize.term(text.desc, item.parameters)}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The History Item component depends on the `APP_CONTEXT` to render the avatar. I have changed the component to slot in the avatar element instead. This is closer to how other generic components work. This also moves the `APP_CONTEXT` responsibility to the implementing part.

On a side note. We shouldn't rely on the `serverUrl` to create the full avatar URL. This can change on the server. I have asked for a change in the Management API to include the absolute URL as we have in other places that expose the avatar URLs.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

> [!CAUTION]
> Breaking Change
> It is no longer possible to pass a `src` prop to the `umb-history-item` element to render an avatar. Use the avatar slot instead.
