### PR TITLE
fix: multiple TinyMCE's on the same page does not work

### DIFF
--- a/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
+++ b/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
@@ -356,12 +356,9 @@ export class UmbInputTinyMceElement extends UUIFormControlMixin(UmbLitElement, '
 
 	static styles = [
 		css`
-			#editor {
+			.tox-tinymce {
 				position: relative;
 				min-height: 100px;
-			}
-
-			.tox-tinymce {
 				border-radius: 0;
 				border: var(--uui-input-border-width, 1px) solid var(--uui-input-border-color, var(--uui-color-border, #d8d7d9));
 			}

--- a/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
+++ b/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
@@ -12,8 +12,12 @@ import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbStylesheetDetailRepository, UmbStylesheetRuleManager } from '@umbraco-cms/backoffice/stylesheet';
 import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
-import type { EditorEvent, Editor, RawEditorOptions } from '@umbraco-cms/backoffice/external/tinymce';
-import type { ManifestTinyMcePlugin } from '@umbraco-cms/backoffice/extension-registry';
+import {
+	type EditorEvent,
+	type Editor,
+	type RawEditorOptions,
+	renderEditor,
+} from '@umbraco-cms/backoffice/external/tinymce';
 import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
 
 /**
@@ -74,7 +78,7 @@ export class UmbInputTinyMceElement extends UUIFormControlMixin(UmbLitElement, '
 		return super.value;
 	}
 
-	@query('#editor', true)
+	@query('.editor', true)
 	private _editorElement?: HTMLElement;
 
 	protected async firstUpdated(): Promise<void> {
@@ -347,7 +351,7 @@ export class UmbInputTinyMceElement extends UUIFormControlMixin(UmbLitElement, '
 	 * a target div and binds the RTE to that element
 	 */
 	render() {
-		return html`<div id="editor"></div>`;
+		return html`<div class="editor"></div>`;
 	}
 
 	static styles = [


### PR DESCRIPTION
## Description

TinyMCE does not support having the same html id for its elements (even though it's inside a Shadow DOM). By changing this to html classes, tiny now works when you have mulitiple instances on the same page, e.g. on a document.

Fixes #1233