### PR TITLE
Umbraco-CMS/issues/16205 - multiple black color options in icon picker

### DIFF
--- a/src/packages/core/modal/common/icon-picker/icon-picker-modal.element.ts
+++ b/src/packages/core/modal/common/icon-picker/icon-picker-modal.element.ts
@@ -5,7 +5,7 @@ import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 
 import type { UmbIconPickerModalData, UmbIconPickerModalValue } from '@umbraco-cms/backoffice/modal';
 import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
-import { extractUmbColorVariable, umbracoColors } from '@umbraco-cms/backoffice/resources';
+import { extractUmbColorVariable, getUniqueUmbracoColors } from '@umbraco-cms/backoffice/resources';
 import { umbFocus } from '@umbraco-cms/backoffice/lit-element';
 import { UMB_ICON_REGISTRY_CONTEXT, type UmbIconDefinition } from '@umbraco-cms/backoffice/icon';
 
@@ -20,7 +20,7 @@ export class UmbIconPickerModalElement extends UmbModalBaseElement<UmbIconPicker
 	private _iconsFiltered?: Array<UmbIconDefinition>;
 
 	@state()
-	private _colorList = umbracoColors.filter((color) => !color.legacy);
+	private _colorList = getUniqueUmbracoColors();
 
 	@state()
 	private _currentIcon?: string;

--- a/src/packages/core/resources/extractUmbColorVariable.function.ts
+++ b/src/packages/core/resources/extractUmbColorVariable.function.ts
@@ -26,3 +26,15 @@ export function extractUmbColorVariable(colorAlias: string): string | undefined 
 	const found = umbracoColors.find((umbColor) => umbColor.alias === colorAlias);
 	return found?.varName;
 }
+
+
+/** 
+ * Gets `umbracoColors` unique by their `varName` property
+ */
+export function getUniqueUmbracoColors() {
+	const uniqueBy = 'varName'
+	const colorVariablesUniqueBy_varName = [...new Map(umbracoColors.map(item => 
+		[item[uniqueBy], item]
+	)).values()];
+	return colorVariablesUniqueBy_varName;
+}


### PR DESCRIPTION
Filters the list of `umbracoColors` in `src\packages\core\resources\extractUmbColorVariable.function.ts` so that users are only presented with unique colours.

https://github.com/umbraco/Umbraco-CMS/issues/16205


## Description

In the icon picker, users are currently offered two `black` options, as the file `src\packages\core\resources\extractUmbColorVariable.function.ts` contains two entries with identical `varName` properties: 

```typescript
export const umbracoColors = [
	{ alias: 'text', varName: '--uui-color-text' },
	{ alias: 'black', varName: '--uui-color-text' },
```

I've added a function to get the same umbracoColor set, but filtered to be unique by `varName`: 


```typescript
/** 
 * Gets `umbracoColors` unique by their `varName` property
 */
export function getUniqueUmbracoColors() {
	const uniqueBy = 'varName'
	const colorVariablesUniqueBy_varName = [...new Map(umbracoColors.map(item => 
		[item[uniqueBy], item]
	)).values()];
	return colorVariablesUniqueBy_varName;
}
```


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ✅ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

This may cause users upgrading from RC2 to RC3 to encounter errors, if for example they've selected `umbracoColors.black`, and it's filtered out of the list. 

## Motivation and context
![327355868-593e3217-cc38-47a1-934e-2f02db1dc063](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/7046713/e78fe42d-cc70-4fae-890e-08a7d481ffc2)

## How to test?

Open a _Select Icon_ window, and check the first two colours are `text` then `yellow`, instead of `text` then `black`

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ✅ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
