### PR TITLE
Bugfix: Fix image cropper remove issue

### DIFF
--- a/src/packages/media/media/components/input-image-cropper/input-image-cropper.element.ts
+++ b/src/packages/media/media/components/input-image-cropper/input-image-cropper.element.ts
@@ -68,8 +68,9 @@ export class UmbInputImageCropperElement extends UmbLitElement {
 
 	#onRemove = () => {
 		this.value = assignToFrozenObject(this.value, { src: '', temporaryFileId: null });
-		if (!this.fileUnique) return;
-		this.#manager?.removeOne(this.fileUnique);
+		if (this.fileUnique) {
+			this.#manager?.removeOne(this.fileUnique);
+		}
 		this.fileUnique = undefined;
 		this.file = undefined;
 
@@ -114,7 +115,7 @@ export class UmbInputImageCropperElement extends UmbLitElement {
 		const value = (e.target as UmbInputImageCropperFieldElement).value;
 
 		if (!value) {
-			this.value = { src: '', crops: [], focalPoint: { left: 0.5, top: 0.5 } };
+			this.value = { src: '', crops: [], focalPoint: { left: 0.5, top: 0.5 }, temporaryFileId: null };
 			this.dispatchEvent(new UmbChangeEvent());
 			return;
 		}

--- a/src/packages/media/media/property-editors/image-cropper/property-editor-ui-image-cropper.element.ts
+++ b/src/packages/media/media/property-editors/image-cropper/property-editor-ui-image-cropper.element.ts
@@ -15,6 +15,7 @@ import {
 export class UmbPropertyEditorUIImageCropperElement extends UmbLitElement implements UmbPropertyEditorUiElement {
 	@property({ attribute: false })
 	value: UmbImageCropperPropertyEditorValue = {
+		temporaryFileId: null,
 		src: '',
 		crops: [],
 		focalPoint: { left: 0.5, top: 0.5 },
@@ -28,6 +29,7 @@ export class UmbPropertyEditorUIImageCropperElement extends UmbLitElement implem
 		if (changedProperties.has('value')) {
 			if (!this.value) {
 				this.value = {
+					temporaryFileId: null,
 					src: '',
 					crops: [],
 					focalPoint: { left: 0.5, top: 0.5 },


### PR DESCRIPTION
## Description

Fixed an issue where the image would not be removed in `Image Cropper` if it was a image that came from the server.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)