### PR TITLE
fix: assume you are logged in if there is a token persisted

### DIFF
--- a/src/packages/core/auth/auth-flow.ts
+++ b/src/packages/core/auth/auth-flow.ts
@@ -171,9 +171,7 @@ export class UmbAuthFlow {
 		const tokenResponseJson = await this.#storageBackend.getItem(UMB_STORAGE_TOKEN_RESPONSE_NAME);
 		if (tokenResponseJson) {
 			const response = new TokenResponse(JSON.parse(tokenResponseJson));
-			if (response.isValid()) {
-				this.#tokenResponse = response;
-			}
+			this.#tokenResponse = response;
 		}
 	}
 
@@ -225,13 +223,13 @@ export class UmbAuthFlow {
 	}
 
 	/**
-	 * This method will check if the user is logged in by validating the timestamp of the stored token.
+	 * This method will check if the user is logged in by validating if there is a token stored.
 	 * If no token is stored, it will return false.
 	 *
 	 * @returns true if the user is logged in, false otherwise.
 	 */
 	isAuthorized(): boolean {
-		return !!this.#tokenResponse && this.#tokenResponse.isValid();
+		return !!this.#tokenResponse;
 	}
 
 	/**


### PR DESCRIPTION
The `isValid` method only checks the lifetime of the access_token, but you may still have a valid refresh_token in your storage, so it doesn't do any good to stop the flow

Instead we will assume that you are always logged in if there is a token in local storage

The end effect of this fix is that you will see the login screen far less often.