### PR TITLE
Chore: Renames `UMB_DEFAULT_COLLECTION_CONTEXT` to `UMB_COLLECTION_CONTEXT`

### DIFF
--- a/src/packages/core/collection/collection-alias.condition.ts
+++ b/src/packages/core/collection/collection-alias.condition.ts
@@ -1,4 +1,4 @@
-import { UMB_DEFAULT_COLLECTION_CONTEXT } from './default/collection-default.context.js';
+import { UMB_COLLECTION_CONTEXT } from './default/collection-default.context.js';
 import type { CollectionAliasConditionConfig } from './collection-alias.manifest.js';
 import type { UmbConditionControllerArguments, UmbExtensionCondition } from '@umbraco-cms/backoffice/extension-api';
 import { UmbConditionBase } from '@umbraco-cms/backoffice/extension-registry';
@@ -10,7 +10,7 @@ export class UmbCollectionAliasCondition
 {
 	constructor(host: UmbControllerHost, args: UmbConditionControllerArguments<CollectionAliasConditionConfig>) {
 		super(host, args);
-		this.consumeContext(UMB_DEFAULT_COLLECTION_CONTEXT, (context) => {
+		this.consumeContext(UMB_COLLECTION_CONTEXT, (context) => {
 			this.permitted = context.getManifest()?.alias === this.config.match;
 		});
 	}

--- a/src/packages/core/collection/collection-bulk-action-permission.condition.ts
+++ b/src/packages/core/collection/collection-bulk-action-permission.condition.ts
@@ -1,4 +1,4 @@
-import { UMB_DEFAULT_COLLECTION_CONTEXT } from './default/collection-default.context.js';
+import { UMB_COLLECTION_CONTEXT } from './default/collection-default.context.js';
 import type { CollectionBulkActionPermissionConditionConfig } from './collection-bulk-action-permission.manifest.js';
 import type { UmbConditionControllerArguments, UmbExtensionCondition } from '@umbraco-cms/backoffice/extension-api';
 import { UmbConditionBase } from '@umbraco-cms/backoffice/extension-registry';
@@ -14,7 +14,7 @@ export class UmbCollectionBulkActionPermissionCondition
 	) {
 		super(host, args);
 
-		this.consumeContext(UMB_DEFAULT_COLLECTION_CONTEXT, (context) => {
+		this.consumeContext(UMB_COLLECTION_CONTEXT, (context) => {
 			const allowedActions = context.getConfig()?.allowedEntityBulkActions;
 			this.permitted = allowedActions ? this.config.match(allowedActions) : false;
 		});

--- a/src/packages/core/collection/components/collection-action-bundle.element.ts
+++ b/src/packages/core/collection/components/collection-action-bundle.element.ts
@@ -1,5 +1,5 @@
 import type { UmbDefaultCollectionContext } from '../default/collection-default.context.js';
-import { UMB_DEFAULT_COLLECTION_CONTEXT } from '../default/collection-default.context.js';
+import { UMB_COLLECTION_CONTEXT } from '../default/collection-default.context.js';
 import { html, customElement, state, nothing } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 
@@ -13,7 +13,7 @@ export class UmbCollectionActionBundleElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_DEFAULT_COLLECTION_CONTEXT, (context) => {
+		this.consumeContext(UMB_COLLECTION_CONTEXT, (context) => {
 			this.#collectionContext = context;
 			if (!this.#collectionContext) return;
 			this._collectionAlias = this.#collectionContext.getManifest()?.alias;

--- a/src/packages/core/collection/components/collection-selection-actions.element.ts
+++ b/src/packages/core/collection/components/collection-selection-actions.element.ts
@@ -1,4 +1,4 @@
-import { UMB_DEFAULT_COLLECTION_CONTEXT } from '../default/collection-default.context.js';
+import { UMB_COLLECTION_CONTEXT } from '../default/collection-default.context.js';
 import type { ManifestEntityBulkAction, MetaEntityBulkAction } from '../../extension-registry/models/index.js';
 import type { UmbActionExecutedEvent } from '@umbraco-cms/backoffice/event';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
@@ -22,11 +22,11 @@ export class UmbCollectionSelectionActionsElement extends UmbLitElement {
 
 	private _selection: Array<string | null> = [];
 
-	private _collectionContext?: typeof UMB_DEFAULT_COLLECTION_CONTEXT.TYPE;
+	private _collectionContext?: typeof UMB_COLLECTION_CONTEXT.TYPE;
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_DEFAULT_COLLECTION_CONTEXT, (instance) => {
+		this.consumeContext(UMB_COLLECTION_CONTEXT, (instance) => {
 			this._collectionContext = instance;
 			this._observeCollectionContext();
 		});

--- a/src/packages/core/collection/components/collection-view-bundle.element.ts
+++ b/src/packages/core/collection/components/collection-view-bundle.element.ts
@@ -1,5 +1,5 @@
 import type { UmbDefaultCollectionContext } from '../default/collection-default.context.js';
-import { UMB_DEFAULT_COLLECTION_CONTEXT } from '../default/collection-default.context.js';
+import { UMB_COLLECTION_CONTEXT } from '../default/collection-default.context.js';
 import type { UmbCollectionLayoutConfiguration } from '../types.js';
 import { css, html, customElement, state, nothing, repeat, query } from '@umbraco-cms/backoffice/external/lit';
 import { observeMultiple } from '@umbraco-cms/backoffice/observable-api';
@@ -35,7 +35,7 @@ export class UmbCollectionViewBundleElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_DEFAULT_COLLECTION_CONTEXT, (context) => {
+		this.consumeContext(UMB_COLLECTION_CONTEXT, (context) => {
 			this.#collectionContext = context;
 			this.#observeCollection();
 		});

--- a/src/packages/core/collection/components/pagination/collection-pagination.element.ts
+++ b/src/packages/core/collection/components/pagination/collection-pagination.element.ts
@@ -1,4 +1,4 @@
-import { UMB_DEFAULT_COLLECTION_CONTEXT } from '../../default/collection-default.context.js';
+import { UMB_COLLECTION_CONTEXT } from '../../default/collection-default.context.js';
 import type { UUIPaginationEvent } from '@umbraco-cms/backoffice/external/uui';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { css, html, customElement, nothing, state } from '@umbraco-cms/backoffice/external/lit';
@@ -17,7 +17,7 @@ export class UmbCollectionPaginationElement extends UmbLitElement {
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_DEFAULT_COLLECTION_CONTEXT, (instance) => {
+		this.consumeContext(UMB_COLLECTION_CONTEXT, (instance) => {
 			this._collectionContext = instance;
 			this.#observeCurrentPage();
 			this.#observerTotalPages();

--- a/src/packages/core/collection/default/collection-default.context.ts
+++ b/src/packages/core/collection/default/collection-default.context.ts
@@ -61,7 +61,7 @@ export class UmbDefaultCollectionContext<
 	});
 
 	constructor(host: UmbControllerHost, defaultViewAlias: string, defaultFilter: Partial<FilterModelType> = {}) {
-		super(host, UMB_DEFAULT_COLLECTION_CONTEXT);
+		super(host, UMB_COLLECTION_CONTEXT);
 
 		this.#defaultViewAlias = defaultViewAlias;
 		this.#defaultFilter = defaultFilter;
@@ -217,4 +217,9 @@ export class UmbDefaultCollectionContext<
 	}
 }
 
-export const UMB_DEFAULT_COLLECTION_CONTEXT = new UmbContextToken<UmbDefaultCollectionContext>('UmbCollectionContext');
+export const UMB_COLLECTION_CONTEXT = new UmbContextToken<UmbDefaultCollectionContext>('UmbCollectionContext');
+
+/**
+ * @deprecated Use UMB_COLLECTION_CONTEXT instead.
+ */
+export { UMB_COLLECTION_CONTEXT as UMB_DEFAULT_COLLECTION_CONTEXT };

--- a/src/packages/core/collection/default/collection-default.element.ts
+++ b/src/packages/core/collection/default/collection-default.element.ts
@@ -1,4 +1,4 @@
-import { UMB_DEFAULT_COLLECTION_CONTEXT, UmbDefaultCollectionContext } from './collection-default.context.js';
+import { UMB_COLLECTION_CONTEXT, UmbDefaultCollectionContext } from './collection-default.context.js';
 import { css, html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
@@ -30,7 +30,7 @@ export class UmbCollectionDefaultElement extends UmbLitElement {
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_DEFAULT_COLLECTION_CONTEXT, (context) => {
+		this.consumeContext(UMB_COLLECTION_CONTEXT, (context) => {
 			this.#collectionContext = context;
 			this.#observeCollectionRoutes();
 		});

--- a/src/packages/core/extension-registry/collection/extension-collection.element.ts
+++ b/src/packages/core/extension-registry/collection/extension-collection.element.ts
@@ -1,7 +1,7 @@
 import { umbExtensionsRegistry } from '../registry.js';
 import { html, customElement, css } from '@umbraco-cms/backoffice/external/lit';
 import { fromCamelCase } from '@umbraco-cms/backoffice/utils';
-import { UMB_DEFAULT_COLLECTION_CONTEXT, UmbCollectionDefaultElement } from '@umbraco-cms/backoffice/collection';
+import { UMB_COLLECTION_CONTEXT, UmbCollectionDefaultElement } from '@umbraco-cms/backoffice/collection';
 import type { UmbDefaultCollectionContext } from '@umbraco-cms/backoffice/collection';
 import type { UUISelectEvent } from '@umbraco-cms/backoffice/external/uui';
 
@@ -17,7 +17,7 @@ export class UmbExtensionCollectionElement extends UmbCollectionDefaultElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_DEFAULT_COLLECTION_CONTEXT, (collectionContext) => {
+		this.consumeContext(UMB_COLLECTION_CONTEXT, (collectionContext) => {
 			this.#collectionContext = collectionContext;
 		});
 

--- a/src/packages/core/extension-registry/collection/views/extension-table-action-column-layout.element.ts
+++ b/src/packages/core/extension-registry/collection/views/extension-table-action-column-layout.element.ts
@@ -1,5 +1,5 @@
 import { umbExtensionsRegistry } from '../../index.js';
-import { UMB_DEFAULT_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
+import { UMB_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
 import { html, customElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { umbConfirmModal } from '@umbraco-cms/backoffice/modal';
@@ -16,7 +16,7 @@ export class UmbExtensionTableActionColumnLayoutElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_DEFAULT_COLLECTION_CONTEXT, (instance) => {
+		this.consumeContext(UMB_COLLECTION_CONTEXT, (instance) => {
 			this.#collectionContext = instance;
 		});
 	}

--- a/src/packages/core/extension-registry/collection/views/table/extension-table-collection-view.element.ts
+++ b/src/packages/core/extension-registry/collection/views/table/extension-table-collection-view.element.ts
@@ -1,5 +1,5 @@
 import type { UmbDefaultCollectionContext } from '@umbraco-cms/backoffice/collection';
-import { UMB_DEFAULT_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
+import { UMB_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
 import type { UmbTableColumn, UmbTableConfig, UmbTableItem } from '@umbraco-cms/backoffice/components';
 import { css, html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
@@ -48,7 +48,7 @@ export class UmbExtensionTableCollectionViewElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_DEFAULT_COLLECTION_CONTEXT, (instance) => {
+		this.consumeContext(UMB_COLLECTION_CONTEXT, (instance) => {
 			this.#collectionContext = instance;
 			this.#observeCollectionItems();
 		});

--- a/src/packages/dictionary/collection/views/table/dictionary-table-collection-view.element.ts
+++ b/src/packages/dictionary/collection/views/table/dictionary-table-collection-view.element.ts
@@ -1,6 +1,6 @@
 import type { UmbDictionaryCollectionModel } from '../../types.js';
 import type { UmbDefaultCollectionContext } from '@umbraco-cms/backoffice/collection';
-import { UMB_DEFAULT_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
+import { UMB_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
 import type { UmbTableColumn, UmbTableConfig, UmbTableItem } from '@umbraco-cms/backoffice/components';
 import { css, html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
@@ -32,7 +32,7 @@ export class UmbDictionaryTableCollectionViewElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_DEFAULT_COLLECTION_CONTEXT, (instance) => {
+		this.consumeContext(UMB_COLLECTION_CONTEXT, (instance) => {
 			this.#collectionContext = instance;
 			this.#observeCollectionItems();
 		});

--- a/src/packages/documents/documents/collection/action/create-document-collection-action.element.ts
+++ b/src/packages/documents/documents/collection/action/create-document-collection-action.element.ts
@@ -1,7 +1,7 @@
 import { html, customElement, property, state, map } from '@umbraco-cms/backoffice/external/lit';
 import { UmbDocumentTypeStructureRepository } from '@umbraco-cms/backoffice/document-type';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import { UMB_DEFAULT_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
+import { UMB_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
 import {
 	UMB_CREATE_DOCUMENT_WORKSPACE_PATH_PATTERN,
 	UMB_DOCUMENT_ENTITY_TYPE,
@@ -58,7 +58,7 @@ export class UmbCreateDocumentCollectionActionElement extends UmbLitElement {
 			});
 		});
 
-		this.consumeContext(UMB_DEFAULT_COLLECTION_CONTEXT, (collectionContext) => {
+		this.consumeContext(UMB_COLLECTION_CONTEXT, (collectionContext) => {
 			this.observe(collectionContext.filter, (filter) => {
 				this._useInfiniteEditor = filter.useInfiniteEditor == true;
 			});

--- a/src/packages/documents/documents/collection/document-collection-toolbar.element.ts
+++ b/src/packages/documents/documents/collection/document-collection-toolbar.element.ts
@@ -1,6 +1,6 @@
 import { css, html, customElement } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import { UMB_DEFAULT_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
+import { UMB_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
 import type { UmbDefaultCollectionContext } from '@umbraco-cms/backoffice/collection';
 
 @customElement('umb-document-collection-toolbar')
@@ -13,7 +13,7 @@ export class UmbDocumentCollectionToolbarElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_DEFAULT_COLLECTION_CONTEXT, (instance) => {
+		this.consumeContext(UMB_COLLECTION_CONTEXT, (instance) => {
 			this.#collectionContext = instance;
 		});
 	}

--- a/src/packages/documents/documents/collection/views/grid/document-grid-collection-view.element.ts
+++ b/src/packages/documents/documents/collection/views/grid/document-grid-collection-view.element.ts
@@ -5,7 +5,7 @@ import { css, html, customElement, state, repeat } from '@umbraco-cms/backoffice
 import { fromCamelCase } from '@umbraco-cms/backoffice/utils';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
-import { UMB_DEFAULT_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
+import { UMB_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
 import type { UmbDefaultCollectionContext } from '@umbraco-cms/backoffice/collection';
 
 @customElement('umb-document-grid-collection-view')
@@ -30,7 +30,7 @@ export class UmbDocumentGridCollectionViewElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_DEFAULT_COLLECTION_CONTEXT, (collectionContext) => {
+		this.consumeContext(UMB_COLLECTION_CONTEXT, (collectionContext) => {
 			this.#collectionContext = collectionContext;
 			this.#observeCollectionContext();
 		});

--- a/src/packages/documents/documents/collection/views/table/document-table-collection-view.element.ts
+++ b/src/packages/documents/documents/collection/views/table/document-table-collection-view.element.ts
@@ -5,7 +5,7 @@ import type { UmbDocumentCollectionContext } from '../../document-collection.con
 import { css, html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
-import { UMB_DEFAULT_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
+import { UMB_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
 import type {
 	UmbTableColumn,
 	UmbTableConfig,
@@ -66,7 +66,7 @@ export class UmbDocumentTableCollectionViewElement extends UmbLitElement {
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_DEFAULT_COLLECTION_CONTEXT, (collectionContext) => {
+		this.consumeContext(UMB_COLLECTION_CONTEXT, (collectionContext) => {
 			this.#collectionContext = collectionContext;
 			this.#observeCollectionContext();
 		});

--- a/src/packages/language/collection/views/table/language-table-collection-view.element.ts
+++ b/src/packages/language/collection/views/table/language-table-collection-view.element.ts
@@ -1,6 +1,6 @@
 import type { UmbLanguageDetailModel } from '../../../types.js';
 import type { UmbDefaultCollectionContext } from '@umbraco-cms/backoffice/collection';
-import { UMB_DEFAULT_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
+import { UMB_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
 import type { UmbTableColumn, UmbTableConfig, UmbTableItem } from '@umbraco-cms/backoffice/components';
 import { css, html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
@@ -58,7 +58,7 @@ export class UmbLanguageTableCollectionViewElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_DEFAULT_COLLECTION_CONTEXT, (instance) => {
+		this.consumeContext(UMB_COLLECTION_CONTEXT, (instance) => {
 			this.#collectionContext = instance;
 			this.#observeCollectionItems();
 		});

--- a/src/packages/media/media/collection/action/create-media-collection-action.element.ts
+++ b/src/packages/media/media/collection/action/create-media-collection-action.element.ts
@@ -1,7 +1,7 @@
 import { html, customElement, property, state, map } from '@umbraco-cms/backoffice/external/lit';
 import { UmbMediaTypeStructureRepository } from '@umbraco-cms/backoffice/media-type';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import { UMB_DEFAULT_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
+import { UMB_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
 import { UMB_MEDIA_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/media';
 import { UMB_WORKSPACE_MODAL, UmbModalRouteRegistrationController } from '@umbraco-cms/backoffice/modal';
 import type { ManifestCollectionAction } from '@umbraco-cms/backoffice/extension-registry';
@@ -53,7 +53,7 @@ export class UmbCreateMediaCollectionActionElement extends UmbLitElement {
 			});
 		});
 
-		this.consumeContext(UMB_DEFAULT_COLLECTION_CONTEXT, (collectionContext) => {
+		this.consumeContext(UMB_COLLECTION_CONTEXT, (collectionContext) => {
 			this.observe(collectionContext.filter, (filter) => {
 				this._useInfiniteEditor = filter.useInfiniteEditor == true;
 			});

--- a/src/packages/media/media/collection/media-collection-toolbar.element.ts
+++ b/src/packages/media/media/collection/media-collection-toolbar.element.ts
@@ -1,7 +1,7 @@
 import type { UmbMediaCollectionContext } from './media-collection.context.js';
 import { css, html, customElement } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import { UMB_DEFAULT_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
+import { UMB_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
 
 @customElement('umb-media-collection-toolbar')
 export class UmbMediaCollectionToolbarElement extends UmbLitElement {
@@ -13,7 +13,7 @@ export class UmbMediaCollectionToolbarElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_DEFAULT_COLLECTION_CONTEXT, (instance) => {
+		this.consumeContext(UMB_COLLECTION_CONTEXT, (instance) => {
 			this.#collectionContext = instance as UmbMediaCollectionContext;
 		});
 	}

--- a/src/packages/media/media/collection/media-collection.element.ts
+++ b/src/packages/media/media/collection/media-collection.element.ts
@@ -1,6 +1,6 @@
 import type { UmbMediaCollectionContext } from './media-collection.context.js';
 import { customElement, html, state, when } from '@umbraco-cms/backoffice/external/lit';
-import { UMB_DEFAULT_COLLECTION_CONTEXT, UmbCollectionDefaultElement } from '@umbraco-cms/backoffice/collection';
+import { UMB_COLLECTION_CONTEXT, UmbCollectionDefaultElement } from '@umbraco-cms/backoffice/collection';
 import type { UmbProgressEvent } from '@umbraco-cms/backoffice/event';
 
 import './media-collection-toolbar.element.js';
@@ -14,7 +14,7 @@ export class UmbMediaCollectionElement extends UmbCollectionDefaultElement {
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_DEFAULT_COLLECTION_CONTEXT, (instance) => {
+		this.consumeContext(UMB_COLLECTION_CONTEXT, (instance) => {
 			this.#mediaCollection = instance as UmbMediaCollectionContext;
 		});
 	}

--- a/src/packages/media/media/collection/views/grid/media-grid-collection-view.element.ts
+++ b/src/packages/media/media/collection/views/grid/media-grid-collection-view.element.ts
@@ -2,7 +2,7 @@ import type { UmbMediaCollectionFilterModel, UmbMediaCollectionItemModel } from 
 import { css, html, customElement, state, repeat } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
-import { UMB_DEFAULT_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
+import { UMB_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
 import type { UmbDefaultCollectionContext } from '@umbraco-cms/backoffice/collection';
 
 @customElement('umb-media-grid-collection-view')
@@ -20,7 +20,7 @@ export class UmbMediaGridCollectionViewElement extends UmbLitElement {
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_DEFAULT_COLLECTION_CONTEXT, (collectionContext) => {
+		this.consumeContext(UMB_COLLECTION_CONTEXT, (collectionContext) => {
 			this.#collectionContext = collectionContext;
 			this.#observeCollectionContext();
 		});

--- a/src/packages/media/media/collection/views/table/media-table-collection-view.element.ts
+++ b/src/packages/media/media/collection/views/table/media-table-collection-view.element.ts
@@ -3,7 +3,7 @@ import type { UmbMediaCollectionFilterModel, UmbMediaCollectionItemModel } from 
 import { css, html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
-import { UMB_DEFAULT_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
+import { UMB_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
 import type { UmbDefaultCollectionContext } from '@umbraco-cms/backoffice/collection';
 import type {
 	UmbTableColumn,
@@ -58,7 +58,7 @@ export class UmbMediaTableCollectionViewElement extends UmbLitElement {
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_DEFAULT_COLLECTION_CONTEXT, (collectionContext) => {
+		this.consumeContext(UMB_COLLECTION_CONTEXT, (collectionContext) => {
 			this.#collectionContext = collectionContext;
 			this.#observeCollectionContext();
 		});

--- a/src/packages/members/member-group/collection/views/table/member-group-table-collection-view.element.ts
+++ b/src/packages/members/member-group/collection/views/table/member-group-table-collection-view.element.ts
@@ -1,6 +1,6 @@
 import type { UmbMemberGroupCollectionModel } from '../../types.js';
 import type { UmbDefaultCollectionContext } from '@umbraco-cms/backoffice/collection';
-import { UMB_DEFAULT_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
+import { UMB_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
 import type { UmbTableColumn, UmbTableConfig, UmbTableItem } from '@umbraco-cms/backoffice/components';
 import { css, html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
@@ -29,7 +29,7 @@ export class UmbMemberGroupTableCollectionViewElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_DEFAULT_COLLECTION_CONTEXT, (instance) => {
+		this.consumeContext(UMB_COLLECTION_CONTEXT, (instance) => {
 			this.#collectionContext = instance;
 			this.#observeCollectionItems();
 		});

--- a/src/packages/members/member/collection/member-collection-header.element.ts
+++ b/src/packages/members/member/collection/member-collection-header.element.ts
@@ -3,7 +3,7 @@ import type { UmbMemberTypeItemModel } from '../../member-type/repository/item/t
 import type { UmbMemberCollectionContext } from './member-collection.context.js';
 import { css, customElement, html, ifDefined, repeat, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import { UMB_DEFAULT_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
+import { UMB_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
 
 @customElement('umb-member-collection-header')
 export class UmbMemberCollectionHeaderElement extends UmbLitElement {
@@ -23,7 +23,7 @@ export class UmbMemberCollectionHeaderElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_DEFAULT_COLLECTION_CONTEXT, (instance) => {
+		this.consumeContext(UMB_COLLECTION_CONTEXT, (instance) => {
 			this.#collectionContext = instance as UmbMemberCollectionContext;
 		});
 

--- a/src/packages/members/member/collection/views/table/member-table-collection-view.element.ts
+++ b/src/packages/members/member/collection/views/table/member-table-collection-view.element.ts
@@ -1,7 +1,7 @@
 import type { UmbMemberCollectionModel } from '../../types.js';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import type { UmbDefaultCollectionContext } from '@umbraco-cms/backoffice/collection';
-import { UMB_DEFAULT_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
+import { UMB_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
 import type { UmbTableColumn, UmbTableConfig, UmbTableItem } from '@umbraco-cms/backoffice/components';
 import { css, html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
@@ -29,7 +29,7 @@ export class UmbMemberTableCollectionViewElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_DEFAULT_COLLECTION_CONTEXT, (instance) => {
+		this.consumeContext(UMB_COLLECTION_CONTEXT, (instance) => {
 			this.#collectionContext = instance;
 			this.#observeCollectionItems();
 		});

--- a/src/packages/relations/relation-types/collection/views/table/relation-type-table-collection-view.element.ts
+++ b/src/packages/relations/relation-types/collection/views/table/relation-type-table-collection-view.element.ts
@@ -1,6 +1,6 @@
 import type { UmbRelationTypeDetailModel } from '../../../types.js';
 import type { UmbDefaultCollectionContext } from '@umbraco-cms/backoffice/collection';
-import { UMB_DEFAULT_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
+import { UMB_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
 import type { UmbTableColumn, UmbTableConfig, UmbTableItem } from '@umbraco-cms/backoffice/components';
 import { css, html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
@@ -29,7 +29,7 @@ export class UmbRelationTypeTableCollectionViewElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_DEFAULT_COLLECTION_CONTEXT, (instance) => {
+		this.consumeContext(UMB_COLLECTION_CONTEXT, (instance) => {
 			this.#collectionContext = instance;
 			this.#observeCollectionItems();
 		});

--- a/src/packages/user/user-group/collection/views/user-group-table-collection-view.element.ts
+++ b/src/packages/user/user-group/collection/views/user-group-table-collection-view.element.ts
@@ -3,7 +3,7 @@ import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { UmbDefaultCollectionContext } from '@umbraco-cms/backoffice/collection';
-import { UMB_DEFAULT_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
+import { UMB_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
 import type {
 	UmbTableColumn,
 	UmbTableConfig,
@@ -67,7 +67,7 @@ export class UmbUserGroupCollectionTableViewElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_DEFAULT_COLLECTION_CONTEXT, (instance) => {
+		this.consumeContext(UMB_COLLECTION_CONTEXT, (instance) => {
 			this.#collectionContext = instance;
 			this.observe(
 				this.#collectionContext.selection.selection,

--- a/src/packages/user/user/collection/user-collection-header.element.ts
+++ b/src/packages/user/user/collection/user-collection-header.element.ts
@@ -5,7 +5,7 @@ import { UmbUserStateFilter } from './utils/index.js';
 import type { UUIBooleanInputEvent, UUICheckboxElement } from '@umbraco-cms/backoffice/external/uui';
 import { css, html, customElement, state, repeat, ifDefined } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import { UMB_DEFAULT_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
+import { UMB_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
 import type { UmbUserGroupDetailModel } from '@umbraco-cms/backoffice/user-group';
 import { UmbUserGroupCollectionRepository } from '@umbraco-cms/backoffice/user-group';
 import { observeMultiple } from '@umbraco-cms/backoffice/observable-api';
@@ -39,7 +39,7 @@ export class UmbUserCollectionHeaderElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_DEFAULT_COLLECTION_CONTEXT, (instance) => {
+		this.consumeContext(UMB_COLLECTION_CONTEXT, (instance) => {
 			this.#collectionContext = instance as UmbUserCollectionContext;
 			this.#observeOrderByOptions();
 		});

--- a/src/packages/user/user/collection/views/grid/user-grid-collection-view.element.ts
+++ b/src/packages/user/user/collection/views/grid/user-grid-collection-view.element.ts
@@ -3,7 +3,7 @@ import type { UmbUserCollectionContext } from '../../user-collection.context.js'
 import type { UmbUserDetailModel } from '../../../types.js';
 import { css, html, nothing, customElement, state, repeat, ifDefined } from '@umbraco-cms/backoffice/external/lit';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
-import { UMB_DEFAULT_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
+import { UMB_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UserStateModel } from '@umbraco-cms/backoffice/external/backend-api';
 import type { UmbUserGroupDetailModel } from '@umbraco-cms/backoffice/user-group';
@@ -29,7 +29,7 @@ export class UmbUserGridCollectionViewElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_DEFAULT_COLLECTION_CONTEXT, (instance) => {
+		this.consumeContext(UMB_COLLECTION_CONTEXT, (instance) => {
 			this.#collectionContext = instance as UmbUserCollectionContext;
 			this.observe(
 				this.#collectionContext.selection.selection,

--- a/src/packages/user/user/collection/views/table/user-table-collection-view.element.ts
+++ b/src/packages/user/user/collection/views/table/user-table-collection-view.element.ts
@@ -11,7 +11,7 @@ import type {
 	UmbTableConfig,
 	UmbTableOrderedEvent,
 } from '@umbraco-cms/backoffice/components';
-import { UMB_DEFAULT_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
+import { UMB_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { UmbUserGroupItemModel } from '@umbraco-cms/backoffice/user-group';
 import { UmbUserGroupItemRepository } from '@umbraco-cms/backoffice/user-group';
@@ -67,7 +67,7 @@ export class UmbUserTableCollectionViewElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_DEFAULT_COLLECTION_CONTEXT, (instance) => {
+		this.consumeContext(UMB_COLLECTION_CONTEXT, (instance) => {
 			this.#collectionContext = instance as UmbUserCollectionContext;
 			this.observe(
 				this.#collectionContext.selection.selection,

--- a/src/packages/webhook/collection/views/table/webhook-table-collection-view.element.ts
+++ b/src/packages/webhook/collection/views/table/webhook-table-collection-view.element.ts
@@ -1,6 +1,6 @@
 import type { UmbWebhookDetailModel } from '../../../types.js';
 import type { UmbDefaultCollectionContext } from '@umbraco-cms/backoffice/collection';
-import { UMB_DEFAULT_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
+import { UMB_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
 import type { UmbTableColumn, UmbTableConfig, UmbTableItem } from '@umbraco-cms/backoffice/components';
 import { css, html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
@@ -51,7 +51,7 @@ export class UmbWebhookTableCollectionViewElement extends UmbLitElement {
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_DEFAULT_COLLECTION_CONTEXT, (instance) => {
+		this.consumeContext(UMB_COLLECTION_CONTEXT, (instance) => {
 			this.#collectionContext = instance;
 			this.#observeCollectionItems();
 		});


### PR DESCRIPTION
## Description

As discussed with @nielslyngsoe, this PR renames `UMB_DEFAULT_COLLECTION_CONTEXT` to `UMB_COLLECTION_CONTEXT`, as what does "default" mean here?

We've kept `UMB_DEFAULT_COLLECTION_CONTEXT` as an aliased export, but marked as deprecated.

## Types of changes

- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
