### PR TITLE
Chore: Temp remove not started entity actions

### DIFF
--- a/src/packages/documents/documents/entity-actions/manifests.ts
+++ b/src/packages/documents/documents/entity-actions/manifests.ts
@@ -86,6 +86,7 @@ const entityActions: Array<ManifestEntityAction> = [
 			},
 		],
 	},
+	/* TODO: Implement Permissions Entity Action
 	{
 		type: 'entityAction',
 		kind: 'default',
@@ -108,6 +109,7 @@ const entityActions: Array<ManifestEntityAction> = [
 			},
 		],
 	},
+	*/
 	{
 		type: 'entityAction',
 		kind: 'default',

--- a/src/packages/documents/documents/entity-actions/manifests.ts
+++ b/src/packages/documents/documents/entity-actions/manifests.ts
@@ -110,6 +110,7 @@ const entityActions: Array<ManifestEntityAction> = [
 		],
 	},
 	*/
+	/* TODO: Implement Notifications Entity Action
 	{
 		type: 'entityAction',
 		kind: 'default',
@@ -132,6 +133,7 @@ const entityActions: Array<ManifestEntityAction> = [
 			},
 		],
 	},
+	*/
 ];
 
 export const manifests: Array<ManifestTypes> = [

--- a/src/packages/documents/documents/entity-bulk-actions/manifests.ts
+++ b/src/packages/documents/documents/entity-bulk-actions/manifests.ts
@@ -57,6 +57,7 @@ export const manifests: Array<ManifestEntityBulkAction> = [
 			},
 		],
 	},
+	/* TODO: implement bulk duplicate action
 	{
 		type: 'entityBulkAction',
 		kind: 'default',
@@ -79,6 +80,8 @@ export const manifests: Array<ManifestEntityBulkAction> = [
 			},
 		],
 	},
+	*/
+	/* TODO: implement bulk move action
 	{
 		type: 'entityBulkAction',
 		kind: 'default',
@@ -101,6 +104,8 @@ export const manifests: Array<ManifestEntityBulkAction> = [
 			},
 		],
 	},
+	*/
+	/* TODO: implement bulk trash action
 	{
 		type: 'entityBulkAction',
 		kind: 'default',
@@ -123,4 +128,5 @@ export const manifests: Array<ManifestEntityBulkAction> = [
 			},
 		],
 	},
+	*/
 ];

--- a/src/packages/user/user/entity-bulk-actions/manifests.ts
+++ b/src/packages/user/user/entity-bulk-actions/manifests.ts
@@ -8,6 +8,7 @@ import type { ManifestEntityBulkAction, ManifestTypes } from '@umbraco-cms/backo
 import { UMB_COLLECTION_ALIAS_CONDITION } from '@umbraco-cms/backoffice/collection';
 
 const entityActions: Array<ManifestEntityBulkAction> = [
+	/* TODO: Implement SetGroup entity action
 	{
 		type: 'entityBulkAction',
 		alias: 'Umb.EntityBulkAction.User.SetGroup',
@@ -25,6 +26,7 @@ const entityActions: Array<ManifestEntityBulkAction> = [
 			},
 		],
 	},
+	*/
 	{
 		type: 'entityBulkAction',
 		alias: 'Umb.EntityBulkAction.User.Enable',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I don't think there is a point in rendering these actions in the UI as the implementation hasn't been started yet. I think it adds to the impression of "things not working" that these are present but only show a console.log or an alert. We can add these back as soon as they are implemented.

The removed actions are:
* Document - set user group
* Document - notifications
* Document - bulk move
* Document - bulk copy
* Document - bulk trash
* User - bulk set user group

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
