### PR TITLE
`property-value-change` should not be hardcoded

### DIFF
--- a/src/packages/block/block-grid/property-editors/block-grid-column-span/property-editor-ui-block-grid-column-span.element.ts
+++ b/src/packages/block/block-grid/property-editors/block-grid-column-span/property-editor-ui-block-grid-column-span.element.ts
@@ -2,7 +2,10 @@ import type { UmbBlockGridTypeColumnSpanOption } from '../../types.js';
 import { html, customElement, property, css, state, repeat } from '@umbraco-cms/backoffice/external/lit';
 import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
+import {
+	UmbPropertyValueChangeEvent,
+	type UmbPropertyEditorConfigCollection,
+} from '@umbraco-cms/backoffice/property-editor';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 
 @customElement('umb-property-editor-ui-block-grid-column-span')
@@ -30,7 +33,7 @@ export class UmbPropertyEditorUIBlockGridColumnSpanElement extends UmbLitElement
 			this.value = [...value, { columnSpan: index }];
 		}
 
-		this.dispatchEvent(new CustomEvent('property-value-change'));
+		this.dispatchEvent(new UmbPropertyValueChangeEvent());
 	}
 
 	render() {

--- a/src/packages/block/block-grid/property-editors/block-grid-group-configuration/property-editor-ui-block-grid-group-configuration.element.ts
+++ b/src/packages/block/block-grid/property-editors/block-grid-group-configuration/property-editor-ui-block-grid-group-configuration.element.ts
@@ -1,7 +1,10 @@
 import { html, customElement, property, css } from '@umbraco-cms/backoffice/external/lit';
 import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
+import {
+	UmbPropertyValueChangeEvent,
+	type UmbPropertyEditorConfigCollection,
+} from '@umbraco-cms/backoffice/property-editor';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { UmbId } from '@umbraco-cms/backoffice/id';
 import type { UmbBlockGridTypeGroupType } from '@umbraco-cms/backoffice/block-grid';
@@ -25,7 +28,7 @@ export class UmbPropertyEditorUIBlockGridGroupConfigurationElement
 
 	#addGroup() {
 		this.value = [...this._value, { name: 'Unnamed group', key: UmbId.new() }];
-		this.dispatchEvent(new CustomEvent('property-value-change'));
+		this.dispatchEvent(new UmbPropertyValueChangeEvent());
 	}
 
 	render() {

--- a/src/packages/block/block-grid/property-editors/block-grid-layout-stylesheet/property-editor-ui-block-grid-layout-stylesheet.element.ts
+++ b/src/packages/block/block-grid/property-editors/block-grid-layout-stylesheet/property-editor-ui-block-grid-layout-stylesheet.element.ts
@@ -6,7 +6,10 @@ import '@umbraco-cms/backoffice/static-file';
 import { html, customElement, property } from '@umbraco-cms/backoffice/external/lit';
 import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
+import {
+	UmbPropertyValueChangeEvent,
+	type UmbPropertyEditorConfigCollection,
+} from '@umbraco-cms/backoffice/property-editor';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 
 @customElement('umb-property-editor-ui-block-grid-layout-stylesheet')
@@ -29,7 +32,7 @@ export class UmbPropertyEditorUIBlockGridLayoutStylesheetElement
 
 	private _onChange(event: CustomEvent) {
 		this.value = (event.target as UmbInputStaticFileElement).selection;
-		this.dispatchEvent(new CustomEvent('property-value-change'));
+		this.dispatchEvent(new UmbPropertyValueChangeEvent());
 	}
 
 	// TODO: Implement mandatory?

--- a/src/packages/markdown-editor/property-editors/markdown-editor/property-editor-ui-markdown-editor.element.ts
+++ b/src/packages/markdown-editor/property-editors/markdown-editor/property-editor-ui-markdown-editor.element.ts
@@ -29,7 +29,7 @@ export class UmbPropertyEditorUIMarkdownEditorElement extends UmbLitElement impl
 
 	#onChange(e: Event) {
 		this.value = (e.target as UmbInputMarkdownElement).value as string;
-		this.dispatchEvent(new CustomEvent('property-value-change'));
+		this.dispatchEvent(new UmbPropertyValueChangeEvent());
 	}
 
 	render() {

--- a/src/packages/media/media/property-editors/image-crops-configuration/property-editor-ui-image-crops-configuration.element.ts
+++ b/src/packages/media/media/property-editors/image-crops-configuration/property-editor-ui-image-crops-configuration.element.ts
@@ -2,6 +2,7 @@ import { html, customElement, property, css, repeat, state } from '@umbraco-cms/
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { UmbPropertyValueChangeEvent } from '@umbraco-cms/backoffice/property-editor';
 
 export type UmbCrop = {
 	label: string;
@@ -27,7 +28,7 @@ export class UmbPropertyEditorUIImageCropsConfigurationElement
 
 	#onRemove(alias: string) {
 		this.value = [...this.value.filter((item) => item.alias !== alias)];
-		this.dispatchEvent(new CustomEvent('property-value-change'));
+		this.dispatchEvent(new UmbPropertyValueChangeEvent());
 	}
 
 	#onEdit(crop: UmbCrop) {
@@ -88,7 +89,7 @@ export class UmbPropertyEditorUIImageCropsConfigurationElement
 		} else {
 			this.value = [...this.value, newCrop];
 		}
-		this.dispatchEvent(new CustomEvent('property-value-change'));
+		this.dispatchEvent(new UmbPropertyValueChangeEvent());
 
 		form.reset();
 	}

--- a/src/packages/property-editors/icon-picker/property-editor-ui-icon-picker.element.ts
+++ b/src/packages/property-editors/icon-picker/property-editor-ui-icon-picker.element.ts
@@ -3,6 +3,7 @@ import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extensi
 import { UMB_MODAL_MANAGER_CONTEXT, UMB_ICON_PICKER_MODAL } from '@umbraco-cms/backoffice/modal';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { extractUmbColorVariable } from '@umbraco-cms/backoffice/resources';
+import { UmbPropertyValueChangeEvent } from '@umbraco-cms/backoffice/property-editor';
 
 /**
  * @element umb-property-editor-ui-icon-picker
@@ -46,7 +47,7 @@ export class UmbPropertyEditorUIIconPickerElement extends UmbLitElement implemen
 			this.value = data.icon as string;
 		}
 
-		this.dispatchEvent(new CustomEvent('property-value-change'));
+		this.dispatchEvent(new UmbPropertyValueChangeEvent());
 	}
 
 	render() {

--- a/src/packages/property-editors/overlay-size/property-editor-ui-overlay-size.element.ts
+++ b/src/packages/property-editors/overlay-size/property-editor-ui-overlay-size.element.ts
@@ -1,7 +1,10 @@
 import { html, customElement, property, state } from '@umbraco-cms/backoffice/external/lit';
 import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
+import {
+	UmbPropertyValueChangeEvent,
+	type UmbPropertyEditorConfigCollection,
+} from '@umbraco-cms/backoffice/property-editor';
 import type { UUIModalSidebarSize, UUISelectEvent } from '@umbraco-cms/backoffice/external/uui';
 
 /**
@@ -33,7 +36,7 @@ export class UmbPropertyEditorUIOverlaySizeElement extends UmbLitElement impleme
 
 	#onChange(event: UUISelectEvent) {
 		this.value = event.target.value as string;
-		this.dispatchEvent(new CustomEvent('property-value-change'));
+		this.dispatchEvent(new UmbPropertyValueChangeEvent());
 	}
 
 	render() {

--- a/src/packages/property-editors/text-box/property-editor-ui-text-box.element.ts
+++ b/src/packages/property-editors/text-box/property-editor-ui-text-box.element.ts
@@ -9,7 +9,10 @@ import {
 } from '@umbraco-cms/backoffice/external/lit';
 import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
+import {
+	UmbPropertyValueChangeEvent,
+	type UmbPropertyEditorConfigCollection,
+} from '@umbraco-cms/backoffice/property-editor';
 import type { UUIInputElement } from '@umbraco-cms/backoffice/external/uui';
 import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 
@@ -50,7 +53,7 @@ export class UmbPropertyEditorUITextBoxElement
 		const newValue = (e.target as HTMLInputElement).value;
 		if (newValue === this.value) return;
 		this.value = newValue;
-		this.dispatchEvent(new CustomEvent('property-value-change'));
+		this.dispatchEvent(new UmbPropertyValueChangeEvent());
 	}
 
 	render() {

--- a/src/packages/property-editors/textarea/property-editor-ui-textarea.element.ts
+++ b/src/packages/property-editors/textarea/property-editor-ui-textarea.element.ts
@@ -2,7 +2,10 @@ import { css, html, customElement, property, state, ifDefined, styleMap } from '
 import type { UUITextareaElement } from '@umbraco-cms/backoffice/external/uui';
 import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
+import {
+	UmbPropertyValueChangeEvent,
+	type UmbPropertyEditorConfigCollection,
+} from '@umbraco-cms/backoffice/property-editor';
 
 @customElement('umb-property-editor-ui-textarea')
 export class UmbPropertyEditorUITextareaElement extends UmbLitElement implements UmbPropertyEditorUiElement {
@@ -38,7 +41,7 @@ export class UmbPropertyEditorUITextareaElement extends UmbLitElement implements
 
 	private onInput(e: InputEvent) {
 		this.value = (e.target as UUITextareaElement).value as string;
-		this.dispatchEvent(new CustomEvent('property-value-change'));
+		this.dispatchEvent(new UmbPropertyValueChangeEvent());
 	}
 
 	render() {

--- a/src/packages/property-editors/upload-field/property-editor-ui-upload-field.element.ts
+++ b/src/packages/property-editors/upload-field/property-editor-ui-upload-field.element.ts
@@ -2,7 +2,10 @@ import type { UmbInputUploadFieldElement } from '../../core/components/input-upl
 import { html, customElement, property, state } from '@umbraco-cms/backoffice/external/lit';
 import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
+import {
+	UmbPropertyValueChangeEvent,
+	type UmbPropertyEditorConfigCollection,
+} from '@umbraco-cms/backoffice/property-editor';
 
 /**
  * @element umb-property-editor-ui-upload-field
@@ -28,7 +31,7 @@ export class UmbPropertyEditorUIUploadFieldElement extends UmbLitElement impleme
 
 	private _onChange(event: CustomEvent) {
 		this.value = (event.target as unknown as UmbInputUploadFieldElement).value as string;
-		this.dispatchEvent(new CustomEvent('property-value-change'));
+		this.dispatchEvent(new UmbPropertyValueChangeEvent());
 	}
 
 	render() {

--- a/src/packages/property-editors/value-type/property-editor-ui-value-type.element.ts
+++ b/src/packages/property-editors/value-type/property-editor-ui-value-type.element.ts
@@ -2,7 +2,10 @@ import { html, customElement, property, state, query } from '@umbraco-cms/backof
 import type { UUISelectElement, UUISelectEvent } from '@umbraco-cms/backoffice/external/uui';
 import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
+import {
+	UmbPropertyValueChangeEvent,
+	type UmbPropertyEditorConfigCollection,
+} from '@umbraco-cms/backoffice/property-editor';
 
 /**
  * @element umb-property-editor-ui-value-type
@@ -46,7 +49,7 @@ export class UmbPropertyEditorUIValueTypeElement extends UmbLitElement implement
 
 	#onChange(e: UUISelectEvent) {
 		this.value = e.target.value as string;
-		this.dispatchEvent(new CustomEvent('property-value-change'));
+		this.dispatchEvent(new UmbPropertyValueChangeEvent());
 	}
 
 	render() {

--- a/src/packages/static-file/property-editors/static-file-picker/property-editor-ui-static-file-picker.element.ts
+++ b/src/packages/static-file/property-editors/static-file-picker/property-editor-ui-static-file-picker.element.ts
@@ -2,7 +2,10 @@ import type { UmbInputStaticFileElement } from '../../components/index.js';
 import { html, customElement, property, state } from '@umbraco-cms/backoffice/external/lit';
 import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
+import {
+	UmbPropertyValueChangeEvent,
+	type UmbPropertyEditorConfigCollection,
+} from '@umbraco-cms/backoffice/property-editor';
 import '../../components/input-static-file/index.js';
 
 @customElement('umb-property-editor-ui-static-file-picker')
@@ -31,7 +34,7 @@ export class UmbPropertyEditorUIStaticFilePickerElement extends UmbLitElement im
 
 	private _onChange(event: CustomEvent) {
 		this.value = (event.target as UmbInputStaticFileElement).selection;
-		this.dispatchEvent(new CustomEvent('property-value-change'));
+		this.dispatchEvent(new UmbPropertyValueChangeEvent());
 	}
 
 	// TODO: Implement mandatory?

--- a/src/packages/tags/property-editors/tags/property-editor-ui-tags.element.ts
+++ b/src/packages/tags/property-editors/tags/property-editor-ui-tags.element.ts
@@ -1,7 +1,10 @@
 import type { UmbTagsInputElement } from '../../components/tags-input/tags-input.element.js';
 import { UMB_PROPERTY_CONTEXT } from '@umbraco-cms/backoffice/property';
 import { html, customElement, property, state, ifDefined } from '@umbraco-cms/backoffice/external/lit';
-import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
+import {
+	UmbPropertyValueChangeEvent,
+	type UmbPropertyEditorConfigCollection,
+} from '@umbraco-cms/backoffice/property-editor';
 import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 
@@ -51,7 +54,7 @@ export class UmbPropertyEditorUITagsElement extends UmbLitElement implements Umb
 
 	#onChange(event: CustomEvent) {
 		this.value = ((event.target as UmbTagsInputElement).value as string).split(',');
-		this.dispatchEvent(new CustomEvent('property-value-change'));
+		this.dispatchEvent(new UmbPropertyValueChangeEvent());
 	}
 
 	render() {

--- a/src/packages/tiny-mce/property-editors/toolbar/property-editor-ui-tiny-mce-toolbar-configuration.element.ts
+++ b/src/packages/tiny-mce/property-editors/toolbar/property-editor-ui-tiny-mce-toolbar-configuration.element.ts
@@ -5,7 +5,10 @@ import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extension-registry';
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { firstValueFrom } from '@umbraco-cms/backoffice/external/rxjs';
-import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
+import {
+	UmbPropertyValueChangeEvent,
+	type UmbPropertyEditorConfigCollection,
+} from '@umbraco-cms/backoffice/property-editor';
 import { tinymce } from '@umbraco-cms/backoffice/external/tinymce';
 
 const tinyIconSet = tinymce.IconManager.get('default');
@@ -106,7 +109,7 @@ export class UmbPropertyEditorUITinyMceToolbarConfigurationElement
 
 		this.value = value;
 
-		this.dispatchEvent(new CustomEvent('property-value-change'));
+		this.dispatchEvent(new UmbPropertyValueChangeEvent());
 	}
 
 	render() {


### PR DESCRIPTION
this updates (essentially search/replaces) all instances of hardcoded `property-value-change` with the `UmbPropertyValueChangeEvent` class