### PR TITLE
Feature: Adds `umb-input-rich-media` component

### DIFF
--- a/src/packages/media/media/property-editors/media-entity-picker/property-editor-ui-media-entity-picker.element.ts
+++ b/src/packages/media/media/property-editors/media-entity-picker/property-editor-ui-media-entity-picker.element.ts
@@ -33,7 +33,7 @@ export class UmbPropertyEditorUIMediaEntityPickerElement extends UmbLitElement i
 		return undefined;
 	}
 
-	#onChange(event: { target: UmbInputMediaElement }) {
+	#onChange(event: CustomEvent & { target: UmbInputMediaElement }) {
 		this.value = event.target.selection?.join(',') ?? null;
 		this.dispatchEvent(new UmbPropertyValueChangeEvent());
 	}

--- a/src/packages/media/media/property-editors/media-picker/components/index.ts
+++ b/src/packages/media/media/property-editors/media-picker/components/index.ts
@@ -1,0 +1,1 @@
+export * from './input-rich-media/index.js';

--- a/src/packages/media/media/property-editors/media-picker/components/input-rich-media/index.ts
+++ b/src/packages/media/media/property-editors/media-picker/components/input-rich-media/index.ts
@@ -1,0 +1,1 @@
+export * from './input-rich-media.element.js';

--- a/src/packages/media/media/property-editors/media-picker/components/input-rich-media/input-rich-media.element.ts
+++ b/src/packages/media/media/property-editors/media-picker/components/input-rich-media/input-rich-media.element.ts
@@ -1,0 +1,69 @@
+import type { UmbCropModel } from '../../index.js';
+import type { UmbMediaCardItemModel } from '../../../../modals/index.js';
+import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
+import { customElement, html, ifDefined, property } from '@umbraco-cms/backoffice/external/lit';
+import { UmbInputMediaElement } from '@umbraco-cms/backoffice/media';
+import type { UmbUploadableFileModel } from '@umbraco-cms/backoffice/media';
+
+const elementName = 'umb-input-rich-media';
+@customElement(elementName)
+export class UmbInputRichMediaElement extends UmbInputMediaElement {
+	@property({ type: Boolean })
+	focalPointEnabled = false;
+
+	@property({ type: Array })
+	crops?: Array<UmbCropModel>;
+
+	async #onUploadCompleted(e: CustomEvent) {
+		const completed = e.detail?.completed as Array<UmbUploadableFileModel>;
+		const uploaded = completed.map((file) => file.unique);
+
+		this.selection = [...this.selection, ...uploaded];
+		this.dispatchEvent(new UmbChangeEvent());
+	}
+
+	render() {
+		return html`${this.#renderDropzone()} ${super.render()}`;
+	}
+
+	#renderDropzone() {
+		if (this.items && this.items.length >= this.max) return;
+		return html`<umb-dropzone @change=${this.#onUploadCompleted}></umb-dropzone>`;
+	}
+
+	protected renderItem(item: UmbMediaCardItemModel) {
+		return html`
+			<uui-card-media
+				name=${ifDefined(item.name === null ? undefined : item.name)}
+				detail=${ifDefined(item.unique)}
+				href="${this.editMediaPath}edit/${item.unique}"
+				@click=${() => {
+					alert('open media crops modal');
+				}}>
+				${item.url
+					? html`<img src=${item.url} alt=${item.name} />`
+					: html`<umb-icon name=${ifDefined(item.mediaType.icon)}></umb-icon>`}
+				${this.renderIsTrashed(item)}
+				<uui-action-bar slot="actions">
+					<uui-button label="Copy media" look="secondary">
+						<uui-icon name="icon-documents"></uui-icon>
+					</uui-button>
+					<uui-button
+						label=${this.localize.term('general_remove')}
+						look="secondary"
+						@click=${() => this.onRemove(item)}>
+						<uui-icon name="icon-trash"></uui-icon>
+					</uui-button>
+				</uui-action-bar>
+			</uui-card-media>
+		`;
+	}
+}
+
+export { UmbInputRichMediaElement as element };
+
+declare global {
+	interface HTMLElementTagNameMap {
+		[elementName]: UmbInputRichMediaElement;
+	}
+}

--- a/src/packages/media/media/property-editors/media-picker/property-editor-ui-media-picker.element.ts
+++ b/src/packages/media/media/property-editors/media-picker/property-editor-ui-media-picker.element.ts
@@ -1,14 +1,14 @@
-import type { UmbInputMediaElement } from '../../components/input-media/input-media.element.js';
-import '../../components/input-media/input-media.element.js';
+import type { UmbInputRichMediaElement } from './components/input-rich-media/input-rich-media.element.js';
 import type { UmbCropModel, UmbMediaPickerPropertyValue } from './index.js';
-import { html, customElement, property, state } from '@umbraco-cms/backoffice/external/lit';
-import {
-	UmbPropertyValueChangeEvent,
-	type UmbPropertyEditorConfigCollection,
-} from '@umbraco-cms/backoffice/property-editor';
-import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extension-registry';
-import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { customElement, html, property, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbId } from '@umbraco-cms/backoffice/id';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { UmbPropertyValueChangeEvent } from '@umbraco-cms/backoffice/property-editor';
+import type { NumberRangeValueType } from '@umbraco-cms/backoffice/models';
+import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
+import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extension-registry';
+
+import './components/input-rich-media/input-rich-media.element.js';
 
 /**
  * @element umb-property-editor-ui-media-picker
@@ -39,28 +39,19 @@ export class UmbPropertyEditorUIMediaPickerElement extends UmbLitElement impleme
 	private _allowedMediaTypes: Array<string> = [];
 
 	public set config(config: UmbPropertyEditorConfigCollection | undefined) {
-		const multiple = config?.getByAlias('multiple');
-		this._multiple = (multiple?.value as boolean) ?? false;
+		if (!config) return;
 
-		const startNodeId = config?.getByAlias('startNodeId');
-		this._startNode = (startNodeId?.value as string) ?? '';
+		this._multiple = Boolean(config.getValueByAlias('multiple'));
+		this._startNode = config.getValueByAlias<string>('startNodeId') ?? '';
+		this._focalPointEnabled = Boolean(config.getValueByAlias('enableFocalPoint'));
+		this._crops = config?.getValueByAlias<Array<UmbCropModel>>('crops') ?? [];
 
-		const enableFocalPoint = config?.getByAlias('enableFocalPoint');
-		this._focalPointEnabled = (enableFocalPoint?.value as boolean) ?? false;
-
-		const crops = config?.getByAlias('crops');
-		this._crops = (crops?.value as Array<UmbCropModel>) ?? [];
-
-		const filter = config?.getByAlias('filter')?.value as string;
+		const filter = config.getValueByAlias<string>('filter') ?? '';
 		this._allowedMediaTypes = filter?.split(',') ?? [];
 
-		const validationLimit = config?.getByAlias('validationLimit');
-		if (!validationLimit) return;
-
-		const minMax: Record<string, number> = validationLimit.value as any;
-
-		this._limitMin = minMax.min ?? 0;
-		this._limitMax = minMax.max ?? Infinity;
+		const minMax = config.getValueByAlias<NumberRangeValueType>('validationLimit');
+		this._limitMin = minMax?.min ?? 0;
+		this._limitMax = minMax?.max ?? Infinity;
 	}
 	public get config() {
 		return undefined;
@@ -80,8 +71,8 @@ export class UmbPropertyEditorUIMediaPickerElement extends UmbLitElement impleme
 
 	#value: Array<UmbMediaPickerPropertyValue> = [];
 
-	#onChange(event: CustomEvent) {
-		const selection = (event.target as UmbInputMediaElement).selection;
+	#onChange(event: CustomEvent & { target: UmbInputRichMediaElement }) {
+		const selection = event.target.selection;
 
 		const result = selection.map((mediaKey) => {
 			return {

--- a/src/packages/media/media/property-editors/media-picker/property-editor-ui-media-picker.element.ts
+++ b/src/packages/media/media/property-editors/media-picker/property-editor-ui-media-picker.element.ts
@@ -100,7 +100,7 @@ export class UmbPropertyEditorUIMediaPickerElement extends UmbLitElement impleme
 
 	render() {
 		return html`
-			<umb-input-media
+			<umb-input-rich-media
 				@change=${this.#onChange}
 				?multiple=${this._multiple}
 				.allowedContentTypeIds=${this._allowedMediaTypes}
@@ -110,7 +110,7 @@ export class UmbPropertyEditorUIMediaPickerElement extends UmbLitElement impleme
 				.selection=${this._items}
 				.min=${this._limitMin}
 				.max=${this._limitMax}>
-			</umb-input-media>
+			</umb-input-rich-media>
 		`;
 	}
 }

--- a/src/packages/packages/package-builder/workspace/workspace-package-builder.element.ts
+++ b/src/packages/packages/package-builder/workspace/workspace-package-builder.element.ts
@@ -229,7 +229,10 @@ export class UmbWorkspacePackageBuilderElement extends UmbLitElement {
 		return html`
 			<umb-property-layout label="Media">
 				<div slot="editor">
-					<umb-input-media .selection=${this._package.mediaIds ?? []} @change=${this.#onMediaChange}></umb-input-media>
+					<umb-input-media
+						multiple
+						.selection=${this._package.mediaIds ?? []}
+						@change=${this.#onMediaChange}></umb-input-media>
 					<uui-checkbox
 						label="Include child nodes"
 						.checked=${this._package.mediaLoadChildNodes ?? false}


### PR DESCRIPTION
## Description

@loivsen, I was looking over PR #1840 (branch `feature/media-picker-filter-and-media-input-config`), and noticed properties added to the `umb-input-media` component (for focal point and crops), which may cause us a potential issue with the different use-cases between the **Media entity picker** (that stores the Guid values) and the **richer Media Picker** (that stores the focal/crop data).

This PR adds in a `umb-input-rich-media` component (that inherits from `umb-input-media`, so not to duplicate too much code), and adds the newer features.

Let me know what you think about these changes.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
