### PR TITLE
Chore: Storybook: Hide legacy icons

### DIFF
--- a/src/packages/core/icon-registry/icon.stories.ts
+++ b/src/packages/core/icon-registry/icon.stories.ts
@@ -8,6 +8,7 @@ export default {
 } as Meta;
 
 const Template: Story = () => {
+	const approvedIcons = icons.filter((x) => x.legacy !== true);
 	return html`
 		<div
 			style="display: grid;
@@ -17,7 +18,7 @@ const Template: Story = () => {
     place-items: start;
     justify-content: space-between;">
 			${repeat(
-				icons,
+				approvedIcons,
 				(icon) => icon.name,
 				(icon) =>
 					html` <div


### PR DESCRIPTION
## Description

The Icons docs in Storybook was displaying all icons, including those marked as `legacy`.
https://apidocs.umbraco.com/v14/ui/?path=/docs/umb-icons--docs

I have updated the story to only display the icons approved for use in the backoffice.

## Types of changes

- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
