### PR TITLE
Feature: allow wide content in property descriptions

### DIFF
--- a/src/packages/core/property/property-layout/property-layout.element.ts
+++ b/src/packages/core/property/property-layout/property-layout.element.ts
@@ -115,6 +115,7 @@ export class UmbPropertyLayoutElement extends UmbLitElement {
 
 			uui-label {
 				position: relative;
+				overflow-x: auto;
 			}
 			:host([invalid]) uui-label {
 				color: var(--uui-color-danger);
@@ -125,6 +126,7 @@ export class UmbPropertyLayoutElement extends UmbLitElement {
 
 			#description {
 				color: var(--uui-color-text-alt);
+				overflow-x: auto;
 			}
 
 			#editorColumn {


### PR DESCRIPTION
adds `overflow-x: auto` to both the label and the description in case very wide content has been added such as an image

**before**
![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/752371/c523086b-c5aa-4fd1-8f92-e64d80bb18ce)

**after**
![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/752371/d28986bc-4106-4023-b5a5-755ba999e15a)
