### PR TITLE
Feat: input with alias

### DIFF
--- a/src/packages/core/components/index.ts
+++ b/src/packages/core/components/index.ts
@@ -25,6 +25,7 @@ export * from './input-radio-button-list/index.js';
 export * from './input-slider/index.js';
 export * from './input-toggle/index.js';
 export * from './input-upload-field/index.js';
+export * from './input-with-alias/input-with-alias.element.js';
 export * from './multiple-color-picker-input/index.js';
 export * from './multiple-text-string-input/index.js';
 export * from './popover-layout/index.js';

--- a/src/packages/core/components/input-slider/input-slider.element.ts
+++ b/src/packages/core/components/input-slider/input-slider.element.ts
@@ -2,6 +2,7 @@ import { html, customElement, property } from '@umbraco-cms/backoffice/external/
 import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { UUISliderEvent } from '@umbraco-cms/backoffice/external/uui';
+import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 
 @customElement('umb-input-slider')
 export class UmbInputSliderElement extends UUIFormControlMixin(UmbLitElement, '') {
@@ -30,7 +31,7 @@ export class UmbInputSliderElement extends UUIFormControlMixin(UmbLitElement, ''
 	#onChange(e: UUISliderEvent) {
 		e.stopPropagation();
 		this.value = e.target.value as string;
-		this.dispatchEvent(new CustomEvent('change', { bubbles: true, composed: true }));
+		this.dispatchEvent(new UmbChangeEvent());
 	}
 
 	render() {

--- a/src/packages/core/components/input-with-alias/input-with-alias.element.ts
+++ b/src/packages/core/components/input-with-alias/input-with-alias.element.ts
@@ -13,6 +13,9 @@ export class UmbInputWithAliasElement extends UmbFormControlMixin<string>(UmbLit
 	@property({ type: String, reflect: false })
 	alias?: string;
 
+	@property({ type: Boolean, attribute: 'auto-generate-alias' })
+	autoGenerateAlias?: boolean;
+
 	@state()
 	private _aliasLocked = true;
 
@@ -32,7 +35,7 @@ export class UmbInputWithAliasElement extends UmbFormControlMixin<string>(UmbLit
 				const oldName = this.value;
 				const oldAlias = this.alias ?? '';
 				this.value = event.target.value.toString();
-				if (this._aliasLocked) {
+				if (this.autoGenerateAlias && this._aliasLocked) {
 					// If locked we will update the alias, but only if it matches the generated alias of the old name [NL]
 					const expectedOldAlias = generateAlias(oldName ?? '');
 					// Only update the alias if the alias matches a generated alias of the old name (otherwise the alias is considered one written by the user.) [NL]

--- a/src/packages/core/components/input-with-alias/input-with-alias.element.ts
+++ b/src/packages/core/components/input-with-alias/input-with-alias.element.ts
@@ -1,0 +1,117 @@
+import { css, customElement, html, property, state } from '@umbraco-cms/backoffice/external/lit';
+import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
+import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { type UUIInputElement, UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
+import { generateAlias } from '@umbraco-cms/backoffice/utils';
+
+@customElement('umb-input-with-alias')
+export class UmbInputWithAliasElement extends UmbFormControlMixin<string>(UmbLitElement) {
+	@property({ type: String })
+	label: string = '';
+
+	@property({ type: String, reflect: false })
+	alias?: string;
+
+	@state()
+	private _aliasLocked = true;
+
+	firstUpdated() {
+		this.shadowRoot?.querySelectorAll<UUIInputElement>('uui-input').forEach((x) => this.addFormControlElement(x));
+	}
+
+	focus() {
+		return this.shadowRoot?.querySelector<UUIInputElement>('uui-input')?.focus();
+	}
+
+	#onNameChange(event: UUIInputEvent) {
+		if (event instanceof UUIInputEvent) {
+			const target = event.composedPath()[0] as UUIInputElement;
+
+			if (typeof target?.value === 'string') {
+				const oldName = this.value;
+				const oldAlias = this.alias ?? '';
+				this.value = event.target.value.toString();
+				if (this._aliasLocked) {
+					// If locked we will update the alias, but only if it matches the generated alias of the old name [NL]
+					const expectedOldAlias = generateAlias(oldName ?? '');
+					// Only update the alias if the alias matches a generated alias of the old name (otherwise the alias is considered one written by the user.) [NL]
+					if (expectedOldAlias === oldAlias) {
+						this.alias = generateAlias(this.value);
+					}
+				}
+				this.dispatchEvent(new UmbChangeEvent());
+			}
+		}
+	}
+
+	#onAliasChange(e: UUIInputEvent) {
+		if (event instanceof UUIInputEvent) {
+			const target = event.composedPath()[0] as UUIInputElement;
+			if (typeof target?.value === 'string') {
+				this.alias = target.value;
+				this.dispatchEvent(new UmbChangeEvent());
+			}
+		}
+		e.stopPropagation();
+	}
+
+	#onToggleAliasLock() {
+		this._aliasLocked = !this._aliasLocked;
+	}
+
+	render() {
+		// Localizations: [NL]
+		return html`
+			<uui-input id="name" label=${this.label} .value=${this.value} @input="${this.#onNameChange}">
+				<!-- TODO: should use UUI-LOCK-INPUT, but that does not fire an event when its locked/unlocked -->
+				<uui-input
+					name="alias"
+					slot="append"
+					label="alias"
+					@input=${this.#onAliasChange}
+					.value=${this.alias}
+					placeholder="Enter alias..."
+					?disabled=${this._aliasLocked}>
+					<!-- TODO: validation for bad characters -->
+					<div @click=${this.#onToggleAliasLock} @keydown=${() => ''} id="alias-lock" slot="prepend">
+						<uui-icon name=${this._aliasLocked ? 'icon-lock' : 'icon-unlocked'}></uui-icon>
+					</div>
+				</uui-input>
+			</uui-input>
+		`;
+	}
+
+	static styles = css`
+		#name {
+			width: 100%;
+			flex: 1 1 auto;
+			align-items: center;
+		}
+
+		:host(:invalid:not([pristine])) {
+			color: var(--uui-color-danger);
+		}
+		:host(:invalid:not([pristine])) > uui-input {
+			border-color: var(--uui-color-danger);
+		}
+
+		#alias-lock {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			cursor: pointer;
+		}
+		#alias-lock uui-icon {
+			margin-bottom: 2px;
+		}
+	`;
+}
+
+export default UmbInputWithAliasElement;
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-input-with-alias': UmbInputWithAliasElement;
+	}
+}

--- a/src/packages/core/components/input-with-alias/input-with-alias.element.ts
+++ b/src/packages/core/components/input-with-alias/input-with-alias.element.ts
@@ -1,4 +1,4 @@
-import { css, customElement, html, property, state } from '@umbraco-cms/backoffice/external/lit';
+import { css, customElement, html, nothing, property, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
@@ -12,6 +12,9 @@ export class UmbInputWithAliasElement extends UmbFormControlMixin<string>(UmbLit
 
 	@property({ type: String, reflect: false })
 	alias?: string;
+
+	@property({ type: Boolean, reflect: true, attribute: 'alias-readonly' })
+	aliasReadonly = false;
 
 	@property({ type: Boolean, attribute: 'auto-generate-alias' })
 	autoGenerateAlias?: boolean;
@@ -75,11 +78,14 @@ export class UmbInputWithAliasElement extends UmbFormControlMixin<string>(UmbLit
 					@input=${this.#onAliasChange}
 					.value=${this.alias}
 					placeholder="Enter alias..."
-					?disabled=${this._aliasLocked}>
+					?disabled=${this._aliasLocked && !this.aliasReadonly}
+					?readonly=${this.aliasReadonly}>
 					<!-- TODO: validation for bad characters -->
-					<div @click=${this.#onToggleAliasLock} @keydown=${() => ''} id="alias-lock" slot="prepend">
-						<uui-icon name=${this._aliasLocked ? 'icon-lock' : 'icon-unlocked'}></uui-icon>
-					</div>
+					${this.aliasReadonly
+						? nothing
+						: html`<div @click=${this.#onToggleAliasLock} @keydown=${() => ''} id="alias-lock" slot="prepend">
+								<uui-icon name=${this._aliasLocked ? 'icon-lock' : 'icon-unlocked'}></uui-icon>
+							</div>`}
 				</uui-input>
 			</uui-input>
 		`;
@@ -105,6 +111,7 @@ export class UmbInputWithAliasElement extends UmbFormControlMixin<string>(UmbLit
 			justify-content: center;
 			cursor: pointer;
 		}
+
 		#alias-lock uui-icon {
 			margin-bottom: 2px;
 		}

--- a/src/packages/documents/document-types/workspace/document-type-workspace-editor.element.ts
+++ b/src/packages/documents/document-types/workspace/document-type-workspace-editor.element.ts
@@ -3,6 +3,7 @@ import type { UmbInputWithAliasElement } from '@umbraco-cms/backoffice/component
 import { umbFocus, UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { css, html, customElement, state, ifDefined } from '@umbraco-cms/backoffice/external/lit';
 import { UMB_MODAL_MANAGER_CONTEXT, UMB_ICON_PICKER_MODAL } from '@umbraco-cms/backoffice/modal';
+
 @customElement('umb-document-type-workspace-editor')
 export class UmbDocumentTypeWorkspaceEditorElement extends UmbLitElement {
 	@state()
@@ -69,7 +70,8 @@ export class UmbDocumentTypeWorkspaceEditorElement extends UmbLitElement {
 						label="name"
 						value=${this._name}
 						alias=${this._alias}
-						@change="${this.#onNameAndAliasChange}"></umb-input-with-alias>
+						@change="${this.#onNameAndAliasChange}"
+						${umbFocus()}></umb-input-with-alias>
 				</div>
 			</umb-workspace-editor>
 		`;

--- a/src/packages/documents/document-types/workspace/document-type-workspace-editor.element.ts
+++ b/src/packages/documents/document-types/workspace/document-type-workspace-editor.element.ts
@@ -16,7 +16,7 @@ export class UmbDocumentTypeWorkspaceEditorElement extends UmbLitElement {
 	private _icon?: string;
 
 	@state()
-	private _isNew?: string;
+	private _isNew?: boolean;
 
 	#workspaceContext?: typeof UMB_DOCUMENT_TYPE_WORKSPACE_CONTEXT.TYPE;
 

--- a/src/packages/documents/document-types/workspace/document-type-workspace-editor.element.ts
+++ b/src/packages/documents/document-types/workspace/document-type-workspace-editor.element.ts
@@ -15,6 +15,9 @@ export class UmbDocumentTypeWorkspaceEditorElement extends UmbLitElement {
 	@state()
 	private _icon?: string;
 
+	@state()
+	private _isNew?: string;
+
 	#workspaceContext?: typeof UMB_DOCUMENT_TYPE_WORKSPACE_CONTEXT.TYPE;
 
 	constructor() {
@@ -31,6 +34,7 @@ export class UmbDocumentTypeWorkspaceEditorElement extends UmbLitElement {
 		this.observe(this.#workspaceContext.name, (name) => (this._name = name), '_observeName');
 		this.observe(this.#workspaceContext.alias, (alias) => (this._alias = alias), '_observeAlias');
 		this.observe(this.#workspaceContext.icon, (icon) => (this._icon = icon), '_observeIcon');
+		this.observe(this.#workspaceContext.isNew, (isNew) => (this._isNew = isNew), '_observeIsNew');
 	}
 
 	private async _handleIconClick() {
@@ -70,6 +74,7 @@ export class UmbDocumentTypeWorkspaceEditorElement extends UmbLitElement {
 						label="name"
 						value=${this._name}
 						alias=${this._alias}
+						?auto-generate-alias=${this._isNew}
 						@change="${this.#onNameAndAliasChange}"
 						${umbFocus()}></umb-input-with-alias>
 				</div>

--- a/src/packages/documents/document-types/workspace/document-type-workspace-editor.element.ts
+++ b/src/packages/documents/document-types/workspace/document-type-workspace-editor.element.ts
@@ -1,10 +1,8 @@
 import { UMB_DOCUMENT_TYPE_WORKSPACE_CONTEXT } from './document-type-workspace.context-token.js';
+import type { UmbInputWithAliasElement } from '@umbraco-cms/backoffice/components';
 import { umbFocus, UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import type { UUIInputElement } from '@umbraco-cms/backoffice/external/uui';
-import { UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
 import { css, html, customElement, state, ifDefined } from '@umbraco-cms/backoffice/external/lit';
 import { UMB_MODAL_MANAGER_CONTEXT, UMB_ICON_PICKER_MODAL } from '@umbraco-cms/backoffice/modal';
-import { generateAlias } from '@umbraco-cms/backoffice/utils';
 @customElement('umb-document-type-workspace-editor')
 export class UmbDocumentTypeWorkspaceEditorElement extends UmbLitElement {
 	@state()
@@ -12,9 +10,6 @@ export class UmbDocumentTypeWorkspaceEditorElement extends UmbLitElement {
 
 	@state()
 	private _alias?: string;
-
-	@state()
-	private _aliasLocked = true;
 
 	@state()
 	private _icon?: string;
@@ -37,42 +32,6 @@ export class UmbDocumentTypeWorkspaceEditorElement extends UmbLitElement {
 		this.observe(this.#workspaceContext.icon, (icon) => (this._icon = icon), '_observeIcon');
 	}
 
-	// TODO. find a way where we don't have to do this for all workspaces.
-	#onNameChange(event: UUIInputEvent) {
-		if (event instanceof UUIInputEvent) {
-			const target = event.composedPath()[0] as UUIInputElement;
-
-			if (typeof target?.value === 'string') {
-				const oldName = this._name;
-				const oldAlias = this._alias;
-				const newName = event.target.value.toString();
-				if (this._aliasLocked) {
-					const expectedOldAlias = generateAlias(oldName ?? '');
-					// Only update the alias if the alias matches a generated alias of the old name (otherwise the alias is considered one written by the user.)
-					if (expectedOldAlias === oldAlias) {
-						this.#workspaceContext?.setAlias(generateAlias(newName));
-					}
-				}
-				this.#workspaceContext?.setName(target.value);
-			}
-		}
-	}
-
-	// TODO. find a way where we don't have to do this for all workspaces.
-	#onAliasChange(event: UUIInputEvent) {
-		if (event instanceof UUIInputEvent) {
-			const target = event.composedPath()[0] as UUIInputElement;
-			if (typeof target?.value === 'string') {
-				this.#workspaceContext?.setAlias(target.value);
-			}
-		}
-		event.stopPropagation();
-	}
-
-	#onToggleAliasLock() {
-		this._aliasLocked = !this._aliasLocked;
-	}
-
 	private async _handleIconClick() {
 		const [alias, color] = this._icon?.replace('color-', '')?.split(' ') ?? [];
 		const modalManager = await this.getContext(UMB_MODAL_MANAGER_CONTEXT);
@@ -92,6 +51,11 @@ export class UmbDocumentTypeWorkspaceEditorElement extends UmbLitElement {
 		});
 	}
 
+	#onNameAndAliasChange(event: InputEvent & { target: UmbInputWithAliasElement }) {
+		this.#workspaceContext?.setName(event.target.value ?? '');
+		this.#workspaceContext?.setAlias(event.target.alias ?? '');
+	}
+
 	render() {
 		return html`
 			<umb-workspace-editor alias="Umb.Workspace.DocumentType">
@@ -100,22 +64,12 @@ export class UmbDocumentTypeWorkspaceEditorElement extends UmbLitElement {
 						<umb-icon name=${ifDefined(this._icon)}></umb-icon>
 					</uui-button>
 
-					<uui-input id="name" label="name" .value=${this._name} @input="${this.#onNameChange}" ${umbFocus()}>
-						<!-- TODO: should use UUI-LOCK-INPUT, but that does not fire an event when its locked/unlocked -->
-						<uui-input
-							name="alias"
-							slot="append"
-							label="alias"
-							@input=${this.#onAliasChange}
-							.value=${this._alias}
-							placeholder="Enter alias..."
-							?disabled=${this._aliasLocked}>
-							<!-- TODO: validation for bad characters -->
-							<div @click=${this.#onToggleAliasLock} @keydown=${() => ''} id="alias-lock" slot="prepend">
-								<uui-icon name=${this._aliasLocked ? 'icon-lock' : 'icon-unlocked'}></uui-icon>
-							</div>
-						</uui-input>
-					</uui-input>
+					<umb-input-with-alias
+						id="name"
+						label="name"
+						value=${this._name}
+						alias=${this._alias}
+						@change="${this.#onNameAndAliasChange}"></umb-input-with-alias>
 				</div>
 			</umb-workspace-editor>
 		`;
@@ -136,18 +90,6 @@ export class UmbDocumentTypeWorkspaceEditorElement extends UmbLitElement {
 
 			#name {
 				width: 100%;
-				flex: 1 1 auto;
-				align-items: center;
-			}
-
-			#alias-lock {
-				display: flex;
-				align-items: center;
-				justify-content: center;
-				cursor: pointer;
-			}
-			#alias-lock uui-icon {
-				margin-bottom: 2px;
 			}
 
 			#icon {

--- a/src/packages/documents/document-types/workspace/document-type-workspace.context.ts
+++ b/src/packages/documents/document-types/workspace/document-type-workspace.context.ts
@@ -287,18 +287,18 @@ export class UmbDocumentTypeWorkspaceContext
 				this.setDefaultTemplate(templateEntity);
 			}
 
-			if ((await this.structure.create(parent.unique)) === true) {
-				// TODO: this might not be the right place to alert the tree, but it works for now
-				const eventContext = await this.getContext(UMB_ACTION_EVENT_CONTEXT);
-				const event = new UmbRequestReloadTreeItemChildrenEvent({
-					entityType: parent.entityType,
-					unique: parent.unique,
-				});
-				eventContext.dispatchEvent(event);
+			await this.structure.create(parent.unique);
 
-				this.setIsNew(false);
-				this.createTemplateMode = false;
-			}
+			// TODO: this might not be the right place to alert the tree, but it works for now
+			const eventContext = await this.getContext(UMB_ACTION_EVENT_CONTEXT);
+			const event = new UmbRequestReloadTreeItemChildrenEvent({
+				entityType: parent.entityType,
+				unique: parent.unique,
+			});
+			eventContext.dispatchEvent(event);
+
+			this.setIsNew(false);
+			this.createTemplateMode = false;
 		} else {
 			await this.structure.save();
 

--- a/src/packages/media/media-types/workspace/media-type-workspace-editor.element.ts
+++ b/src/packages/media/media-types/workspace/media-type-workspace-editor.element.ts
@@ -3,6 +3,7 @@ import { UMB_MEDIA_TYPE_WORKSPACE_CONTEXT } from './media-type-workspace.context
 import { css, html, customElement, state, ifDefined } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement, umbFocus } from '@umbraco-cms/backoffice/lit-element';
 import { UMB_ICON_PICKER_MODAL, UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
+import type { UmbInputWithAliasElement } from '@umbraco-cms/backoffice/components';
 
 @customElement('umb-media-type-workspace-editor')
 export class UmbMediaTypeWorkspaceEditorElement extends UmbLitElement {

--- a/src/packages/media/media-types/workspace/media-type-workspace-editor.element.ts
+++ b/src/packages/media/media-types/workspace/media-type-workspace-editor.element.ts
@@ -39,43 +39,6 @@ export class UmbMediaTypeWorkspaceEditorElement extends UmbLitElement {
 		this.observe(this.#workspaceContext.icon, (icon) => (this._icon = icon), '_observeIcon');
 	}
 
-	// TODO: find a way where we don't have to do this for all workspaces.
-	#onNameChange(event: UUIInputEvent) {
-		if (event instanceof UUIInputEvent) {
-			const target = event.composedPath()[0] as UUIInputElement;
-
-			if (typeof target?.value === 'string') {
-				const oldName = this._name;
-				const oldAlias = this._alias;
-				const newName = event.target.value.toString();
-				if (this._aliasLocked) {
-					const expectedOldAlias = generateAlias(oldName ?? '');
-					// Only update the alias if the alias matches a generated alias of the old name (otherwise the alias is considered one written by the user.)
-					if (expectedOldAlias === oldAlias) {
-						this.#workspaceContext?.setAlias(generateAlias(newName));
-					}
-				}
-				this.#workspaceContext?.setName(target.value);
-			}
-		}
-	}
-
-	// TODO: find a way where we don't have to do this for all workspaces.
-	#onAliasChange(event: UUIInputEvent) {
-		if (event instanceof UUIInputEvent) {
-			const target = event.composedPath()[0] as UUIInputElement;
-
-			if (typeof target?.value === 'string') {
-				this.#workspaceContext?.setAlias(target.value);
-			}
-		}
-		event.stopPropagation();
-	}
-
-	#onToggleAliasLock() {
-		this._aliasLocked = !this._aliasLocked;
-	}
-
 	private async _handleIconClick() {
 		const [alias, color] = this._icon?.replace('color-', '')?.split(' ') ?? [];
 
@@ -96,6 +59,11 @@ export class UmbMediaTypeWorkspaceEditorElement extends UmbLitElement {
 		});
 	}
 
+	#onNameAndAliasChange(event: InputEvent & { target: UmbInputWithAliasElement }) {
+		this.#workspaceContext?.setName(event.target.value ?? '');
+		this.#workspaceContext?.setAlias(event.target.alias ?? '');
+	}
+
 	render() {
 		return html`<umb-workspace-editor alias="Umb.Workspace.MediaType">
 			<div id="header" slot="header">
@@ -103,22 +71,12 @@ export class UmbMediaTypeWorkspaceEditorElement extends UmbLitElement {
 					<umb-icon name=${ifDefined(this._icon)}></umb-icon>
 				</uui-button>
 
-				<uui-input id="name" .value=${this._name} @input="${this.#onNameChange}" label="name" ${umbFocus()}>
-					<!-- TODO: should use UUI-LOCK-INPUT, but that does not fire an event when its locked/unlocked -->
-					<uui-input
-						name="alias"
-						slot="append"
-						label="alias"
-						@input=${this.#onAliasChange}
-						.value=${this._alias}
-						placeholder="Enter alias..."
-						?disabled=${this._aliasLocked}>
-						<!-- TODO: validation for bad characters -->
-						<div @click=${this.#onToggleAliasLock} @keydown=${() => ''} id="alias-lock" slot="prepend">
-							<uui-icon name=${this._aliasLocked ? 'icon-lock' : 'icon-unlocked'}></uui-icon>
-						</div>
-					</uui-input>
-				</uui-input>
+				<umb-input-with-alias
+					id="name"
+					label="name"
+					value=${this._name}
+					alias=${this._alias}
+					@change="${this.#onNameAndAliasChange}"></umb-input-with-alias>
 			</div>
 		</umb-workspace-editor>`;
 	}
@@ -138,18 +96,6 @@ export class UmbMediaTypeWorkspaceEditorElement extends UmbLitElement {
 
 			#name {
 				width: 100%;
-				flex: 1 1 auto;
-				align-items: center;
-			}
-
-			#alias-lock {
-				display: flex;
-				align-items: center;
-				justify-content: center;
-				cursor: pointer;
-			}
-			#alias-lock uui-icon {
-				margin-bottom: 2px;
 			}
 
 			#icon {

--- a/src/packages/media/media-types/workspace/media-type-workspace-editor.element.ts
+++ b/src/packages/media/media-types/workspace/media-type-workspace-editor.element.ts
@@ -18,6 +18,9 @@ export class UmbMediaTypeWorkspaceEditorElement extends UmbLitElement {
 	@state()
 	private _icon?: string;
 
+	@state()
+	private _isNew?: string;
+
 	#workspaceContext?: UmbMediaTypeWorkspaceContext;
 
 	constructor() {
@@ -34,6 +37,7 @@ export class UmbMediaTypeWorkspaceEditorElement extends UmbLitElement {
 		this.observe(this.#workspaceContext.name, (name) => (this._name = name), '_observeName');
 		this.observe(this.#workspaceContext.alias, (alias) => (this._alias = alias), '_observeAlias');
 		this.observe(this.#workspaceContext.icon, (icon) => (this._icon = icon), '_observeIcon');
+		this.observe(this.#workspaceContext.isNew, (isNew) => (this._isNew = isNew), '_observeIsNew');
 	}
 
 	private async _handleIconClick() {
@@ -73,6 +77,7 @@ export class UmbMediaTypeWorkspaceEditorElement extends UmbLitElement {
 					label="name"
 					value=${this._name}
 					alias=${this._alias}
+					?auto-generate-alias=${this._isNew}
 					@change="${this.#onNameAndAliasChange}"
 					${umbFocus()}></umb-input-with-alias>
 			</div>

--- a/src/packages/media/media-types/workspace/media-type-workspace-editor.element.ts
+++ b/src/packages/media/media-types/workspace/media-type-workspace-editor.element.ts
@@ -1,11 +1,8 @@
 import type { UmbMediaTypeWorkspaceContext } from './media-type-workspace.context.js';
 import { UMB_MEDIA_TYPE_WORKSPACE_CONTEXT } from './media-type-workspace.context-token.js';
-import type { UUIInputElement } from '@umbraco-cms/backoffice/external/uui';
-import { UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
 import { css, html, customElement, state, ifDefined } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement, umbFocus } from '@umbraco-cms/backoffice/lit-element';
 import { UMB_ICON_PICKER_MODAL, UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
-import { generateAlias } from '@umbraco-cms/backoffice/utils';
 
 @customElement('umb-media-type-workspace-editor')
 export class UmbMediaTypeWorkspaceEditorElement extends UmbLitElement {
@@ -76,7 +73,8 @@ export class UmbMediaTypeWorkspaceEditorElement extends UmbLitElement {
 					label="name"
 					value=${this._name}
 					alias=${this._alias}
-					@change="${this.#onNameAndAliasChange}"></umb-input-with-alias>
+					@change="${this.#onNameAndAliasChange}"
+					${umbFocus()}></umb-input-with-alias>
 			</div>
 		</umb-workspace-editor>`;
 	}

--- a/src/packages/media/media-types/workspace/media-type-workspace-editor.element.ts
+++ b/src/packages/media/media-types/workspace/media-type-workspace-editor.element.ts
@@ -19,7 +19,7 @@ export class UmbMediaTypeWorkspaceEditorElement extends UmbLitElement {
 	private _icon?: string;
 
 	@state()
-	private _isNew?: string;
+	private _isNew?: boolean;
 
 	#workspaceContext?: UmbMediaTypeWorkspaceContext;
 

--- a/src/packages/media/media-types/workspace/media-type-workspace.context.ts
+++ b/src/packages/media/media-types/workspace/media-type-workspace.context.ts
@@ -208,17 +208,15 @@ export class UmbMediaTypeWorkspaceContext
 			const parent = this.#parent.getValue();
 			if (!parent) throw new Error('Parent is not set');
 
-			if ((await this.structure.create(parent.unique)) === true) {
-				if (!parent) throw new Error('Parent is not set');
+			await this.structure.create(parent.unique);
 
-				const eventContext = await this.getContext(UMB_ACTION_EVENT_CONTEXT);
-				const event = new UmbRequestReloadTreeItemChildrenEvent({
-					entityType: parent.entityType,
-					unique: parent.unique,
-				});
-				eventContext.dispatchEvent(event);
-				this.setIsNew(false);
-			}
+			const eventContext = await this.getContext(UMB_ACTION_EVENT_CONTEXT);
+			const event = new UmbRequestReloadTreeItemChildrenEvent({
+				entityType: parent.entityType,
+				unique: parent.unique,
+			});
+			eventContext.dispatchEvent(event);
+			this.setIsNew(false);
 		} else {
 			await this.structure.save();
 

--- a/src/packages/members/member-type/workspace/member-type-workspace-editor.element.ts
+++ b/src/packages/members/member-type/workspace/member-type-workspace-editor.element.ts
@@ -1,4 +1,5 @@
 import { UMB_MEMBER_TYPE_WORKSPACE_CONTEXT } from './member-type-workspace.context-token.js';
+import type { UmbInputWithAliasElement } from '@umbraco-cms/backoffice/components';
 import { css, html, customElement, state, ifDefined } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement, umbFocus } from '@umbraco-cms/backoffice/lit-element';
 import { UMB_ICON_PICKER_MODAL, UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';

--- a/src/packages/members/member-type/workspace/member-type-workspace-editor.element.ts
+++ b/src/packages/members/member-type/workspace/member-type-workspace-editor.element.ts
@@ -15,7 +15,7 @@ export class UmbMemberTypeWorkspaceEditorElement extends UmbLitElement {
 	private _icon?: string;
 
 	@state()
-	private _isNew?: string;
+	private _isNew?: boolean;
 
 	@state()
 	private _iconColorAlias?: string;

--- a/src/packages/members/member-type/workspace/member-type-workspace-editor.element.ts
+++ b/src/packages/members/member-type/workspace/member-type-workspace-editor.element.ts
@@ -15,6 +15,9 @@ export class UmbMemberTypeWorkspaceEditorElement extends UmbLitElement {
 	private _icon?: string;
 
 	@state()
+	private _isNew?: string;
+
+	@state()
 	private _iconColorAlias?: string;
 	// TODO: Color should be using an alias, and look up in some dictionary/key/value) of project-colors.
 
@@ -34,18 +37,7 @@ export class UmbMemberTypeWorkspaceEditorElement extends UmbLitElement {
 		this.observe(this.#workspaceContext.name, (name) => (this._name = name), '_observeName');
 		this.observe(this.#workspaceContext.alias, (alias) => (this._alias = alias), '_observeAlias');
 		this.observe(this.#workspaceContext.icon, (icon) => (this._icon = icon), '_observeIcon');
-
-		this.observe(
-			this.#workspaceContext.isNew,
-			(isNew) => {
-				if (isNew) {
-					// TODO: Would be good with a more general way to bring focus to the name input.
-					(this.shadowRoot?.querySelector('#name') as HTMLElement)?.focus();
-				}
-				this.removeUmbControllerByAlias('_observeIsNew');
-			},
-			'_observeIsNew',
-		);
+		this.observe(this.#workspaceContext.isNew, (isNew) => (this._isNew = isNew), '_observeIsNew');
 	}
 
 	private async _handleIconClick() {
@@ -85,6 +77,7 @@ export class UmbMemberTypeWorkspaceEditorElement extends UmbLitElement {
 						label="name"
 						value=${this._name}
 						alias=${this._alias}
+						?auto-generate-alias=${this._isNew}
 						@change="${this.#onNameAndAliasChange}"
 						${umbFocus()}></umb-input-with-alias>
 				</div>


### PR DESCRIPTION
Input with alias component + fixing isNew implementations of ContentType Editors, as they were slightly off, this might fix a few known issues. Like not turning into edit when creating the contentTypes.

## Description

<!--- Describe the changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
