### PR TITLE
Adds title attribute to icons in icon picker modal - to help identify…

### DIFF
--- a/src/packages/core/modal/common/icon-picker/icon-picker-modal.element.ts
+++ b/src/packages/core/modal/common/icon-picker/icon-picker-modal.element.ts
@@ -140,6 +140,7 @@ export class UmbIconPickerModalElement extends UmbModalBaseElement<UmbIconPicker
 					(icon) => html`
 						<uui-button
 							label="${icon.name}"
+							title="${icon.name}"
 							class="${icon.name === this._currentIcon ? 'selected' : ''}"
 							@click="${this.#changeIcon}"
 							@keyup="${this.#changeIcon}">


### PR DESCRIPTION
## Description
Adds title attribute to icons in icon picker modal - to help identify what icon label is for use for package devs

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This is useful for package devs, who need to know the full name of an icon in order to consume/use it in packages

## How to test?
* See animated gif below
* Open icon picker modal
* Hover over an icon and the title will display the icon name


## Screenshots (if appropriate)
When hovering over icons its now possible to see the name of the icon (See GIF)
![Icon Picker names](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/1389894/e46a1963-62f3-48d3-8f17-36fbae7fecb4)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
