### PR TITLE
Fix: Umbraco.DatePicker should not care about timezones

### DIFF
--- a/src/assets/lang/en.ts
+++ b/src/assets/lang/en.ts
@@ -641,6 +641,7 @@ export default {
 		entername: 'Enter a name...',
 		enteremail: 'Enter an email...',
 		enterusername: 'Enter a username...',
+		enterdate: 'Set a date...',
 		label: 'Label...',
 		enterDescription: 'Enter a description...',
 		search: 'Type to search...',

--- a/src/packages/core/components/input-date/input-date.element.ts
+++ b/src/packages/core/components/input-date/input-date.element.ts
@@ -1,9 +1,18 @@
-import { html, customElement, property } from '@umbraco-cms/backoffice/external/lit';
+import { html, customElement, property, ifDefined } from '@umbraco-cms/backoffice/external/lit';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import type { UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
 
+/**
+ * This element passes a datetime string to a regular HTML input element.
+ *
+ * @remark Be aware that you cannot include a time demonination, i.e. "10:44:00" if you
+ * set the input type of this element to "date". If you do, the browser will not show
+ * the value at all.
+ *
+ * @element umb-input-date
+ */
 @customElement('umb-input-date')
 export class UmbInputDateElement extends UUIFormControlMixin(UmbLitElement, '') {
 	protected getFormElement() {
@@ -20,9 +29,6 @@ export class UmbInputDateElement extends UUIFormControlMixin(UmbLitElement, '') 
 	type: 'date' | 'time' | 'datetime-local' = 'date';
 
 	@property({ type: String })
-	displayValue?: string;
-
-	@property({ type: String })
 	min?: string;
 
 	@property({ type: String })
@@ -31,59 +37,20 @@ export class UmbInputDateElement extends UUIFormControlMixin(UmbLitElement, '') 
 	@property({ type: Number })
 	step?: number;
 
-	connectedCallback(): void {
-		super.connectedCallback();
-
-		if (!this.value) return;
-		this.displayValue = this.#UTCToLocal(this.value as string);
-	}
-
-	#localToUTC(date: string) {
-		if (this.type === 'time') {
-			return new Date(`${new Date().toJSON().slice(0, 10)} ${date}`).toISOString().slice(11, 16);
-		} else {
-			return new Date(date).toJSON();
-		}
-	}
-
-	#UTCToLocal(d: string) {
-		if (this.type === 'time') {
-			const local = new Date(`${new Date().toJSON().slice(0, 10)} ${d}Z`)
-				.toLocaleTimeString(undefined, { hourCycle: 'h23' })
-				.slice(0, 5);
-			return local;
-		} else {
-			const timezoneReset = `${d.replace('Z', '')}Z`;
-			const date = new Date(timezoneReset);
-
-			const dateString = `${date.getFullYear()}-${('0' + (date.getMonth() + 1)).slice(-2)}-${(
-				'0' + date.getDate()
-			).slice(-2)}T${('0' + date.getHours()).slice(-2)}:${('0' + date.getMinutes()).slice(-2)}:${(
-				'0' + date.getSeconds()
-			).slice(-2)}`;
-
-			return this.type === 'datetime-local' ? dateString : `${dateString.substring(0, 10)}`;
-		}
-	}
-
 	#onChange(event: UUIInputEvent) {
-		const newValue = event.target.value as string;
-		if (!newValue) return;
-
-		this.value = this.#localToUTC(newValue);
-		this.displayValue = newValue;
+		this.value = event.target.value;
 		this.dispatchEvent(new UmbChangeEvent());
 	}
 
 	render() {
 		return html`<uui-input
 			id="datetime"
-			label="Pick a date or time"
-			.min=${this.min}
-			.max=${this.max}
-			.step=${this.step}
-			.type=${this.type}
-			.value="${this.displayValue?.replace('Z', '')}"
+			label=${this.localize.term('placeholders_enterdate')}
+			min=${ifDefined(this.min)}
+			max=${ifDefined(this.max)}
+			step=${ifDefined(this.step)}
+			type=${this.type}
+			value=${ifDefined(this.value)}
 			@change=${this.#onChange}>
 		</uui-input>`;
 	}

--- a/src/packages/property-editors/date-picker/property-editor-ui-date-picker.element.ts
+++ b/src/packages/property-editors/date-picker/property-editor-ui-date-picker.element.ts
@@ -40,14 +40,7 @@ export class UmbPropertyEditorUIDatePickerElement extends UmbLitElement implemen
 	private _step?: number;
 
 	@property()
-	set value(value: string | undefined) {
-		// Replace the potential time demoninator 'T' with a whitespace for backwards compatibility
-		this.#value = value?.replace('T', ' ');
-	}
-	get value() {
-		return this.#value;
-	}
-	#value?: string;
+	value?: string;
 
 	public set config(config: UmbPropertyEditorConfigCollection | undefined) {
 		if (!config) return;
@@ -67,20 +60,37 @@ export class UmbPropertyEditorUIDatePickerElement extends UmbLitElement implemen
 		this._max = config.getValueByAlias('max');
 		this._step = config.getValueByAlias('step');
 
-		// If the inputType is 'date', we need to make sure the value doesn't have a time
-		if (this._inputType === 'date' && this.value?.includes(' ')) {
-			this.value = this.value.split(' ')[0];
-		}
-
-		// If the inputType is 'time', we need to remove the date part of the value
-		if (this._inputType === 'time' && this.value?.includes(' ')) {
-			this.value = this.value.split(' ')[1];
+		if (this.value) {
+			this.#formatValue(this.value);
 		}
 	}
 
 	#onChange(event: CustomEvent & { target: UmbInputDateElement }) {
-		this.value = event.target.value.toString();
-		this.dispatchEvent(new UmbPropertyValueChangeEvent());
+		this.#formatValue(event.target.value.toString());
+	}
+
+	/**
+	 * Formats the value depending on the input type.
+	 */
+	#formatValue(value: string) {
+		// Replace the potential time demoninator 'T' with a whitespace for backwards compatibility
+		value = value.replace('T', ' ');
+
+		// If the inputType is 'date', we need to make sure the value doesn't have a time
+		if (this._inputType === 'date' && value.includes(' ')) {
+			value = value.split(' ')[0];
+		}
+
+		// If the inputType is 'time', we need to remove the date part of the value
+		if (this._inputType === 'time' && value.includes(' ')) {
+			value = value.split(' ')[1];
+		}
+
+		const valueHasChanged = this.value !== value;
+		if (valueHasChanged) {
+			this.value = value;
+			this.dispatchEvent(new UmbPropertyValueChangeEvent());
+		}
 	}
 
 	render() {

--- a/src/packages/property-editors/date-picker/property-editor-ui-date-picker.element.ts
+++ b/src/packages/property-editors/date-picker/property-editor-ui-date-picker.element.ts
@@ -6,6 +6,23 @@ import type { UmbInputDateElement } from '@umbraco-cms/backoffice/components';
 import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extension-registry';
 
 /**
+ * This property editor allows the user to pick a date, datetime-local, or time.
+ * It uses raw datetime strings back and forth, and therefore it has no knowledge
+ * of timezones. It uses a regular HTML input element underneath, which supports the known
+ * definitions of "date", "datetime-local", and "time".
+ *
+ * The underlying input element reports the value differently depending on the type configuration. Here
+ * are some examples from the change event:
+ *
+ * date: 2024-05-03
+ * datetime-local: 2024-05-03T10:44
+ * time: 10:44
+ *
+ * These values are approximately similar to what Umbraco expects for the Umbraco.DateTime
+ * data editor with one exception: the "T" character in "datetime-local". To be backwards compatible, we are
+ * replacing the T character with a whitespace, which also happens to work just fine
+ * with the "datetime-local" type.
+ *
  * @element umb-property-editor-ui-date-picker
  */
 @customElement('umb-property-editor-ui-date-picker')
@@ -24,11 +41,9 @@ export class UmbPropertyEditorUIDatePickerElement extends UmbLitElement implemen
 
 	@property()
 	set value(value: string | undefined) {
-		if (value) {
-			// NOTE: If the `value` contains a space, then it doesn't contain the timezone, so may not be parsed as UTC. [LK]
-			const datetime = !value.includes(' ') ? value : value + ' +00';
-			this.#value = new Date(datetime).toJSON();
-		}
+		// Replace the potential time demoninator 'T' with a whitespace for backwards compatibility
+		this.#value = value?.replace('T', ' ');
+		console.log('got value', value, 'translated to', this.#value);
 	}
 	get value() {
 		return this.#value;
@@ -37,7 +52,6 @@ export class UmbPropertyEditorUIDatePickerElement extends UmbLitElement implemen
 
 	public set config(config: UmbPropertyEditorConfigCollection | undefined) {
 		if (!config) return;
-		const oldVal = this._inputType;
 
 		// Format string prevalue/config
 		const format = config.getValueByAlias<string>('format');
@@ -54,11 +68,14 @@ export class UmbPropertyEditorUIDatePickerElement extends UmbLitElement implemen
 		this._max = config.getValueByAlias('max');
 		this._step = config.getValueByAlias('step');
 
-		this.requestUpdate('_inputType', oldVal);
+		// If the inputType is only 'date' we need to make sure the value doesn't have a time
+		if (this._inputType === 'date' && this.value?.includes(' ')) {
+			this.value = this.value.split(' ')[0];
+		}
 	}
 
-	#onChange(event: CustomEvent & { target: HTMLInputElement }) {
-		this.value = event.target.value;
+	#onChange(event: CustomEvent & { target: UmbInputDateElement }) {
+		this.value = event.target.value.toString();
 		this.dispatchEvent(new UmbPropertyValueChangeEvent());
 	}
 
@@ -66,10 +83,10 @@ export class UmbPropertyEditorUIDatePickerElement extends UmbLitElement implemen
 		return html`
 			<umb-input-date
 				value="${ifDefined(this.value)}"
-				.min=${this._min}
-				.max=${this._max}
-				.step=${this._step}
-				.type=${this._inputType}
+				min=${ifDefined(this._min)}
+				max=${ifDefined(this._max)}
+				step=${ifDefined(this._step)}
+				type=${this._inputType}
 				@change=${this.#onChange}>
 			</umb-input-date>
 		`;

--- a/src/packages/property-editors/date-picker/property-editor-ui-date-picker.element.ts
+++ b/src/packages/property-editors/date-picker/property-editor-ui-date-picker.element.ts
@@ -52,6 +52,9 @@ export class UmbPropertyEditorUIDatePickerElement extends UmbLitElement implemen
 		this._inputType = hasTime ? 'datetime-local' : 'date';
 
 		// Based on the type of format string change the UUI-input type
+		// Note: The format string is not validated, so it's possible to have an invalid format string,
+		// but we do not use the format string for anything else than to determine the input type.
+		// The format string is not used to validate the value and is only used on the frontend.
 		const timeFormatPattern = /^h{1,2}:m{1,2}(:s{1,2})?\s?a?$/gim;
 		if (format?.toLowerCase().match(timeFormatPattern)) {
 			this._inputType = 'time';

--- a/src/packages/property-editors/date-picker/property-editor-ui-date-picker.element.ts
+++ b/src/packages/property-editors/date-picker/property-editor-ui-date-picker.element.ts
@@ -74,6 +74,13 @@ export class UmbPropertyEditorUIDatePickerElement extends UmbLitElement implemen
 	 * Formats the value depending on the input type.
 	 */
 	#formatValue(value: string) {
+		// Check that the value is a valid date
+		const valueToDate = new Date(value);
+		if (isNaN(valueToDate.getTime())) {
+			console.warn('[Umbraco.DatePicker] The value is not a valid date.', value);
+			return;
+		}
+
 		// Replace the potential time demoninator 'T' with a whitespace for backwards compatibility
 		value = value.replace('T', ' ');
 

--- a/src/packages/property-editors/date-picker/property-editor-ui-date-picker.element.ts
+++ b/src/packages/property-editors/date-picker/property-editor-ui-date-picker.element.ts
@@ -48,6 +48,7 @@ export class UmbPropertyEditorUIDatePickerElement extends UmbLitElement implemen
 		// Format string prevalue/config
 		const format = config.getValueByAlias<string>('format');
 		const hasTime = format?.includes('H') || format?.includes('m');
+		const hasSeconds = format?.includes('s');
 		this._inputType = hasTime ? 'datetime-local' : 'date';
 
 		// Based on the type of format string change the UUI-input type
@@ -58,7 +59,7 @@ export class UmbPropertyEditorUIDatePickerElement extends UmbLitElement implemen
 
 		this._min = config.getValueByAlias('min');
 		this._max = config.getValueByAlias('max');
-		this._step = config.getValueByAlias('step');
+		this._step = config.getValueByAlias('step') ?? hasSeconds ? 1 : undefined;
 
 		if (this.value) {
 			this.#formatValue(this.value);

--- a/src/packages/property-editors/date-picker/property-editor-ui-date-picker.element.ts
+++ b/src/packages/property-editors/date-picker/property-editor-ui-date-picker.element.ts
@@ -43,7 +43,6 @@ export class UmbPropertyEditorUIDatePickerElement extends UmbLitElement implemen
 	set value(value: string | undefined) {
 		// Replace the potential time demoninator 'T' with a whitespace for backwards compatibility
 		this.#value = value?.replace('T', ' ');
-		console.log('got value', value, 'translated to', this.#value);
 	}
 	get value() {
 		return this.#value;
@@ -68,9 +67,14 @@ export class UmbPropertyEditorUIDatePickerElement extends UmbLitElement implemen
 		this._max = config.getValueByAlias('max');
 		this._step = config.getValueByAlias('step');
 
-		// If the inputType is only 'date' we need to make sure the value doesn't have a time
+		// If the inputType is 'date', we need to make sure the value doesn't have a time
 		if (this._inputType === 'date' && this.value?.includes(' ')) {
 			this.value = this.value.split(' ')[0];
+		}
+
+		// If the inputType is 'time', we need to remove the date part of the value
+		if (this._inputType === 'time' && this.value?.includes(' ')) {
+			this.value = this.value.split(' ')[1];
 		}
 	}
 


### PR DESCRIPTION
## Description

The title may sound counter-intuitive, but the datepicker as it was in V13 did not care about timezones. Instead, it saved the values as the user typed them in (or rather as they picked them) and did not persist any local timezone information.

In practical terms this means two things:

1. The values in the database look like this "2024-05-03 14:58:00" which practically means that the server should assume the date is in its own timezone, which could very well be something else than UTC, but often isn't.
2. The date being picked by the user is timezone-less and therefore is simply shown "as-is".

During my testing, I have found this solution to be the best fitting in terms of "showing" the same values as V13 did.

We should consider implementing a new datepicker, that supports timezones and offsets so that the server could more easily understand that a user potentially do not share the same timezone as the server and therefore needs to save the datetime string with an offset, which should be supported everywhere.

I have also made sure that we support the "time only" datepicker, and that it also supports picking seconds as well as hours and minutes. We do all of this by analysing the date format string as configured on the data type. This might not be the best way to do it, but it again reflects how V13 would handle it with its datepicker.