### PR TITLE
Adds different content for `Community` and `Support` blocks

### DIFF
--- a/.github/localization_overview.md
+++ b/.github/localization_overview.md
@@ -201,6 +201,7 @@ Then we need your help! With Bellissima we added new localization keys, and we s
 - documentationHeader
 - documentationDescription
 - communityHeader
+- communityDescription
 - trainingHeader
 - trainingDescription
 - supportHeader

--- a/src/assets/lang/da-dk.ts
+++ b/src/assets/lang/da-dk.ts
@@ -2464,10 +2464,10 @@ export default {
 	},
 	settingsDashboard: {
 		communityHeader: 'Community',
+		communityDescription: 'Stil et spørgsmål i community forummet eller i vores Discord community',
 		trainingHeader: 'Træning',
 		trainingDescription: 'Se mulighederne for real-life træning og certificering',
 		supportHeader: 'Support',
-		supportDescription: 'Stil et spørgsmål i community forummet eller i vores Discord community',
 		videosHeader: 'Videoer',
 		videosDescription:
 			'Se vores gratis tutortial videoer på Umbraco Learning Base YouTube-kanel, for hurtigt at komme i gang med Umbraco.',

--- a/src/assets/lang/en-us.ts
+++ b/src/assets/lang/en-us.ts
@@ -2305,10 +2305,12 @@ export default {
 		documentationHeader: 'Documentation',
 		documentationDescription: 'Read more about working with the items in Settings in our Documentation.',
 		communityHeader: 'Community',
+		communitytDescription: 'Ask a question in the community forum or our Discord community.',
+
 		trainingHeader: 'Training',
 		trainingDescription: 'Find out about real-life training and certification opportunities',
 		supportHeader: 'Support',
-		supportDescription: 'Ask a question in the community forum or our Discord community.',
+		supportDescription: 'Extend your team with a highly skilled and passionate bunch of Umbraco know-it-alls.',
 		videosHeader: 'Videos',
 		videosDescription:
 			'Watch our free tutorial videos on the Umbraco Learning Base YouTube channel, to get up to speed quickly with Umbraco.',

--- a/src/assets/lang/en.ts
+++ b/src/assets/lang/en.ts
@@ -2379,10 +2379,11 @@ export default {
 		documentationHeader: 'Documentation',
 		documentationDescription: 'Read more about working with the items in Settings in our Documentation.',
 		communityHeader: 'Community',
+		communityDescription: 'Ask a question in the community forum or our Discord community.',
 		trainingHeader: 'Training',
 		trainingDescription: 'Find out about real-life training and certification opportunities',
 		supportHeader: 'Support',
-		supportDescription: 'Ask a question in the community forum or our Discord community.',
+		supportDescription: 'Extend your team with a highly skilled and passionate bunch of Umbraco know-it-alls',
 		videosHeader: 'Videos',
 		videosDescription:
 			'Watch our free tutorial videos on the Umbraco Learning Base YouTube channel, to get up to speed quickly with Umbraco.',

--- a/src/packages/core/modal/common/icon-picker/icon-picker-modal.element.ts
+++ b/src/packages/core/modal/common/icon-picker/icon-picker-modal.element.ts
@@ -5,7 +5,7 @@ import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 
 import type { UmbIconPickerModalData, UmbIconPickerModalValue } from '@umbraco-cms/backoffice/modal';
 import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
-import { extractUmbColorVariable, umbracoColors } from '@umbraco-cms/backoffice/resources';
+import { extractUmbColorVariable, getUniqueUmbracoColors } from '@umbraco-cms/backoffice/resources';
 import { umbFocus } from '@umbraco-cms/backoffice/lit-element';
 import { UMB_ICON_REGISTRY_CONTEXT, type UmbIconDefinition } from '@umbraco-cms/backoffice/icon';
 
@@ -20,7 +20,7 @@ export class UmbIconPickerModalElement extends UmbModalBaseElement<UmbIconPicker
 	private _iconsFiltered?: Array<UmbIconDefinition>;
 
 	@state()
-	private _colorList = umbracoColors.filter((color) => !color.legacy);
+	private _colorList = getUniqueUmbracoColors();
 
 	@state()
 	private _currentIcon?: string;

--- a/src/packages/core/resources/extractUmbColorVariable.function.ts
+++ b/src/packages/core/resources/extractUmbColorVariable.function.ts
@@ -26,3 +26,15 @@ export function extractUmbColorVariable(colorAlias: string): string | undefined 
 	const found = umbracoColors.find((umbColor) => umbColor.alias === colorAlias);
 	return found?.varName;
 }
+
+
+/** 
+ * Gets `umbracoColors` unique by their `varName` property
+ */
+export function getUniqueUmbracoColors() {
+	const uniqueBy = 'varName'
+	const colorVariablesUniqueBy_varName = [...new Map(umbracoColors.map(item => 
+		[item[uniqueBy], item]
+	)).values()];
+	return colorVariablesUniqueBy_varName;
+}

--- a/src/packages/core/settings/welcome-dashboard/settings-welcome-dashboard.element.ts
+++ b/src/packages/core/settings/welcome-dashboard/settings-welcome-dashboard.element.ts
@@ -25,7 +25,7 @@ export class UmbSettingsWelcomeDashboardElement extends UmbLitElement {
 				<uui-box>
 					<h1 class="uui-h3"><umb-localize key="settingsDashboard_communityHeader">Community</umb-localize></h1>
 					<p>
-						<umb-localize key="settingsDashboard_supportDescription">
+						<umb-localize key="settingsDashboard_communityDescription">
 							Ask a question in the community forum or our Discord community
 						</umb-localize>
 					</p>
@@ -64,7 +64,7 @@ export class UmbSettingsWelcomeDashboardElement extends UmbLitElement {
 
 					<p>
 						<umb-localize key="settingsDashboard_supportDescription">
-							Ask a question in the community forum or our Discord community.
+						Extend your team with a highly skilled and passionate bunch of Umbraco know-it-alls
 						</umb-localize>
 					</p>
 					<uui-button


### PR DESCRIPTION
Adds different content for `Community` and `Support` blocks in the Settings->Welcome dashboard

See issue here: https://github.com/umbraco/Umbraco-CMS/issues/16209


## Description
- Updates the localization in the _Community_ widget so that it pulls from a new `communityDescription` property
- Updates the text in the _Support_ widget so that it reads "Extend your team with a highly skilled and passionate bunch of Umbraco know-it-alls" (text taken from here https://umbraco.com/products/support/ )
- Removed the `dk` file's entry for `supportDescription` (I'm not a native speaker, so wouldn't want to attempt a translation)

## Types of changes

localization + content

- [ ✅ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/7046713/54c08724-fe40-44ae-a8d0-e8616d2cdeef)

## How to test?

Open the Settings tab, see new content
https://localhost:44320/umbraco/section/settings/dashboard/welcome 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ✅ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ✅] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ❌ ] I have added tests to cover my changes.
