### PR TITLE
Feature: Validate the token on first load

### DIFF
--- a/src/packages/core/auth/auth.context.ts
+++ b/src/packages/core/auth/auth.context.ts
@@ -175,6 +175,15 @@ export class UmbAuthContext extends UmbContextBase<UmbAuthContext> {
 	}
 
 	/**
+	 * Validates the token against the server and returns true if the token is valid.
+	 * @memberof UmbAuthContext
+	 * @returns True if the token is valid, otherwise false
+	 */
+	async validateToken(): Promise<boolean> {
+		return this.#authFlow.makeRefreshTokenRequest();
+	}
+
+	/**
 	 * Clears the token storage.
 	 * @memberof UmbAuthContext
 	 */
@@ -188,7 +197,6 @@ export class UmbAuthContext extends UmbContextBase<UmbAuthContext> {
 	 * @memberof UmbAuthContext
 	 */
 	timeOut() {
-		this.clearTokenStorage();
 		this.#isAuthorized.setValue(false);
 		this.#isTimeout.next();
 	}


### PR DESCRIPTION
## Description

If the client thinks it has a valid token (i.e. if the token was set on another umbraco instance or it has expired on the server or been revoked), it will still try and use it. The first authenticated request will then return a 401 prompting the client to show the "time out" screen. This is not entirely correct, as the user might simply expect to see the login screen directly.

This PR aims to introduce a simple server request to validate the token if one is present. We do this by trying to exchange the stored refresh_token to an access_token only on the first load. This has two benefits:

1. We let the server tell us directly if it thinks the stored token is useful.
2. We get a freshly minted access_token that is now valid for the configured timeout period and wont accidentally expire during the next 2 seconds thereby prompting the "time out" screen anyway.

## How to test

1. Log in
2. Go to local storage and change the values of the token and refresh_token to something bogus
3. Refresh (F5) and check that the client performs a "token" call that should yield a 400 error code prompting the client to show the "real" login screen
4. Try and change just the token (not the refresh token) and hit F5 and check that the refresh_token is correctly exchanged to an access_token and you stay logged in
