### PR TITLE
fix: token after refresh is not persisted

### DIFF
--- a/src/packages/core/auth/auth-flow.ts
+++ b/src/packages/core/auth/auth-flow.ts
@@ -371,8 +371,10 @@ export class UmbAuthFlow {
 	async #performTokenRequest(request: TokenRequest): Promise<void> {
 		try {
 			this.#tokenResponse = await this.#tokenHandler.performTokenRequest(this.#configuration, request);
+			this.#saveTokenState();
 		} catch (error) {
-			// If the token request fails, it means the refresh token is invalid
+			// If the token request fails, it means the code or refresh token is invalid
+			this.clearTokenStorage();
 			console.error('Token request error', error);
 		}
 	}


### PR DESCRIPTION
## Description

When your access_token expires, we exchange the refresh_token for a new access_token, however this new token is never persisted in local storage meaning, that next time you refresh you are "logged out" prematurely

## How to test

1. Let your access token expire (usually 5 minutes but configurable with "TimeOut" in appsettings) and check that the client exchanges its refresh token to new access token
2. Now refresh the browser (F5) and verify that you are still logged in