### PR TITLE
Bugfix: Document Collection: Create action modal route

### DIFF
--- a/src/packages/documents/documents/collection/action/create-document-collection-action.element.ts
+++ b/src/packages/documents/documents/collection/action/create-document-collection-action.element.ts
@@ -1,4 +1,4 @@
-import { html, customElement, property, state, map } from '@umbraco-cms/backoffice/external/lit';
+import { css, customElement, html, map, property, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbDocumentTypeStructureRepository } from '@umbraco-cms/backoffice/document-type';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UMB_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
@@ -8,9 +8,9 @@ import {
 	UMB_DOCUMENT_ROOT_ENTITY_TYPE,
 	UMB_DOCUMENT_WORKSPACE_CONTEXT,
 } from '@umbraco-cms/backoffice/document';
+import { UMB_WORKSPACE_MODAL, UmbModalRouteRegistrationController } from '@umbraco-cms/backoffice/modal';
 import type { ManifestCollectionAction } from '@umbraco-cms/backoffice/extension-registry';
 import type { UmbAllowedDocumentTypeModel } from '@umbraco-cms/backoffice/document-type';
-import { UMB_WORKSPACE_MODAL, UmbModalRouteRegistrationController } from '@umbraco-cms/backoffice/modal';
 
 @customElement('umb-create-document-collection-action')
 export class UmbCreateDocumentCollectionActionElement extends UmbLitElement {
@@ -21,6 +21,9 @@ export class UmbCreateDocumentCollectionActionElement extends UmbLitElement {
 	private _createDocumentPath = '';
 
 	@state()
+	private _currentView?: string;
+
+	@state()
 	private _documentUnique?: string;
 
 	@state()
@@ -28,6 +31,9 @@ export class UmbCreateDocumentCollectionActionElement extends UmbLitElement {
 
 	@state()
 	private _popoverOpen = false;
+
+	@state()
+	private _rootPathName?: string;
 
 	@state()
 	private _useInfiniteEditor = false;
@@ -59,6 +65,12 @@ export class UmbCreateDocumentCollectionActionElement extends UmbLitElement {
 		});
 
 		this.consumeContext(UMB_COLLECTION_CONTEXT, (collectionContext) => {
+			this.observe(collectionContext.view.currentView, (currentView) => {
+				this._currentView = currentView?.meta.pathName;
+			});
+			this.observe(collectionContext.view.rootPathName, (rootPathName) => {
+				this._rootPathName = rootPathName;
+			});
 			this.observe(collectionContext.filter, (filter) => {
 				this._useInfiniteEditor = filter.useInfiniteEditor == true;
 			});
@@ -87,20 +99,22 @@ export class UmbCreateDocumentCollectionActionElement extends UmbLitElement {
 	}
 
 	#getCreateUrl(item: UmbAllowedDocumentTypeModel) {
-		// TODO: [LK] I need help with this. I don't know what the infinity editor URL should be.
-		// TODO: Yes, revisit the path extension of the routable modal, cause this is not pretty...? [NL]
-		return this._useInfiniteEditor
-			? this._createDocumentPath +
-					UMB_CREATE_DOCUMENT_WORKSPACE_PATH_PATTERN.generateLocal({
-						parentEntityType: this._documentUnique ? UMB_DOCUMENT_ENTITY_TYPE : UMB_DOCUMENT_ROOT_ENTITY_TYPE,
-						parentUnique: this._documentUnique ?? 'null',
-						documentTypeUnique: item.unique,
-					})
-			: UMB_CREATE_DOCUMENT_WORKSPACE_PATH_PATTERN.generateAbsolute({
+		if (this._useInfiniteEditor) {
+			return (
+				this._createDocumentPath.replace(`${this._rootPathName}`, `${this._rootPathName}/${this._currentView}`) +
+				UMB_CREATE_DOCUMENT_WORKSPACE_PATH_PATTERN.generateLocal({
 					parentEntityType: this._documentUnique ? UMB_DOCUMENT_ENTITY_TYPE : UMB_DOCUMENT_ROOT_ENTITY_TYPE,
 					parentUnique: this._documentUnique ?? 'null',
 					documentTypeUnique: item.unique,
-				});
+				})
+			);
+		}
+
+		return UMB_CREATE_DOCUMENT_WORKSPACE_PATH_PATTERN.generateAbsolute({
+			parentEntityType: this._documentUnique ? UMB_DOCUMENT_ENTITY_TYPE : UMB_DOCUMENT_ROOT_ENTITY_TYPE,
+			parentUnique: this._documentUnique ?? 'null',
+			documentTypeUnique: item.unique,
+		});
 	}
 
 	render() {
@@ -113,11 +127,9 @@ export class UmbCreateDocumentCollectionActionElement extends UmbLitElement {
 		const item = this._allowedDocumentTypes[0];
 		const label = (this.manifest?.meta.label ?? this.localize.term('general_create')) + ' ' + item.name;
 
-		return html`<uui-button
-			color="default"
-			href=${this.#getCreateUrl(item)}
-			label=${label}
-			look="outline"></uui-button>`;
+		return html`
+			<uui-button color="default" href=${this.#getCreateUrl(item)} label=${label} look="outline"></uui-button>
+		`;
 	}
 
 	#renderDropdown() {
@@ -149,6 +161,14 @@ export class UmbCreateDocumentCollectionActionElement extends UmbLitElement {
 			</uui-popover-container>
 		`;
 	}
+
+	static styles = [
+		css`
+			uui-scroll-container {
+				max-height: 500px;
+			}
+		`,
+	];
 }
 
 export default UmbCreateDocumentCollectionActionElement;


### PR DESCRIPTION
## Description

In the Document Collection, the Create action was broken when using the "Edit in Infinite Editor" configuration option.
This PR attempts to generate the correct modal route, by accounting for the current Collection View path-name.

Also includes UI amends, for limiting the height of the available document-types in the Create popover container, _(as my development database has over 30 available document-types in the list, it went off-screen, without a scrollbar!)_ 😱

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
