### PR TITLE
remove the unused 'allowDecimals' configuration and the "Integer" property editor

### DIFF
--- a/src/mocks/data/data-type/data-type.data.ts
+++ b/src/mocks/data/data-type/data-type.data.ts
@@ -985,7 +985,7 @@ export const data: Array<UmbMockDataTypeModel> = [
 		id: 'dt-integer',
 		parent: null,
 		editorAlias: 'Umbraco.Integer',
-		editorUiAlias: 'Umb.PropertyEditorUi.Integer',
+		editorUiAlias: 'Umb.PropertyEditorUi.Number',
 		hasChildren: false,
 		isFolder: false,
 		isDeletable: true,

--- a/src/packages/property-editors/number/Umbraco.Integer.ts
+++ b/src/packages/property-editors/number/Umbraco.Integer.ts
@@ -6,7 +6,7 @@ export const manifests: Array<ManifestTypes> = [
 		name: 'Integer',
 		alias: 'Umbraco.Integer',
 		meta: {
-			defaultPropertyEditorUiAlias: 'Umb.PropertyEditorUi.Integer',
+			defaultPropertyEditorUiAlias: 'Umb.PropertyEditorUi.Number',
 			settings: {
 				properties: [
 					{

--- a/src/packages/property-editors/number/manifests.ts
+++ b/src/packages/property-editors/number/manifests.ts
@@ -2,35 +2,7 @@ import { manifests as decimalSchemaManifests } from './Umbraco.Decimal.js';
 import { manifests as integerSchemaManifests } from './Umbraco.Integer.js';
 import type { ManifestTypes } from '@umbraco-cms/backoffice/extension-registry';
 
-// TODO: we don't really want this config value to be changed from the UI. We need a way to handle hidden config properties.
-const allowDecimalsConfig = {
-	alias: 'allowDecimals',
-	label: 'Allow decimals',
-	propertyEditorUiAlias: 'Umb.PropertyEditorUi.Toggle',
-};
-
 export const manifests: Array<ManifestTypes> = [
-	{
-		type: 'propertyEditorUi',
-		alias: 'Umb.PropertyEditorUi.Integer',
-		name: 'Integer Property Editor UI',
-		element: () => import('./property-editor-ui-number.element.js'),
-		meta: {
-			label: 'Integer',
-			propertyEditorSchemaAlias: 'Umbraco.Integer',
-			icon: 'icon-autofill',
-			group: 'common',
-			settings: {
-				properties: [allowDecimalsConfig],
-				defaultData: [
-					{
-						alias: 'allowDecimals',
-						value: false,
-					},
-				],
-			},
-		},
-	},
 	{
 		type: 'propertyEditorUi',
 		alias: 'Umb.PropertyEditorUi.Decimal',
@@ -42,12 +14,8 @@ export const manifests: Array<ManifestTypes> = [
 			icon: 'icon-autofill',
 			group: 'common',
 			settings: {
-				properties: [allowDecimalsConfig],
+				properties: [],
 				defaultData: [
-					{
-						alias: 'allowDecimals',
-						value: true,
-					},
 					{
 						alias: 'step',
 						value: '0.01',


### PR DESCRIPTION
this aligns the "numeric" and "decimal" property editors with V13

fixes #1660