### PR TITLE
Bugfix: Register content picker components on startup

### DIFF
--- a/src/packages/property-editors/entry-point.ts
+++ b/src/packages/property-editors/entry-point.ts
@@ -1,1 +1,2 @@
 import './checkbox-list/components/index.js';
+import './content-picker/components/index.js';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We forgot to register the content picker components on startup.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
