### PR TITLE
Update property-layout.element.ts

### DIFF
--- a/src/packages/core/property/property-layout/property-layout.element.ts
+++ b/src/packages/core/property/property-layout/property-layout.element.ts
@@ -104,7 +104,7 @@ export class UmbPropertyLayoutElement extends LitElement {
 				height: min-content;
 			}
 			/*@container (width > 600px) {*/
-			#headerColumn {
+			:host(:not([orientation='vertical'])) #headerColumn {
 				position: sticky;
 				top: calc(var(--uui-size-space-2) * -1);
 			}
@@ -128,7 +128,7 @@ export class UmbPropertyLayoutElement extends LitElement {
 				margin-top: var(--uui-size-space-3);
 			}
 			/*@container (width > 600px) {*/
-			#editorColumn {
+			:host(:not([orientation='vertical'])) #editorColumn {
 				margin-top: 0;
 			}
 			/*}*/


### PR DESCRIPTION
Don't enable sticky styles in vertical orientation

## Description

Updated sticky styles to be prefixed with a negative lookup of the `orientation='vertical'` attribute. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

I have a number of modals that render the `umb-property-layout` component in vertical orientation and the label + description incorrectly scroll over the top of the input when scrolling down the page. In vertical orientation, these labels shouldn't be sticky.

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
