### PR TITLE
Chore: Sort top level menu items

### DIFF
--- a/src/packages/core/settings/manifests.ts
+++ b/src/packages/core/settings/manifests.ts
@@ -8,7 +8,7 @@ export const manifests: Array<ManifestTypes> = [
 		type: 'section',
 		alias: UMB_SETTINGS_SECTION_ALIAS,
 		name: 'Settings Section',
-		weight: 400,
+		weight: 800,
 		meta: {
 			label: '#sections_settings',
 			pathname: 'settings',

--- a/src/packages/dictionary/section/manifests.ts
+++ b/src/packages/dictionary/section/manifests.ts
@@ -12,7 +12,7 @@ const section: ManifestSection = {
 	type: 'section',
 	alias: UMB_DICTIONARY_SECTION_ALIAS,
 	name: 'Dictionary Section',
-	weight: 100,
+	weight: 400,
 	meta: {
 		label: '#sections_translation',
 		pathname: 'dictionary',

--- a/src/packages/documents/section.manifests.ts
+++ b/src/packages/documents/section.manifests.ts
@@ -11,7 +11,7 @@ const section: ManifestSection = {
 	type: 'section',
 	alias: sectionAlias,
 	name: 'Content Section',
-	weight: 600,
+	weight: 1000,
 	meta: {
 		label: '#sections_content',
 		pathname: 'content',

--- a/src/packages/media/section.manifests.ts
+++ b/src/packages/media/section.manifests.ts
@@ -11,7 +11,7 @@ const section: ManifestSection = {
 	type: 'section',
 	alias: sectionAlias,
 	name: 'Media Section',
-	weight: 500,
+	weight: 900,
 	meta: {
 		label: '#sections_media',
 		pathname: 'media',

--- a/src/packages/members/member-section/manifests.ts
+++ b/src/packages/members/member-section/manifests.ts
@@ -4,7 +4,7 @@ const section: ManifestSection = {
 	type: 'section',
 	alias: 'Umb.Section.Members',
 	name: 'Members Section',
-	weight: 300,
+	weight: 500,
 	meta: {
 		label: '#sections_member',
 		pathname: 'member-management',

--- a/src/packages/members/member/section-view/manifests.ts
+++ b/src/packages/members/member/section-view/manifests.ts
@@ -8,7 +8,7 @@ const sectionsViews: Array<ManifestSectionView> = [
 		js: () => import('./member-section-view.element.js'),
 		weight: 200,
 		meta: {
-			label: 'Members',
+			label: '#sections_member',
 			pathname: 'members',
 			icon: 'icon-user',
 		},

--- a/src/packages/members/member/section-view/manifests.ts
+++ b/src/packages/members/member/section-view/manifests.ts
@@ -6,7 +6,7 @@ const sectionsViews: Array<ManifestSectionView> = [
 		alias: 'Umb.SectionView.Member',
 		name: 'Member Section View',
 		js: () => import('./member-section-view.element.js'),
-		weight: 200,
+		weight: 500,
 		meta: {
 			label: '#sections_member',
 			pathname: 'members',

--- a/src/packages/members/member/section-view/manifests.ts
+++ b/src/packages/members/member/section-view/manifests.ts
@@ -6,9 +6,9 @@ const sectionsViews: Array<ManifestSectionView> = [
 		alias: 'Umb.SectionView.Member',
 		name: 'Member Section View',
 		js: () => import('./member-section-view.element.js'),
-		weight: 500,
+		weight: 200,
 		meta: {
-			label: '#sections_member',
+			label: 'Members',
 			pathname: 'members',
 			icon: 'icon-user',
 		},

--- a/src/packages/packages/package-section/manifests.ts
+++ b/src/packages/packages/package-section/manifests.ts
@@ -6,7 +6,7 @@ const section: ManifestSection = {
 	type: 'section',
 	alias: sectionAlias,
 	name: 'Packages Section',
-	weight: 200,
+	weight: 700,
 	meta: {
 		label: '#sections_packages',
 		pathname: 'packages',

--- a/src/packages/user/user-section/manifests.ts
+++ b/src/packages/user/user-section/manifests.ts
@@ -6,7 +6,7 @@ const section: ManifestSection = {
 	type: 'section',
 	alias: UMB_USER_MANAGEMENT_SECTION_ALIAS,
 	name: 'User Management Section',
-	weight: 100,
+	weight: 600,
 	meta: {
 		label: '#sections_users',
 		pathname: 'user-management',


### PR DESCRIPTION
## Description

This sets the weight on the sections according to Umbraco 13.

**Before**
![Screenshot 2024-04-29 at 11 14 28](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/752371/d697948e-a8e0-40a6-9f21-10c14a28e6ee)

**After**
![Screenshot 2024-04-29 at 11 14 02](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/752371/f0a19636-c173-422d-b0ed-2d1e234ca750)
