### PR TITLE
Feature: Collection - syncs Order By with Columns Displayed field

### DIFF
--- a/src/packages/property-editors/collection/manifests.ts
+++ b/src/packages/property-editors/collection/manifests.ts
@@ -24,13 +24,6 @@ const propertyEditorUiManifest: ManifestPropertyEditorUi = {
 					propertyEditorUiAlias: 'Umb.PropertyEditorUi.Collection.LayoutConfiguration',
 				},
 				{
-					alias: 'pageSize',
-					label: 'Page Size',
-					description: 'Number of items per page.',
-					propertyEditorUiAlias: 'Umb.PropertyEditorUi.Number',
-					config: [{ alias: 'min', value: 0 }],
-				},
-				{
 					alias: 'orderBy',
 					label: 'Order By',
 					description: 'The default sort order for the list.',
@@ -40,6 +33,13 @@ const propertyEditorUiManifest: ManifestPropertyEditorUi = {
 					alias: 'orderDirection',
 					label: 'Order Direction',
 					propertyEditorUiAlias: 'Umb.PropertyEditorUi.OrderDirection',
+				},
+				{
+					alias: 'pageSize',
+					label: 'Page Size',
+					description: 'Number of items per page.',
+					propertyEditorUiAlias: 'Umb.PropertyEditorUi.Number',
+					config: [{ alias: 'min', value: 0 }],
 				},
 				{
 					alias: 'bulkActionPermissions',


### PR DESCRIPTION
## Description

On the Collections configuration, previously the Order By field was hardcoded to 3 options.

This PR aligns the options with the items used in the Columns Displayed field. This is useful for when a user would like to set the default order by on their own column configuration.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How to test?

On a data type for a Collection configuration, add, remove, sort the Columns Displayed items, see the changes reflected in the Order By dropdown field.
