### PR TITLE
fix: ensure any property editor UIs save their initial value on the context

### DIFF
--- a/src/packages/core/property/property/property.element.ts
+++ b/src/packages/core/property/property/property.element.ts
@@ -234,7 +234,10 @@ export class UmbPropertyElement extends UmbLitElement {
 				this.#valueObserver = this.observe(
 					this.#propertyContext.value,
 					(value) => {
+						// Set the value on the element:
 						this._element!.value = value;
+						// Set the value on the context as well, to ensure that any default values are stored right away:
+						this.#propertyContext.setValue(value);
 						if (this.#validationMessageBinder) {
 							this.#validationMessageBinder.value = value;
 						}


### PR DESCRIPTION
## Description
This ensures that if, say, a textarea is saved with "rows=10" without touching the input box at all

**Before**
![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/752371/1870e9f7-d1b2-4bb0-830e-bce67d0ae03c)

**After**
![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/752371/3a466314-ed7b-4bca-aef5-3cd7aee87682)

## How to test
1. Create a new data type
2. Select textarea
3. Hit save
4. Verify that the default configuration is saved, i.e. rows=10