### PR TITLE
Feature: Login without popup

### DIFF
--- a/src/apps/app/app.element.ts
+++ b/src/apps/app/app.element.ts
@@ -82,7 +82,7 @@ export class UmbAppElement extends UmbLitElement {
 						: this.localize.term('errors_externalLoginFailed');
 				} else {
 					(component as UmbAppErrorElement).errorMessage = hasCode
-						? 'Login successful, you will be redirected shortly'
+						? this.localize.term('errors_externalLoginRedirectSuccess')
 						: this.localize.term('errors_externalLoginFailed');
 
 					this.observe(this.#authContext.authorizationSignal, () => {

--- a/src/assets/lang/da-dk.ts
+++ b/src/assets/lang/da-dk.ts
@@ -711,6 +711,7 @@ export default {
 		externalLoginFailed:
 			'Serveren mislykkedes i at logge ind med den eksterne loginudbyder. Luk dette vindue og prøv igen.',
 		externalLoginSuccess: 'Du er nu logget ind. Du kan nu lukke dette vindue.',
+		externalLoginRedirectSuccess: 'Du er nu logget ind. Du vil blive omdirigeret om et øjeblik.',
 	},
 	openidErrors: {
 		accessDenied: 'Access denied',

--- a/src/assets/lang/en-us.ts
+++ b/src/assets/lang/en-us.ts
@@ -720,6 +720,7 @@ export default {
 		externalLoginFailed:
 			'The server failed to authorize you against the external login provider. Please close the window and try again.',
 		externalLoginSuccess: 'You have successfully logged in. You may now close this window.',
+		externalLoginRedirectSuccess: 'You have successfully logged in. You will be redirected shortly.',
 	},
 	openidErrors: {
 		accessDenied: 'Access denied',

--- a/src/assets/lang/en.ts
+++ b/src/assets/lang/en.ts
@@ -731,6 +731,7 @@ export default {
 		externalLoginFailed:
 			'The server failed to authorize you against the external login provider. Please close the window and try again.',
 		externalLoginSuccess: 'You have successfully logged in. You may now close this window.',
+		externalLoginRedirectSuccess: 'You have successfully logged in. You will be redirected shortly.',
 	},
 	openidErrors: {
 		accessDenied: 'Access denied',

--- a/src/packages/core/auth/modals/umb-app-auth-modal.element.ts
+++ b/src/packages/core/auth/modals/umb-app-auth-modal.element.ts
@@ -95,14 +95,16 @@ export class UmbAppAuthModalElement extends UmbModalBaseElement<UmbModalAppAuthC
 			const providerName =
 				typeof providerOrManifest === 'string' ? providerOrManifest : providerOrManifest.forProviderName;
 
-			await authContext.makeAuthorizationRequest(providerName, false, loginHint, manifest);
+			// If the user is timed out, we do not want to lose the state, so avoid redirecting to the provider
+			// and instead just make the authorization request. In all other cases, we want to redirect to the provider.
+			const isTimedOut = this.data?.userLoginState === 'timedOut';
+
+			await authContext.makeAuthorizationRequest(providerName, isTimedOut ? false : true, loginHint, manifest);
 
 			const isAuthed = authContext.getIsAuthorized();
 			this.value = { success: isAuthed };
 			if (isAuthed) {
 				this._submitModal();
-			} else {
-				this._error = 'Failed to authenticate';
 			}
 		} catch (error) {
 			console.error('[AuthModal] Error submitting auth request', error);


### PR DESCRIPTION
## Description

Currently, when you have more than one provider, we are logging you in through a popup. This is a major difference from the normal flow where you are just redirected to the login screen. This PR aims to align the two, so regardless whether you have 1 or 3 login providers, you always get the same experience.

Log in (no previous session): You click a login provider, you get sent to the login screen of that provider

Login (no previous session, no providers): You get automatically redirected to the login screen (this experience has not been altered with this PR)

Timed out (all cases): You see the login modal on top of your backoffice, you click a login provider and log in through a popup

This PR also fixes a small-ish issue where the redirect back to the frontpage could happen even if there was no token saved yet (race condition).