### PR TITLE
Retry requests after log in

### DIFF
--- a/src/apps/backoffice/backoffice.context.ts
+++ b/src/apps/backoffice/backoffice.context.ts
@@ -8,6 +8,7 @@ import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registr
 import type { ManifestSection } from '@umbraco-cms/backoffice/extension-registry';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import type { UmbExtensionManifestInitializer } from '@umbraco-cms/backoffice/extension-api';
+import { UMB_AUTH_CONTEXT } from '@umbraco-cms/backoffice/auth';
 
 export class UmbBackofficeContext extends UmbContextBase<UmbBackofficeContext> {
 	#activeSectionAlias = new UmbStringState(undefined);
@@ -26,7 +27,13 @@ export class UmbBackofficeContext extends UmbContextBase<UmbBackofficeContext> {
 			this.#allowedSections.setValue([...sections]);
 		});
 
-		this.#getVersion();
+		// TODO: We need to ensure this request is called every time the user logs in, but this should be done somewhere across the app and not here [JOV]
+		this.consumeContext(UMB_AUTH_CONTEXT, (authContext) => {
+			this.observe(authContext.isAuthorized, (isAuthorized) => {
+				if (!isAuthorized) return;
+				this.#getVersion();
+			});
+		});
 	}
 
 	async #getVersion() {

--- a/src/apps/backoffice/backoffice.element.ts
+++ b/src/apps/backoffice/backoffice.element.ts
@@ -7,6 +7,7 @@ import {
 } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbServerExtensionRegistrator } from '@umbraco-cms/backoffice/extension-api';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { UMB_AUTH_CONTEXT } from '@umbraco-cms/backoffice/auth';
 
 import './components/index.js';
 
@@ -58,7 +59,15 @@ export class UmbBackofficeElement extends UmbLitElement {
 			umbExtensionsRegistry.registerMany(packageModule.extensions);
 		});
 
-		new UmbServerExtensionRegistrator(this, umbExtensionsRegistry).registerPrivateExtensions();
+		const serverExtensions = new UmbServerExtensionRegistrator(this, umbExtensionsRegistry);
+
+		// TODO: We need to ensure this request is called every time the user logs in, but this should be done somewhere across the app and not here [JOV]
+		this.consumeContext(UMB_AUTH_CONTEXT, (authContext) => {
+			this.observe(authContext.isAuthorized, (isAuthorized) => {
+				if (!isAuthorized) return;
+				serverExtensions.registerPrivateExtensions();
+			});
+		});
 	}
 
 	render() {

--- a/src/packages/language/global-contexts/app-language.context.ts
+++ b/src/packages/language/global-contexts/app-language.context.ts
@@ -5,6 +5,7 @@ import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
 import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
 import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
+import { UMB_AUTH_CONTEXT } from '@umbraco-cms/backoffice/auth';
 
 // TODO: Make a store for the App Languages.
 // TODO: Implement default language end-point, in progress at backend team, so we can avoid getting all languages.
@@ -28,7 +29,14 @@ export class UmbAppLanguageContext extends UmbContextBase<UmbAppLanguageContext>
 	constructor(host: UmbControllerHost) {
 		super(host, UMB_APP_LANGUAGE_CONTEXT);
 		this.#languageCollectionRepository = new UmbLanguageCollectionRepository(this);
-		this.#observeLanguages();
+
+		// TODO: We need to ensure this request is called every time the user logs in, but this should be done somewhere across the app and not here [JOV]
+		this.consumeContext(UMB_AUTH_CONTEXT, (authContext) => {
+			this.observe(authContext.isAuthorized, (isAuthorized) => {
+				if (!isAuthorized) return;
+				this.#observeLanguages();
+			});
+		});
 	}
 
 	setLanguage(unique: string) {


### PR DESCRIPTION
Some requests need to be called when the user is logged in, but if the user starts out with a timeout, these requests are never called again, and we need to make absolutely sure that they are being executed