### PR TITLE
fix split panel overflow

### DIFF
--- a/src/packages/core/components/split-panel/split-panel.element.ts
+++ b/src/packages/core/components/split-panel/split-panel.element.ts
@@ -250,7 +250,7 @@ export class UmbSplitPanelElement extends LitElement {
 		slot {
 			overflow: var(--umb-split-panel-slot-overflow);
 			display: block;
-			overflow: auto;
+			min-height: 0;
 		}
 		#main {
 			width: 100%;


### PR DESCRIPTION
Fixes issues with overflow in the split-panel. Now used min-height instead of overflow 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
