### PR TITLE
Feature: Confirm Modal: Adds `cancelLabel` option

### DIFF
--- a/src/packages/core/modal/common/confirm/confirm-modal.element.ts
+++ b/src/packages/core/modal/common/confirm/confirm-modal.element.ts
@@ -24,13 +24,17 @@ export class UmbConfirmModalElement extends UmbLitElement {
 			<uui-dialog-layout class="uui-text" .headline=${this.data?.headline || null}>
 				${this.data?.content}
 
-				<uui-button slot="actions" id="cancel" label="Cancel" @click="${this._handleCancel}"></uui-button>
+				<uui-button
+					slot="actions"
+					id="cancel"
+					label=${this.data?.cancelLabel || this.localize.term('buttons_confirmActionCancel')}
+					@click=${this._handleCancel}></uui-button>
 				<uui-button
 					slot="actions"
 					id="confirm"
-					color="${this.data?.color || 'positive'}"
+					color=${this.data?.color || 'positive'}
 					look="primary"
-					label="${this.data?.confirmLabel || 'Confirm'}"
+					label=${this.data?.confirmLabel || this.localize.term('buttons_confirmActionConfirm')}
 					@click=${this._handleConfirm}
 					${umbFocus()}></uui-button>
 			</uui-dialog-layout>

--- a/src/packages/core/modal/token/confirm-modal.token.ts
+++ b/src/packages/core/modal/token/confirm-modal.token.ts
@@ -5,6 +5,7 @@ export interface UmbConfirmModalData {
 	headline: string;
 	content: TemplateResult | string;
 	color?: 'positive' | 'danger';
+	cancelLabel?: string;
 	confirmLabel?: string;
 }
 


### PR DESCRIPTION
## Description

Adds `cancelLabel` option to the Confirm Modal.

This PR also localizes the fallback labels for "Cancel" and "Confirm".

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Motivation and context

I needed this as part of the Document Preview feature #1778, when exiting the Preview mode a confirmation prompt modal is opened, with two options: "Preview latest version" (confirm) or "View published version" (cancel). Having "Cancel" didn't seem friendly in this scenario, _(it may be that it needs it's own modal, we can discuss)_.
