### PR TITLE
Bugfix: using elementName should not fire console error 

### DIFF
--- a/src/libs/extension-api/functions/create-extension-element.function.ts
+++ b/src/libs/extension-api/functions/create-extension-element.function.ts
@@ -11,7 +11,7 @@ export async function createExtensionElement<ElementType extends HTMLElement>(
 		const elementConstructor = await loadManifestElement<ElementType>(elementPropValue);
 		if (elementConstructor) {
 			return new elementConstructor();
-		} else {
+		} else if (!manifest.elementName) {
 			console.error(
 				`-- Extension of alias "${manifest.alias}" did not succeed creating an element class instance via the extension manifest property '${elementPropValue}'. The imported Element JS file did not export a 'element' or 'default'. Alternatively define the 'elementName' in the manifest.`,
 				manifest,


### PR DESCRIPTION
Stop firing a console error when there is a elementName defined.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
