### PR TITLE
Change labels of buttons in webhook

### DIFF
--- a/src/packages/webhook/components/input-webhook-events.element.ts
+++ b/src/packages/webhook/components/input-webhook-events.element.ts
@@ -52,7 +52,7 @@ export class UmbInputWebhookEventsElement extends UmbLitElement {
 				(item) => item.alias,
 				(item) => html`
 					<span>${item.eventName}</span>
-					<uui-button @click=${() => this.#removeEvent(item.alias)} label="remove"></uui-button>
+					<uui-button label=${this.localize.term('general_remove')} @click=${() => this.#removeEvent(item.alias)}></uui-button>
 				`,
 			)}
 		`;
@@ -60,7 +60,7 @@ export class UmbInputWebhookEventsElement extends UmbLitElement {
 
 	render() {
 		return html`${this.#renderEvents()}
-			<uui-button id="add" look="placeholder" label="Add" @click=${this.#openModal}></uui-button>`;
+			<uui-button id="choose" look="placeholder" label=${this.localize.term('general_choose')} @click=${this.#openModal}></uui-button>`;
 	}
 
 	static styles = [
@@ -73,7 +73,7 @@ export class UmbInputWebhookEventsElement extends UmbLitElement {
 				align-items: center;
 			}
 
-			#add {
+			#choose {
 				grid-column: -1 / 1;
 			}
 		`,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I noticed remove button at events had label "remove" unlike other places in UI where it is "Remove".
Furthermore I added localized value and at think "Choose" was a better term at events at one is choosing from available events registered in application to react on. It doesn't add any new events here.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/2919859/a2a6bc37-2367-4c95-9a7f-eb012f0ea177)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
