### PR TITLE
Bugfix: request reload of entity after unpublish

### DIFF
--- a/src/packages/documents/documents/entity-actions/unpublish.action.ts
+++ b/src/packages/documents/documents/entity-actions/unpublish.action.ts
@@ -2,10 +2,15 @@ import { UmbDocumentDetailRepository, UmbDocumentPublishingRepository } from '..
 import type { UmbDocumentVariantOptionModel } from '../types.js';
 import { UMB_DOCUMENT_UNPUBLISH_MODAL } from '../modals/index.js';
 import { UMB_APP_LANGUAGE_CONTEXT, UmbLanguageCollectionRepository } from '@umbraco-cms/backoffice/language';
-import { type UmbEntityActionArgs, UmbEntityActionBase } from '@umbraco-cms/backoffice/entity-action';
+import {
+	type UmbEntityActionArgs,
+	UmbEntityActionBase,
+	UmbRequestReloadStructureForEntityEvent,
+} from '@umbraco-cms/backoffice/entity-action';
 import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
+import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
 
 export class UmbUnpublishDocumentEntityAction extends UmbEntityActionBase<never> {
 	constructor(host: UmbControllerHost, args: UmbEntityActionArgs<never>) {
@@ -73,6 +78,14 @@ export class UmbUnpublishDocumentEntityAction extends UmbEntityActionBase<never>
 		if (variantIds.length) {
 			const publishingRepository = new UmbDocumentPublishingRepository(this._host);
 			await publishingRepository.unpublish(this.args.unique, variantIds);
+
+			const actionEventContext = await this.getContext(UMB_ACTION_EVENT_CONTEXT);
+			const event = new UmbRequestReloadStructureForEntityEvent({
+				unique: this.args.unique,
+				entityType: this.args.entityType,
+			});
+
+			actionEventContext.dispatchEvent(event);
 		}
 	}
 }

--- a/src/packages/documents/documents/entity-bulk-actions/unpublish/unpublish.action.ts
+++ b/src/packages/documents/documents/entity-bulk-actions/unpublish/unpublish.action.ts
@@ -8,9 +8,19 @@ import { UmbEntityBulkActionBase } from '@umbraco-cms/backoffice/entity-bulk-act
 import { UMB_APP_LANGUAGE_CONTEXT, UmbLanguageCollectionRepository } from '@umbraco-cms/backoffice/language';
 import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 import { UmbLocalizationController } from '@umbraco-cms/backoffice/localization-api';
+import { UMB_ENTITY_CONTEXT } from '@umbraco-cms/backoffice/entity';
+import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
+import { UmbRequestReloadChildrenOfEntityEvent } from '@umbraco-cms/backoffice/entity-action';
 
 export class UmbDocumentUnpublishEntityBulkAction extends UmbEntityBulkActionBase<object> {
 	async execute() {
+		const entityContext = await this.getContext(UMB_ENTITY_CONTEXT);
+		const entityType = entityContext.getEntityType();
+		const unique = entityContext.getUnique();
+
+		if (!entityType) throw new Error('Entity type not found');
+		if (unique === undefined) throw new Error('Entity unique not found');
+
 		// If there is only one selection, we can refer to the regular unpublish entity action:
 		if (this.selection.length === 1) {
 			const action = new UmbUnpublishDocumentEntityAction(this._host, {
@@ -43,6 +53,12 @@ export class UmbDocumentUnpublishEntityBulkAction extends UmbEntityBulkActionBas
 
 		const modalManagerContext = await this.getContext(UMB_MODAL_MANAGER_CONTEXT);
 
+		const eventContext = await this.getContext(UMB_ACTION_EVENT_CONTEXT);
+		const event = new UmbRequestReloadChildrenOfEntityEvent({
+			entityType,
+			unique,
+		});
+
 		// If there is only one language available, we can skip the modal and unpublish directly:
 		if (options.length === 1) {
 			const localizationController = new UmbLocalizationController(this._host);
@@ -62,6 +78,7 @@ export class UmbDocumentUnpublishEntityBulkAction extends UmbEntityBulkActionBas
 				const variantId = new UmbVariantId(options[0].language.unique, null);
 				const publishingRepository = new UmbDocumentPublishingRepository(this._host);
 				await publishingRepository.unpublish(this.selection[0], [variantId]);
+				eventContext.dispatchEvent(event);
 			}
 			return;
 		}
@@ -95,6 +112,7 @@ export class UmbDocumentUnpublishEntityBulkAction extends UmbEntityBulkActionBas
 		if (variantIds.length) {
 			for (const unique of this.selection) {
 				await repository.unpublish(unique, variantIds);
+				eventContext.dispatchEvent(event);
 			}
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Dispatch request reload event after unpublish and unpublish bulk actions.

## How to test:
* Test that a collection publishing state is updated when using the bulk actions.
* Test that a collection publishing state is updated when using the tree item actions

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
