### PR TITLE
fix data-type- property-editor-ui-picker

### DIFF
--- a/src/packages/data-type/modals/property-editor-ui-picker/property-editor-ui-picker-modal.element.ts
+++ b/src/packages/data-type/modals/property-editor-ui-picker/property-editor-ui-picker-modal.element.ts
@@ -30,14 +30,13 @@ export class UmbPropertyEditorUIPickerModalElement extends UmbModalBaseElement<
 	connectedCallback(): void {
 		super.connectedCallback();
 
-		this._submitLabel = this.data?.submitLabel ?? this._submitLabel;
+		// TODO: We never parse on a submit label, so this seem weird as we don't enable this of other places.
+		//this._submitLabel = this.data?.submitLabel ?? this._submitLabel;
 
 		this.#usePropertyEditorUIs();
 	}
 
 	#usePropertyEditorUIs() {
-		if (!this.data) return;
-
 		this.observe(umbExtensionsRegistry.byType('propertyEditorUi'), (propertyEditorUIs) => {
 			// Only include Property Editor UIs which has Property Editor Schema Alias
 			this._propertyEditorUIs = propertyEditorUIs.filter(


### PR DESCRIPTION
Fix property editor ui picker, so there is something to select in the modal.

test via create new Data type in the Data Type tree. :-)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
