### PR TITLE
fix: Rearrange colors and match with Umbraco 13

### DIFF
--- a/src/packages/core/modal/common/icon-picker/icon-picker-modal.element.ts
+++ b/src/packages/core/modal/common/icon-picker/icon-picker-modal.element.ts
@@ -26,7 +26,7 @@ export class UmbIconPickerModalElement extends UmbModalBaseElement<UmbIconPicker
 	private _currentIcon?: string;
 
 	@state()
-	private _currentColor = 'text';
+	private _currentColor = 'black';
 
 	constructor() {
 		super();
@@ -57,7 +57,7 @@ export class UmbIconPickerModalElement extends UmbModalBaseElement<UmbIconPicker
 				this.modalContext?.value,
 				(newValue) => {
 					this._currentIcon = newValue?.icon;
-					this._currentColor = newValue?.color ?? 'text';
+					this._currentColor = newValue?.color ?? 'black';
 				},
 				'_observeModalContextValue',
 			);

--- a/src/packages/core/resources/extractUmbColorVariable.function.ts
+++ b/src/packages/core/resources/extractUmbColorVariable.function.ts
@@ -1,25 +1,25 @@
 export const umbracoColors = [
-	{ alias: 'text', varName: '--uui-color-text' },
-	{ alias: 'black', varName: '--uui-color-text' },
-	{ alias: 'yellow', varName: '--uui-palette-sunglow' },
-	{ alias: 'pink', varName: '--uui-palette-spanish-pink' },
-	{ alias: 'blue', varName: '--uui-palette-violet-blue' },
-	{ alias: 'light-blue', varName: '--uui-palette-malibu' },
-	{ alias: 'red', varName: '--uui-palette-maroon-flush' },
-	{ alias: 'green', varName: '--uui-palette-jungle-green' },
+	{ alias: 'black', varName: '--uui-palette-black' },
+	{ alias: 'blue-grey', varName: '--uui-palette-space-cadet-dimmed' },
+	{ alias: 'grey', varName: '--uui-palette-grey' },
 	{ alias: 'brown', varName: '--uui-palette-chamoisee' },
-	{ alias: 'grey', varName: '--uui-palette-dusty-grey' },
+	{ alias: 'blue', varName: '--uui-palette-malibu' },
+	{ alias: 'light-blue', varName: '--uui-palette-malibu-light' },
+	{ alias: 'indigo', varName: '--uui-palette-violet-blue' },
+	{ alias: 'purple', varName: '--uui-palette-purple' }, // Missing UUI variable
+	{ alias: 'deep-purple', varName: '--uui-palette-space-cadet' }, // Missing UUI variable
+	{ alias: 'cyan', varName: '--uui-palette-cyan' }, // Missing UUI variable
+	{ alias: 'green', varName: '--uui-palette-forest-green' },
+	{ alias: 'light-green', varName: '--uui-palette-jungle-green' },
+	{ alias: 'lime', varName: '--uui-palette-jungle-green-light' },
+	{ alias: 'yellow', varName: '--uui-palette-sunglow' },
+	{ alias: 'amber', varName: '--uui-palette-deep-saffron-light' },
+	{ alias: 'orange', varName: '--uui-palette-deep-saffron' },
+	{ alias: 'deep-orange', varName: '--uui-palette-deep-saffron-dark' },
+	{ alias: 'red', varName: '--uui-palette-maroon-flush' },
+	{ alias: 'pink', varName: '--uui-palette-spanish-pink' },
 
-	{ alias: 'blue-grey', legacy: true, varName: '--uui-palette-dusty-grey' },
-	{ alias: 'indigo', legacy: true, varName: '--uui-palette-malibu' },
-	{ alias: 'purple', legacy: true, varName: '--uui-palette-space-cadet' },
-	{ alias: 'deep-purple', legacy: true, varName: '--uui-palette-space-cadet' },
-	{ alias: 'cyan', legacy: true, varName: '-uui-palette-jungle-green' },
-	{ alias: 'light-green', legacy: true, varName: '-uui-palette-jungle-green' },
-	{ alias: 'lime', legacy: true, varName: '-uui-palette-jungle-green' },
-	{ alias: 'amber', legacy: true, varName: '--uui-palette-chamoisee' },
-	{ alias: 'orange', legacy: true, varName: '--uui-palette-chamoisee' },
-	{ alias: 'deep-orange', legacy: true, varName: '--uui-palette-cocoa-brown' },
+	{ alias: 'text', legacy: true, varName: '--uui-color-text' },
 ];
 
 export function extractUmbColorVariable(colorAlias: string): string | undefined {


### PR DESCRIPTION
**Umbraco 13**
![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/752371/37042e28-8e89-4e0b-93e3-1b8be65d2ef1)

**Umbraco 14**
![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/752371/3b4ead99-a275-47ca-91fc-3e62ae22c582)

Note: Three of the colors have no equivalent in UUI (purple, deep-purple, and cyan), however the uui swatch component then uses the browser default, which works for purple and cyan, but for "deep-purple" I have selected an acceptable color that could work until we can introduce more variables.

Fixes https://github.com/umbraco/Umbraco-CMS/issues/16205