### PR TITLE
Feature: Property Editor Media Picker Thumbnails

### DIFF
--- a/src/packages/core/components/input-upload-field/input-upload-field.element.ts
+++ b/src/packages/core/components/input-upload-field/input-upload-field.element.ts
@@ -25,7 +25,7 @@ export class UmbInputUploadFieldElement extends UmbLitElement {
 		this._src = value.src;
 	}
 	get value(): MediaValueType {
-		return !this.temporaryFile ? { src: this._src } : { temporaryFileId: this.temporaryFile.unique };
+		return !this.temporaryFile ? { src: this._src } : { temporaryFileId: this.temporaryFile.temporaryUnique };
 	}
 
 	/**
@@ -67,7 +67,7 @@ export class UmbInputUploadFieldElement extends UmbLitElement {
 	async #onUpload(e: UUIFileDropzoneEvent) {
 		//Property Editor for Upload field will always only have one file.
 		const item: UmbTemporaryFileModel = {
-			unique: UmbId.new(),
+			temporaryUnique: UmbId.new(),
 			file: e.detail.files[0],
 		};
 		const upload = this.#manager.uploadOne(item);
@@ -80,7 +80,7 @@ export class UmbInputUploadFieldElement extends UmbLitElement {
 
 		const uploaded = await upload;
 		if (uploaded.status === TemporaryFileStatus.SUCCESS) {
-			this.temporaryFile = { unique: item.unique, file: item.file };
+			this.temporaryFile = { temporaryUnique: item.temporaryUnique, file: item.file };
 			this.dispatchEvent(new UmbChangeEvent());
 		}
 	}

--- a/src/packages/media/media/components/input-image-cropper/input-image-cropper.element.ts
+++ b/src/packages/media/media/components/input-image-cropper/input-image-cropper.element.ts
@@ -56,7 +56,7 @@ export class UmbInputImageCropperElement extends UmbLitElement {
 
 		this.value = assignToFrozenObject(this.value, { temporaryFileId: unique });
 
-		this.#manager?.uploadOne({ unique, file });
+		this.#manager?.uploadOne({ temporaryUnique: unique, file });
 
 		this.dispatchEvent(new UmbChangeEvent());
 	}

--- a/src/packages/media/media/components/input-media/input-media.context.ts
+++ b/src/packages/media/media/components/input-media/input-media.context.ts
@@ -1,3 +1,4 @@
+import type { UmbMediaCardItemModel } from '../../modals/index.js';
 import { UMB_MEDIA_ITEM_REPOSITORY_ALIAS } from '../../repository/index.js';
 import type { UmbMediaItemModel } from '../../repository/item/types.js';
 import type { UmbMediaTreeItemModel } from '../../tree/index.js';
@@ -8,6 +9,8 @@ import type {
 } from '../../tree/media-tree-picker-modal.token.js';
 import { UmbPickerInputContext } from '@umbraco-cms/backoffice/picker-input';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import { UmbArrayState } from '@umbraco-cms/backoffice/observable-api';
+import { UmbImagingRepository } from '@umbraco-cms/backoffice/imaging';
 
 export class UmbMediaPickerContext extends UmbPickerInputContext<
 	UmbMediaItemModel,
@@ -15,7 +18,32 @@ export class UmbMediaPickerContext extends UmbPickerInputContext<
 	UmbMediaTreePickerModalData,
 	UmbMediaTreePickerModalValue
 > {
+	#imagingRepository: UmbImagingRepository;
+
+	#cardItems = new UmbArrayState<UmbMediaCardItemModel>([], (x) => x.unique);
+	readonly cardItems = this.#cardItems.asObservable();
+
 	constructor(host: UmbControllerHost) {
 		super(host, UMB_MEDIA_ITEM_REPOSITORY_ALIAS, UMB_MEDIA_TREE_PICKER_MODAL);
+		this.#imagingRepository = new UmbImagingRepository(host);
+
+		this.observe(this.selectedItems, async (selectedItems) => {
+			if (!selectedItems.length) return;
+			const { data } = await this.#imagingRepository.requestResizedItems(selectedItems.map((x) => x.unique));
+
+			this.#cardItems.setValue(
+				selectedItems.map((item) => {
+					const url = data?.find((x) => x.unique === item.unique)?.url;
+					return {
+						icon: item.mediaType.icon,
+						name: item.name,
+						unique: item.unique,
+						isTrashed: item.isTrashed,
+						entityType: item.entityType,
+						url,
+					};
+				}),
+			);
+		});
 	}
 }

--- a/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
+++ b/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
@@ -67,7 +67,14 @@ export class UmbMediaPickerModalElement extends UmbModalBaseElement<UmbMediaPick
 
 		return items.map((item): UmbMediaCardItemModel => {
 			const url = data?.find((media) => media.unique === item.unique)?.url;
-			return { name: item.name, unique: item.unique, url, icon: item.mediaType.icon, entityType: item.entityType };
+			return {
+				name: item.name,
+				unique: item.unique,
+				url,
+				icon: item.mediaType.icon,
+				entityType: item.entityType,
+				isTrashed: item.isTrashed,
+			};
 		});
 	}
 

--- a/src/packages/media/media/modals/media-picker/types.ts
+++ b/src/packages/media/media/modals/media-picker/types.ts
@@ -5,8 +5,9 @@ export interface UmbMediaCardItemModel {
 	name: string;
 	unique: string;
 	entityType: UmbMediaEntityType;
+	isTrashed: boolean;
+	icon: string;
 	url?: string;
-	icon?: string;
 }
 
 export interface UmbMediaPathModel extends UmbEntityModel {


### PR DESCRIPTION
## Description

Property Editor Media Picker and Multiple Media Picker now uses the Imaging Endpoint to display the images.

Dropzone manager now returns media unique + temporary unique of an created media item, rather than only the temporary unique. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
