### PR TITLE
fix: donut chart components are not exported

### DIFF
--- a/src/packages/log-viewer/index.ts
+++ b/src/packages/log-viewer/index.ts
@@ -1,1 +1,3 @@
 export * from './repository/index.js';
+export * from './components/donut-chart/donut-chart.element.js';
+export * from './components/donut-chart/donut-slice.element.js';


### PR DESCRIPTION
Fixed https://github.com/umbraco/Umbraco.CMS.Backoffice/issues/1832 by exporting the donut chart from the log viewer as aggreged with @iOvergaard on Discord.



## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)


## Checklist

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
