### PR TITLE
Bugfix: Document Picker: Start node

### DIFF
--- a/src/packages/documents/documents/property-editors/document-picker/property-editor-ui-document-picker.element.ts
+++ b/src/packages/documents/documents/property-editors/document-picker/property-editor-ui-document-picker.element.ts
@@ -15,28 +15,30 @@ export class UmbPropertyEditorUIDocumentPickerElement extends UmbLitElement impl
 		if (!config) return;
 
 		const minMax = config.getValueByAlias<NumberRangeValueType>('validationLimit');
-		this.min = minMax?.min ?? 0;
-		this.max = minMax?.max ?? Infinity;
+		if (minMax) {
+			this._min = minMax.min && minMax.min > 0 ? minMax.min : 0;
+			this._max = minMax.max && minMax.max > 0 ? minMax.max : Infinity;
+		}
 
-		this.ignoreUserStartNodes = config.getValueByAlias('ignoreUserStartNodes') ?? false;
-		this.startNodeId = config.getValueByAlias('startNodeId');
-		this.showOpenButton = config.getValueByAlias('showOpenButton') ?? false;
+		this._ignoreUserStartNodes = config.getValueByAlias('ignoreUserStartNodes') ?? false;
+		this._startNodeId = config.getValueByAlias('startNodeId');
+		this._showOpenButton = config.getValueByAlias('showOpenButton') ?? false;
 	}
 
 	@state()
-	min = 0;
+	private _min = 0;
 
 	@state()
-	max = Infinity;
+	private _max = Infinity;
 
 	@state()
-	startNodeId?: string;
+	private _startNodeId?: string;
 
 	@state()
-	showOpenButton?: boolean;
+	private _showOpenButton?: boolean;
 
 	@state()
-	ignoreUserStartNodes?: boolean;
+	private _ignoreUserStartNodes?: boolean;
 
 	#onChange(event: CustomEvent & { target: UmbInputDocumentElement }) {
 		this.value = event.target.selection.join(',');
@@ -44,14 +46,15 @@ export class UmbPropertyEditorUIDocumentPickerElement extends UmbLitElement impl
 	}
 
 	render() {
+		const startNode = this._startNodeId ? { unique: this._startNodeId } : undefined;
 		return html`
 			<umb-input-document
-				.min=${this.min}
-				.max=${this.max}
-				.startNodeId=${this.startNodeId ?? ''}
+				.min=${this._min}
+				.max=${this._max}
+				.startNode=${startNode}
 				.value=${this.value ?? ''}
-				?showOpenButton=${this.showOpenButton}
-				?ignoreUserStartNodes=${this.ignoreUserStartNodes}
+				?ignoreUserStartNodes=${this._ignoreUserStartNodes}
+				?showOpenButton=${this._showOpenButton}
 				@change=${this.#onChange}>
 			</umb-input-document>
 		`;


### PR DESCRIPTION
## Description

Following on from #1769, this PR wires up the Document Picker's (root) start node configuration, (this is the separate editor from MNTP).

I've also included some code tidy-up and configuration validation, (for min/max values).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
