### PR TITLE
Feat: Content Type editor — remove props when removing container

### DIFF
--- a/src/packages/core/content-type/structure/content-type-structure-manager.class.ts
+++ b/src/packages/core/content-type/structure/content-type-structure-manager.class.ts
@@ -425,10 +425,15 @@ export class UmbContentTypeStructureManager<
 			throw new Error('Could not find the Content Type to remove container from');
 		}
 		const frozenContainers = contentType.containers ?? [];
+		const removedContainerIds = frozenContainers
+			.filter((x) => x.id === containerId || x.parent?.id === containerId)
+			.map((x) => x.id);
 		const containers = frozenContainers.filter((x) => x.id !== containerId && x.parent?.id !== containerId);
 
-		const frozenProperties = contentType.properties ?? [];
-		const properties = frozenProperties.filter((x) => x.container?.id !== containerId);
+		const frozenProperties = contentType.properties;
+		const properties = frozenProperties.filter((x) =>
+			x.container ? !removedContainerIds.some((ids) => ids === x.container?.id) : true,
+		);
 
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore


### PR DESCRIPTION
Also removing properties when removing a container, also works for properties of a container which is child of the container begin removed.

This fixes an issue where a Implementor(user) has a tab with a group with a property, and decides to remove the tab. then the property was not removed before this PR.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
