### PR TITLE
Bugfix: Collection View Table fixes

### DIFF
--- a/src/mocks/data/data-type/data-type.data.ts
+++ b/src/mocks/data/data-type/data-type.data.ts
@@ -804,7 +804,7 @@ export const data: Array<UmbMockDataTypeModel> = [
 				value: [
 					{ alias: 'sortOrder', header: 'Sort order', isSystem: true, nameTemplate: '' },
 					{ alias: 'updateDate', header: 'Last edited', isSystem: true },
-					{ alias: 'owner', header: 'Created by', isSystem: true },
+					{ alias: 'creator', header: 'Created by', isSystem: true },
 				],
 			},
 			{ alias: 'orderBy', value: 'updateDate' },
@@ -849,7 +849,7 @@ export const data: Array<UmbMockDataTypeModel> = [
 				value: [
 					{ alias: 'sortOrder', header: 'Sort order', isSystem: true, nameTemplate: '' },
 					{ alias: 'updateDate', header: 'Last edited', isSystem: true },
-					{ alias: 'owner', header: 'Created by', isSystem: true },
+					{ alias: 'creator', header: 'Created by', isSystem: true },
 				],
 			},
 			{ alias: 'orderBy', value: 'updateDate' },

--- a/src/packages/documents/documents/collection/repository/document-collection.server.data-source.ts
+++ b/src/packages/documents/documents/collection/repository/document-collection.server.data-source.ts
@@ -24,8 +24,8 @@ export class UmbDocumentCollectionServerDataSource implements UmbCollectionDataS
 			orderCulture: query.orderCulture ?? 'en-US',
 			orderDirection: query.orderDirection === 'asc' ? DirectionModel.ASCENDING : DirectionModel.DESCENDING,
 			filter: query.filter,
-			skip: query.skip ?? 0,
-			take: query.take ?? 100,
+			skip: query.skip || 0,
+			take: query.take || 100,
 		};
 
 		const { data, error } = await tryExecuteAndNotify(this.#host, DocumentService.getCollectionDocumentById(params));

--- a/src/packages/documents/documents/collection/repository/document-collection.server.data-source.ts
+++ b/src/packages/documents/documents/collection/repository/document-collection.server.data-source.ts
@@ -43,6 +43,7 @@ export class UmbDocumentCollectionServerDataSource implements UmbCollectionDataS
 					creator: item.creator,
 					icon: item.documentType.icon,
 					name: variant.name,
+					sortOrder: item.sortOrder,
 					state: variant.state,
 					updateDate: new Date(variant.updateDate),
 					updater: item.updater,

--- a/src/packages/documents/documents/collection/types.ts
+++ b/src/packages/documents/documents/collection/types.ts
@@ -17,6 +17,7 @@ export interface UmbDocumentCollectionItemModel {
 	creator?: string | null;
 	icon: string;
 	name: string;
+	sortOrder: number;
 	state: string;
 	updateDate: Date;
 	updater?: string | null;

--- a/src/packages/documents/documents/collection/views/grid/document-grid-collection-view.element.ts
+++ b/src/packages/documents/documents/collection/views/grid/document-grid-collection-view.element.ts
@@ -96,14 +96,13 @@ export class UmbDocumentGridCollectionViewElement extends UmbLitElement {
 				${repeat(
 					this._items,
 					(item) => item.unique,
-					(item, index) => this.#renderCard(index, item),
+					(item) => this.#renderCard(item),
 				)}
 			</div>
 		`;
 	}
 
-	#renderCard(index: number, item: UmbDocumentCollectionItemModel) {
-		const sortOrder = this._skip + index;
+	#renderCard(item: UmbDocumentCollectionItemModel) {
 		return html`
 			<uui-card-content-node
 				.name=${item.name ?? 'Unnamed Document'}
@@ -114,7 +113,7 @@ export class UmbDocumentGridCollectionViewElement extends UmbLitElement {
 				@selected=${() => this.#onSelect(item)}
 				@deselected=${() => this.#onDeselect(item)}>
 				<umb-icon slot="icon" name=${item.icon}></umb-icon>
-				${this.#renderState(item)} ${this.#renderProperties(sortOrder, item)}
+				${this.#renderState(item)} ${this.#renderProperties(item)}
 			</uui-card-content-node>
 		`;
 	}
@@ -142,15 +141,14 @@ export class UmbDocumentGridCollectionViewElement extends UmbLitElement {
 		}
 	}
 
-	#renderProperties(sortOrder: number, item: UmbDocumentCollectionItemModel) {
+	#renderProperties(item: UmbDocumentCollectionItemModel) {
 		if (!this._userDefinedProperties) return;
 		return html`
 			<ul>
 				${repeat(
 					this._userDefinedProperties,
 					(column) => column.alias,
-					(column) =>
-						html`<li><span>${column.header}:</span> ${getPropertyValueByAlias(sortOrder, item, column.alias)}</li>`,
+					(column) => html`<li><span>${column.header}:</span> ${getPropertyValueByAlias(item, column.alias)}</li>`,
 				)}
 			</ul>
 		`;

--- a/src/packages/documents/documents/collection/views/index.ts
+++ b/src/packages/documents/documents/collection/views/index.ts
@@ -9,13 +9,12 @@ export function getPropertyValueByAlias(sortOrder: number, item: UmbDocumentColl
 		case 'createDate':
 			return item.createDate.toLocaleString();
 		case 'creator':
+		case 'owner':
 			return item.creator;
 		case 'entityName':
 			return item.name;
 		case 'entityState':
 			return item.state.replace(/([A-Z])/g, ' $1');
-		case 'owner':
-			return item.creator;
 		case 'published':
 			return item.state !== 'Draft' ? 'True' : 'False';
 		case 'sortOrder':

--- a/src/packages/documents/documents/collection/views/index.ts
+++ b/src/packages/documents/documents/collection/views/index.ts
@@ -1,4 +1,5 @@
 import type { UmbDocumentCollectionItemModel } from '../types.js';
+import { fromCamelCase } from '@umbraco-cms/backoffice/utils';
 
 export { UMB_DOCUMENT_GRID_COLLECTION_VIEW_ALIAS, UMB_DOCUMENT_TABLE_COLLECTION_VIEW_ALIAS } from './manifests.js';
 
@@ -13,8 +14,8 @@ export function getPropertyValueByAlias(sortOrder: number, item: UmbDocumentColl
 			return item.creator;
 		case 'name':
 			return item.name;
-		case 'entityState':
-			return item.state.replace(/([A-Z])/g, ' $1');
+		case 'state':
+			return fromCamelCase(item.state);
 		case 'published':
 			return item.state !== 'Draft' ? 'True' : 'False';
 		case 'sortOrder':

--- a/src/packages/documents/documents/collection/views/index.ts
+++ b/src/packages/documents/documents/collection/views/index.ts
@@ -11,7 +11,7 @@ export function getPropertyValueByAlias(sortOrder: number, item: UmbDocumentColl
 		case 'creator':
 		case 'owner':
 			return item.creator;
-		case 'entityName':
+		case 'name':
 			return item.name;
 		case 'entityState':
 			return item.state.replace(/([A-Z])/g, ' $1');

--- a/src/packages/documents/documents/collection/views/index.ts
+++ b/src/packages/documents/documents/collection/views/index.ts
@@ -3,7 +3,7 @@ import { fromCamelCase } from '@umbraco-cms/backoffice/utils';
 
 export { UMB_DOCUMENT_GRID_COLLECTION_VIEW_ALIAS, UMB_DOCUMENT_TABLE_COLLECTION_VIEW_ALIAS } from './manifests.js';
 
-export function getPropertyValueByAlias(sortOrder: number, item: UmbDocumentCollectionItemModel, alias: string) {
+export function getPropertyValueByAlias(item: UmbDocumentCollectionItemModel, alias: string) {
 	switch (alias) {
 		case 'contentTypeAlias':
 			return item.contentTypeAlias;
@@ -19,7 +19,7 @@ export function getPropertyValueByAlias(sortOrder: number, item: UmbDocumentColl
 		case 'published':
 			return item.state !== 'Draft' ? 'True' : 'False';
 		case 'sortOrder':
-			return sortOrder;
+			return item.sortOrder;
 		case 'updateDate':
 			return item.updateDate.toLocaleString();
 		case 'updater':

--- a/src/packages/documents/documents/collection/views/table/column-layouts/document-table-column-name.element.ts
+++ b/src/packages/documents/documents/collection/views/table/column-layouts/document-table-column-name.element.ts
@@ -1,7 +1,7 @@
 import type { UmbDocumentCollectionItemModel } from '../../../types.js';
 import { css, customElement, html, property, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import { UMB_WORKSPACE_MODAL, UmbModalRouteRegistrationController } from '@umbraco-cms/backoffice/modal';
+//import { UMB_WORKSPACE_MODAL, UmbModalRouteRegistrationController } from '@umbraco-cms/backoffice/modal';
 import type { UmbTableColumn, UmbTableColumnLayoutElement, UmbTableItem } from '@umbraco-cms/backoffice/components';
 
 @customElement('umb-document-table-column-name')
@@ -21,30 +21,33 @@ export class UmbDocumentTableColumnNameElement extends UmbLitElement implements 
 	constructor() {
 		super();
 
-		new UmbModalRouteRegistrationController(this, UMB_WORKSPACE_MODAL)
-			.addAdditionalPath('document')
-			.onSetup(() => {
-				return { data: { entityType: 'document', preset: {} } };
-			})
-			.observeRouteBuilder((routeBuilder) => {
-				this._editDocumentPath = routeBuilder({});
-			});
+		// new UmbModalRouteRegistrationController(this, UMB_WORKSPACE_MODAL)
+		// 	.addAdditionalPath('document')
+		// 	.onSetup(() => {
+		// 		return { data: { entityType: 'document', preset: {} } };
+		// 	})
+		// 	.observeRouteBuilder((routeBuilder) => {
+		// 		this._editDocumentPath = routeBuilder({});
+		// 	});
+
+		this._editDocumentPath = '/section/content/workspace/document/';
 	}
 
-	#onClick(event: Event) {
-		// TODO: [LK] Review the `stopPropagation` usage, as it causes a page reload.
-		// But we still need a say to prevent the `umb-table` from triggering a selection event.
-		event.stopPropagation();
-	}
+	// #onClick(event: Event) {
+	// 	// TODO: [LK] Review the `stopPropagation` usage, as it causes a page reload.
+	// 	// But we still need a say to prevent the `umb-table` from triggering a selection event.
+	// 	event.stopPropagation();
+	// }
 
 	render() {
-		return html`<uui-button
-			look="default"
-			color="default"
-			compact
-			href="${this._editDocumentPath}edit/${this.value.unique}"
-			label="${this.value.name}"
-			@click=${this.#onClick}></uui-button>`;
+		return html`
+			<uui-button
+				compact
+				color="default"
+				look="default"
+				href="${this._editDocumentPath}edit/${this.value.unique}"
+				label=${this.value.name}></uui-button>
+		`;
 	}
 
 	static styles = [

--- a/src/packages/documents/documents/collection/views/table/column-layouts/document-table-column-name.element.ts
+++ b/src/packages/documents/documents/collection/views/table/column-layouts/document-table-column-name.element.ts
@@ -1,8 +1,9 @@
 import type { UmbDocumentCollectionItemModel } from '../../../types.js';
 import { css, customElement, html, property, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-//import { UMB_WORKSPACE_MODAL, UmbModalRouteRegistrationController } from '@umbraco-cms/backoffice/modal';
+import { UMB_WORKSPACE_MODAL, UmbModalRouteRegistrationController } from '@umbraco-cms/backoffice/modal';
 import type { UmbTableColumn, UmbTableColumnLayoutElement, UmbTableItem } from '@umbraco-cms/backoffice/components';
+import type { UUIButtonElement } from '@umbraco-cms/backoffice/external/uui';
 
 @customElement('umb-document-table-column-name')
 export class UmbDocumentTableColumnNameElement extends UmbLitElement implements UmbTableColumnLayoutElement {
@@ -21,32 +22,29 @@ export class UmbDocumentTableColumnNameElement extends UmbLitElement implements 
 	constructor() {
 		super();
 
-		// new UmbModalRouteRegistrationController(this, UMB_WORKSPACE_MODAL)
-		// 	.addAdditionalPath('document')
-		// 	.onSetup(() => {
-		// 		return { data: { entityType: 'document', preset: {} } };
-		// 	})
-		// 	.observeRouteBuilder((routeBuilder) => {
-		// 		this._editDocumentPath = routeBuilder({});
-		// 	});
-
-		this._editDocumentPath = '/section/content/workspace/document/';
+		new UmbModalRouteRegistrationController(this, UMB_WORKSPACE_MODAL)
+			.addAdditionalPath('document')
+			.onSetup(() => {
+				return { data: { entityType: 'document', preset: {} } };
+			})
+			.observeRouteBuilder((routeBuilder) => {
+				this._editDocumentPath = routeBuilder({});
+			});
 	}
 
-	// #onClick(event: Event) {
-	// 	// TODO: [LK] Review the `stopPropagation` usage, as it causes a page reload.
-	// 	// But we still need a say to prevent the `umb-table` from triggering a selection event.
-	// 	event.stopPropagation();
-	// }
+	#onClick(event: Event & { target: UUIButtonElement }) {
+		event.preventDefault();
+		event.stopPropagation();
+		window.history.pushState({}, '', event.target.href);
+	}
 
 	render() {
 		return html`
 			<uui-button
 				compact
-				color="default"
-				look="default"
 				href="${this._editDocumentPath}edit/${this.value.unique}"
-				label=${this.value.name}></uui-button>
+				label=${this.value.name}
+				@click=${this.#onClick}></uui-button>
 		`;
 	}
 

--- a/src/packages/documents/documents/collection/views/table/document-table-collection-view.element.ts
+++ b/src/packages/documents/documents/collection/views/table/document-table-collection-view.element.ts
@@ -47,9 +47,9 @@ export class UmbDocumentTableCollectionViewElement extends UmbLitElement {
 		},
 		{
 			name: this.localize.term('content_publishStatus'),
-			alias: 'entityState',
+			alias: 'state',
 			elementName: 'umb-document-table-column-state',
-			allowSorting: true,
+			allowSorting: false,
 		},
 	];
 

--- a/src/packages/documents/documents/collection/views/table/document-table-collection-view.element.ts
+++ b/src/packages/documents/documents/collection/views/table/document-table-collection-view.element.ts
@@ -126,16 +126,14 @@ export class UmbDocumentTableCollectionViewElement extends UmbLitElement {
 	}
 
 	#createTableItems(items: Array<UmbDocumentCollectionItemModel>) {
-		this._tableItems = items.map((item, rowIndex) => {
+		this._tableItems = items.map((item) => {
 			if (!item.unique) throw new Error('Item id is missing.');
-
-			const sortOrder = this._skip + rowIndex;
 
 			const data =
 				this._tableColumns?.map((column) => {
 					return {
 						columnAlias: column.alias,
-						value: column.elementName ? item : getPropertyValueByAlias(sortOrder, item, column.alias),
+						value: column.elementName ? item : getPropertyValueByAlias(item, column.alias),
 					};
 				}) ?? [];
 

--- a/src/packages/documents/documents/collection/views/table/document-table-collection-view.element.ts
+++ b/src/packages/documents/documents/collection/views/table/document-table-collection-view.element.ts
@@ -41,7 +41,7 @@ export class UmbDocumentTableCollectionViewElement extends UmbLitElement {
 	#systemColumns: Array<UmbTableColumn> = [
 		{
 			name: this.localize.term('general_name'),
-			alias: 'entityName',
+			alias: 'name',
 			elementName: 'umb-document-table-column-name',
 			allowSorting: true,
 		},

--- a/src/packages/media/media/collection/repository/media-collection.server.data-source.ts
+++ b/src/packages/media/media/collection/repository/media-collection.server.data-source.ts
@@ -36,6 +36,7 @@ export class UmbMediaCollectionServerDataSource implements UmbCollectionDataSour
 					creator: item.creator,
 					icon: item.mediaType.icon,
 					name: variant.name,
+					sortOrder: item.sortOrder,
 					updateDate: new Date(variant.updateDate),
 					values: item.values.map((item) => {
 						return { alias: item.alias, value: item.value as string };

--- a/src/packages/media/media/collection/types.ts
+++ b/src/packages/media/media/collection/types.ts
@@ -14,6 +14,7 @@ export interface UmbMediaCollectionItemModel {
 	creator?: string | null;
 	icon: string;
 	name: string;
+	sortOrder: number;
 	updateDate: Date;
 	values: Array<{ alias: string; value: string }>;
 }

--- a/src/packages/media/media/collection/views/table/media-table-collection-view.element.ts
+++ b/src/packages/media/media/collection/views/table/media-table-collection-view.element.ts
@@ -39,7 +39,7 @@ export class UmbMediaTableCollectionViewElement extends UmbLitElement {
 	#systemColumns: Array<UmbTableColumn> = [
 		{
 			name: this.localize.term('general_name'),
-			alias: 'entityName',
+			alias: 'name',
 			elementName: 'umb-media-table-column-name',
 			allowSorting: true,
 		},
@@ -149,7 +149,7 @@ export class UmbMediaTableCollectionViewElement extends UmbLitElement {
 		switch (alias) {
 			case 'createDate':
 				return item.createDate.toLocaleString();
-			case 'entityName':
+			case 'name':
 				return item.name;
 			case 'creator':
 			case 'owner':

--- a/src/packages/media/media/collection/views/table/media-table-collection-view.element.ts
+++ b/src/packages/media/media/collection/views/table/media-table-collection-view.element.ts
@@ -124,16 +124,14 @@ export class UmbMediaTableCollectionViewElement extends UmbLitElement {
 			this.#createTableHeadings();
 		}
 
-		this._tableItems = items.map((item, rowIndex) => {
+		this._tableItems = items.map((item) => {
 			if (!item.unique) throw new Error('Item id is missing.');
-
-			const sortOrder = this._skip + rowIndex;
 
 			const data =
 				this._tableColumns?.map((column) => {
 					return {
 						columnAlias: column.alias,
-						value: column.elementName ? item : this.#getPropertyValueByAlias(sortOrder, item, column.alias),
+						value: column.elementName ? item : this.#getPropertyValueByAlias(item, column.alias),
 					};
 				}) ?? [];
 
@@ -145,7 +143,7 @@ export class UmbMediaTableCollectionViewElement extends UmbLitElement {
 		});
 	}
 
-	#getPropertyValueByAlias(sortOrder: number, item: UmbMediaCollectionItemModel, alias: string) {
+	#getPropertyValueByAlias(item: UmbMediaCollectionItemModel, alias: string) {
 		switch (alias) {
 			case 'createDate':
 				return item.createDate.toLocaleString();
@@ -155,7 +153,7 @@ export class UmbMediaTableCollectionViewElement extends UmbLitElement {
 			case 'owner':
 				return item.creator;
 			case 'sortOrder':
-				return sortOrder;
+				return item.sortOrder;
 			case 'updateDate':
 				return item.updateDate.toLocaleString();
 			default:

--- a/src/packages/media/media/collection/views/table/media-table-collection-view.element.ts
+++ b/src/packages/media/media/collection/views/table/media-table-collection-view.element.ts
@@ -151,6 +151,7 @@ export class UmbMediaTableCollectionViewElement extends UmbLitElement {
 				return item.createDate.toLocaleString();
 			case 'entityName':
 				return item.name;
+			case 'creator':
 			case 'owner':
 				return item.creator;
 			case 'sortOrder':

--- a/src/packages/property-editors/collection/config/column/components/input-collection-content-type-property.element.ts
+++ b/src/packages/property-editors/collection/config/column/components/input-collection-content-type-property.element.ts
@@ -57,7 +57,12 @@ export class UmbInputCollectionContentTypePropertyElement extends UUIFormControl
 					value: 'createDate',
 					icon: 'icon-settings',
 				},
-				{ label: this.localize.term('content_createBy'), description: 'owner', value: 'owner', icon: 'icon-settings' },
+				{
+					label: this.localize.term('content_createBy'),
+					description: 'creator',
+					value: 'creator',
+					icon: 'icon-settings',
+				},
 				{
 					label: this.localize.term('content_isPublished'),
 					description: 'published',
@@ -124,7 +129,12 @@ export class UmbInputCollectionContentTypePropertyElement extends UUIFormControl
 					value: 'createDate',
 					icon: 'icon-settings',
 				},
-				{ label: this.localize.term('content_createBy'), description: 'owner', value: 'owner', icon: 'icon-settings' },
+				{
+					label: this.localize.term('content_createBy'),
+					description: 'creator',
+					value: 'creator',
+					icon: 'icon-settings',
+				},
 				{
 					label: this.localize.term('general_sort'),
 					description: 'sortOrder',

--- a/src/packages/property-editors/collection/manifests.ts
+++ b/src/packages/property-editors/collection/manifests.ts
@@ -89,7 +89,7 @@ const propertyEditorUiManifest: ManifestPropertyEditorUi = {
 					],
 				},
 				{ alias: 'pageSize', value: 10 },
-				{ alias: 'orderBy', value: 'updateDate' },
+				{ alias: 'orderBy', value: 'sortOrder' },
 				{ alias: 'orderDirection', value: 'desc' },
 				{
 					alias: 'bulkActionPermissions',

--- a/src/packages/templating/modals/templating-page-field-builder/components/template-field-dropdown-list/template-field-dropdown-list.element.ts
+++ b/src/packages/templating/modals/templating-page-field-builder/components/template-field-dropdown-list/template-field-dropdown-list.element.ts
@@ -69,7 +69,7 @@ export class UmbTemplateFieldDropdownListElement extends UmbLitElement {
 		{ alias: 'updateDate', name: this.localize.term('content_updateDate') },
 		{ alias: 'updater', name: this.localize.term('content_updatedBy') },
 		{ alias: 'createDate', name: this.localize.term('content_createDate') },
-		{ alias: 'owner', name: this.localize.term('content_createBy') },
+		{ alias: 'creator', name: this.localize.term('content_createBy') },
 		{ alias: 'published', name: this.localize.term('content_isPublished') },
 		{ alias: 'contentTypeAlias', name: this.localize.term('content_documentType') },
 	];


### PR DESCRIPTION
## Description

Fixes for various bugs that @elit0451 has spotted during her testing.

- Replaces `"owner"` with `"creator"` (for consistency with Management API)
- Replaces `"entityName"` with `"name"` (for consistency with Management API)
- Replaces `"entityState"` with `"state"` (for consistency with Management API)
- Disables sorting of `"state"` column, (as current List View Table did not support this)
- Implemented `"sortOrder"` property, (this may have not been available when the Collection View Table was initially developed, so it was faked).

Updated PR with fixes for bugs raised by @Zeegaan and @bergmania.

- Fixes server error when `pageSize` is `NaN`
- Fixes the item's name button to open the document editor modal

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
