### PR TITLE
Feature: Property Editor Config Value Converter

### DIFF
--- a/src/packages/core/property-editor/config/property-editor-config-collection.class.ts
+++ b/src/packages/core/property-editor/config/property-editor-config-collection.class.ts
@@ -13,11 +13,15 @@ export class UmbPropertyEditorConfigCollection extends Array<UmbPropertyEditorCo
 		return Array;
 	}
 
-	getValueByAlias<T>(alias: string): T | undefined {
+	getValueByAlias<T>(alias: string, converter?: (value: unknown) => T): T | undefined {
 		const property = this.getByAlias(alias);
 
 		if (property?.value === undefined || property?.value === null) {
 			return;
+		}
+
+		if (converter) {
+			return converter(property.value) as T;
 		}
 
 		return property.value as T;

--- a/src/packages/property-editors/multi-url-picker/property-editor-ui-multi-url-picker.element.ts
+++ b/src/packages/property-editors/multi-url-picker/property-editor-ui-multi-url-picker.element.ts
@@ -21,9 +21,15 @@ export class UmbPropertyEditorUIMultiUrlPickerElement extends UmbLitElement impl
 
 		this._hideAnchor = config.getValueByAlias('hideAnchor') ?? false;
 		this._ignoreUserStartNodes = config.getValueByAlias<boolean>('ignoreUserStartNodes') ?? false;
-		this._minNumber = Number(config.getValueByAlias('minNumber')) ?? 0;
-		this._maxNumber = Number(config.getValueByAlias('maxNumber')) ?? Infinity;
 		this._overlaySize = config.getValueByAlias<UUIModalSidebarSize>('overlaySize') ?? 'small';
+
+		this.min = config.getValueByAlias('minNumber', (value) => this.#parseIntOrFallback(value, 0)) ?? 0;
+		this.max = config.getValueByAlias('maxNumber', (value) => this.#parseIntOrFallback(value, Infinity)) ?? Infinity;
+	}
+
+	#parseIntOrFallback(input: unknown, fallback: number): number {
+		const num = Number(input);
+		return num > 0 ? num : fallback;
 	}
 
 	@state()
@@ -36,10 +42,10 @@ export class UmbPropertyEditorUIMultiUrlPickerElement extends UmbLitElement impl
 	private _ignoreUserStartNodes?: boolean;
 
 	@state()
-	private _minNumber? = 0;
+	min = 0;
 
 	@state()
-	private _maxNumber? = Infinity;
+	max = Infinity;
 
 	@state()
 	private _alias?: string;
@@ -66,8 +72,8 @@ export class UmbPropertyEditorUIMultiUrlPickerElement extends UmbLitElement impl
 			<umb-input-multi-url
 				.alias=${this._alias}
 				.ignoreUserStartNodes=${this._ignoreUserStartNodes}
-				.max=${this._maxNumber}
-				.min=${this._minNumber}
+				.min=${this.min}
+				.max=${this.max}
 				.overlaySize=${this._overlaySize}
 				.urls=${this.value ?? []}
 				.variantId=${this._variantId}

--- a/src/packages/property-editors/number/property-editor-ui-number.element.ts
+++ b/src/packages/property-editors/number/property-editor-ui-number.element.ts
@@ -20,9 +20,9 @@ export class UmbPropertyEditorUINumberElement extends UmbLitElement implements U
 
 	public set config(config: UmbPropertyEditorConfigCollection | undefined) {
 		if (!config) return;
-		this._min = this.#parseInt(config.getValueByAlias('min'));
-		this._max = this.#parseInt(config.getValueByAlias('max'));
-		this._step = this.#parseInt(config.getValueByAlias('step'));
+		this._min = config.getValueByAlias('min', this.#parseInt);
+		this._max = config.getValueByAlias('max', this.#parseInt);
+		this._step = config.getValueByAlias('step', this.#parseInt);
 	}
 
 	#parseInt(input: unknown): number | undefined {


### PR DESCRIPTION
## Description

A proposal to add a `converter` function parameter to the `UmbPropertyEditorConfigCollection.getValueByAlias<T>()` method.

This is for scenarios where a configuration value can be converted from `unknown` into a target object-type. e.g. to parse, validate, return or to potentially set a sensible fallback/default value.

Consider the general use-case for minimum/maximum configurations, typically these would be positive integers, so would need to ensure that negative values can't leak through.

e.g. to ensure a maximum value...
```
config.getValueByAlias('max', (value) => { const num = Number(input); return num > 0 ? num : Infinity; });
```

I'm open to alternative approaches on how to parse/converter the config values.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
