### PR TITLE
Add missing entity type exports

### DIFF
--- a/src/packages/dictionary/index.ts
+++ b/src/packages/dictionary/index.ts
@@ -1,3 +1,4 @@
 export * from './repository/index.js';
 export * from './tree/index.js';
+export * from './entity.js';
 export { UMB_DICTIONARY_PICKER_MODAL } from './modals/dictionary-picker-modal.token.js';

--- a/src/packages/language/index.ts
+++ b/src/packages/language/index.ts
@@ -2,6 +2,7 @@ import './components/index.js';
 
 export { UmbInputLanguageElement } from './components/index.js';
 
+export * from './entity.js';
 export * from './repository/index.js';
 export * from './collection/index.js';
 export * from './global-contexts/index.js';

--- a/src/packages/media/media-types/index.ts
+++ b/src/packages/media/media-types/index.ts
@@ -6,6 +6,7 @@ export * from './workspace/index.js';
 export * from './repository/index.js';
 export * from './tree/types.js';
 export * from './types.js';
+export * from './entity.js';
 
 export * from './utils/index.js';
 

--- a/src/packages/members/member-group/index.ts
+++ b/src/packages/members/member-group/index.ts
@@ -1,5 +1,6 @@
 import './components/index.js';
 
+export * from './entity.js';
 export * from './repository/index.js';
 export * from './components/index.js';
 export type { UmbMemberGroupDetailModel } from './types.js';

--- a/src/packages/members/member/index.ts
+++ b/src/packages/members/member/index.ts
@@ -1,4 +1,5 @@
 import './components/index.js';
 
+export * from './entity.js';
 export * from './components/index.js';
 export * from './repository/index.js';

--- a/src/packages/static-file/index.ts
+++ b/src/packages/static-file/index.ts
@@ -1,3 +1,4 @@
+export * from './entity.js';
 export * from './components/index.js';
 export * from './tree/index.js';
 export * from './modals/index.js';

--- a/src/packages/templating/partial-views/index.ts
+++ b/src/packages/templating/partial-views/index.ts
@@ -1,1 +1,2 @@
 export * from './repository/index.js';
+export * from './entity.js';

--- a/src/packages/templating/stylesheets/index.ts
+++ b/src/packages/templating/stylesheets/index.ts
@@ -1,6 +1,8 @@
 import './components/index.js';
 
 export * from './repository/index.js';
+export * from './entity.js';
+
 export { UmbStylesheetTreeRepository } from './tree/index.js';
 
 // Components

--- a/src/packages/user/user-group/index.ts
+++ b/src/packages/user/user-group/index.ts
@@ -2,7 +2,6 @@ export * from './collection/index.js';
 export * from './components/index.js';
 export * from './repository/index.js';
 export * from './types.js';
-
-export const UMB_USER_GROUP_ENTITY_TYPE = 'user-group';
+export * from './entity.js';
 
 export { UMB_USER_GROUP_PICKER_MODAL } from './modals/user-group-picker/index.js';

--- a/src/packages/user/user/index.ts
+++ b/src/packages/user/user/index.ts
@@ -4,3 +4,4 @@ export * from './invite/index.js';
 export * from './repository/index.js';
 export type * from './types.js';
 export * from './utils/index.js';
+export * from './entity.js';

--- a/src/packages/webhook/index.ts
+++ b/src/packages/webhook/index.ts
@@ -1,3 +1,4 @@
 export * from './collection/index.js';
 
 export type * from './types.js';
+export * from './entity.js';


### PR DESCRIPTION
Adds exports for missing entity types

Adds missing exports for entity types across package (#1740)

## Description

There were missing exports of entity types meaning that externally you couldn't access several extension points. 

Adds the export of entities for: 

- Dictionary
- Languages
- Media-types
- Members
- Member-Groups
- static-files ?
- partial-views
- stylesheets
- users
- user-groups
- webhooks.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

Without the exports external packages can't add to action menus or workspaces.

## How to test?

NOT SURE? - I don't think this changes any core functionality it simply exposes the entity types in the library. ?? 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
