### PR TITLE
set es2022 for tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,8 @@
 {
 	"compilerOptions": {
 		"module": "esnext",
-		"target": "ES2020",
-		"lib": ["es2020", "dom", "dom.iterable"],
+		"target": "es2022",
+		"lib": ["es2022", "dom", "dom.iterable"],
 		"outDir": "./types",
 		"allowSyntheticDefaultImports": true,
 		"experimentalDecorators": true,


### PR DESCRIPTION
Today when using ES2020 there are some of the modern JS features that TypeScript compiles into js-polyfills, which result in some issues when we use the feature in some special ways.

Here is a screendump from front-end build for the CMS (build `via :for:cms` script) and running purely on the server(not Vite)
![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/6791648/899ed5ed-ecaf-482d-8662-ca9b0a47198a)

Error originates from the polyfill code, like this:
![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/6791648/620e3f5b-f3ef-4f65-9e59-f392181e9f07)

Which looks like this in TypeScript:
![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/6791648/c431ba89-e8b5-4121-926b-2b13c61064b7)

Which is from the JS polyfill, which sees the internal property setting as coming from an outside, but is actually not.

So to fix the bad polyfill, I'm changing our compiler to ES2022 so it doesn't polyfill it. And that simplifies code and makes it work :-)

## Description

<!--- Describe the changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
