### PR TITLE
Feature: umb-body-layout - Hide empty slots

### DIFF
--- a/src/packages/core/components/body-layout/body-layout.element.ts
+++ b/src/packages/core/components/body-layout/body-layout.element.ts
@@ -185,7 +185,6 @@ export class UmbBodyLayoutElement extends LitElement {
 			}
 
 			#header-slot,
-			#tabs-slot,
 			#action-menu-slot,
 			#navigation-slot {
 				display: flex;
@@ -195,8 +194,7 @@ export class UmbBodyLayoutElement extends LitElement {
 				min-width: 0;
 			}
 
-			#navigation-slot,
-			#tabs-slot {
+			#navigation-slot {
 				margin-left: auto;
 			}
 

--- a/src/packages/core/components/body-layout/body-layout.element.ts
+++ b/src/packages/core/components/body-layout/body-layout.element.ts
@@ -75,6 +75,10 @@ export class UmbBodyLayoutElement extends LitElement {
 		this.toggleAttribute('scrolling', this._scrollContainer.scrollTop > 0);
 	};
 
+	#setSlotVisibility(target: HTMLElement, hasChildren: boolean) {
+		target.style.display = hasChildren ? 'flex' : 'none';
+	}
+
 	render() {
 		return html`
 			<div
@@ -92,18 +96,21 @@ export class UmbBodyLayoutElement extends LitElement {
 					name="header"
 					@slotchange=${(e: Event) => {
 						this._headerSlotHasChildren = this.#hasNodes(e);
+						this.#setSlotVisibility(e.target as HTMLElement, this._headerSlotHasChildren);
 					}}></slot>
 				<slot
 					id="navigation-slot"
 					name="navigation"
 					@slotchange=${(e: Event) => {
-						this._actionsMenuSlotHasChildren = this.#hasNodes(e);
+						this._navigationSlotHasChildren = this.#hasNodes(e);
+						this.#setSlotVisibility(e.target as HTMLElement, this._navigationSlotHasChildren);
 					}}></slot>
 				<slot
 					id="action-menu-slot"
 					name="action-menu"
 					@slotchange=${(e: Event) => {
 						this._actionsMenuSlotHasChildren = this.#hasNodes(e);
+						this.#setSlotVisibility(e.target as HTMLElement, this._actionsMenuSlotHasChildren);
 					}}></slot>
 			</div>
 
@@ -187,7 +194,7 @@ export class UmbBodyLayoutElement extends LitElement {
 			#header-slot,
 			#action-menu-slot,
 			#navigation-slot {
-				display: flex;
+				display: none;
 				height: 100%;
 				align-items: center;
 				box-sizing: border-box;


### PR DESCRIPTION
Hides empty slots in `umb-body-layout`
Empty slots previously caused layout issues because of padding.

Notice the empty header slot taking up space, squishing the rest of the content, which causes the navigation to collapse into a dropdown

Before:
<img width="588" alt="image" src="https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/26099018/60a61fb7-b966-45cc-8d64-9bcd46fe62a0">

After:
<img width="591" alt="image" src="https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/26099018/b54d6625-0301-49c4-9da9-38999cefbe7b">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
