### PR TITLE
fix: tinymce does not use its default config

### DIFF
--- a/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.defaults.ts
+++ b/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.defaults.ts
@@ -35,7 +35,7 @@ export const defaultFallbackConfig: RawEditorOptions = {
 		},
 		{
 			title: 'Blocks',
-			items: [{ title: 'Normal', block: 'p' }],
+			items: [{ title: 'Paragraph', block: 'p' }],
 		},
 		{
 			title: 'Containers',

--- a/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
+++ b/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
@@ -196,10 +196,10 @@ export class UmbInputTinyMceElement extends UUIFormControlMixin(UmbLitElement, '
 		// create an object by merging the configuration onto the fallback config
 		const configurationOptions: RawEditorOptions = {
 			...defaultFallbackConfig,
-			height: dimensions?.height || undefined,
-			width: dimensions?.width || undefined,
-			content_css: stylesheets,
-			style_formats: styleFormats,
+			height: dimensions?.height ?? defaultFallbackConfig.height,
+			width: dimensions?.width ?? defaultFallbackConfig.width,
+			content_css: stylesheets.length ? stylesheets : defaultFallbackConfig.content_css,
+			style_formats: styleFormats.length ? styleFormats : defaultFallbackConfig.style_formats,
 		};
 
 		// no auto resize when a fixed height is set


### PR DESCRIPTION
Specifically for height, width, content_css, and style_formats, tinymce did not use its fallbacks if they were not provided through the data type.

This is particularly useful to have something visible in the "styles" menu.