### PR TITLE
Bugfix: lower document tree item opacity on drafts

### DIFF
--- a/src/packages/documents/documents/tree/tree-item/document-tree-item.element.ts
+++ b/src/packages/documents/documents/tree/tree-item/document-tree-item.element.ts
@@ -1,5 +1,5 @@
 import type { UmbDocumentTreeItemModel, UmbDocumentTreeItemVariantModel } from '../types.js';
-import { css, html, nothing, customElement, state } from '@umbraco-cms/backoffice/external/lit';
+import { css, html, nothing, customElement, state, classMap } from '@umbraco-cms/backoffice/external/lit';
 import type { UmbAppLanguageContext } from '@umbraco-cms/backoffice/language';
 import { UMB_APP_LANGUAGE_CONTEXT } from '@umbraco-cms/backoffice/language';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
@@ -60,9 +60,17 @@ export class UmbDocumentTreeItemElement extends UmbTreeItemElementBase<UmbDocume
 		return this._variant?.name ?? `(${fallbackName})`;
 	}
 
+	#isDraft() {
+		if (this.#isInvariant()) {
+			return this._item?.variants[0].state === 'Draft';
+		}
+
+		return this._variant?.state === 'Draft';
+	}
+
 	renderIconContainer() {
 		return html`
-			<span id="icon-container" slot="icon">
+			<span id="icon-container" slot="icon" class=${classMap({ draft: this.#isDraft() })}>
 				${this.item?.documentType.icon
 					? html`
 							<umb-icon id="icon" slot="icon" name="${this.item.documentType.icon}"></umb-icon>
@@ -76,9 +84,10 @@ export class UmbDocumentTreeItemElement extends UmbTreeItemElementBase<UmbDocume
 		`;
 	}
 
-	// TODO: lower opacity if item is not published
 	renderLabel() {
-		return html`<span id="label" slot="label">${this.#getLabel()}</span> `;
+		return html`<span id="label" slot="label" class=${classMap({ draft: this.#isDraft() })}
+			>${this.#getLabel()}</span
+		> `;
 	}
 
 	static styles = [
@@ -102,6 +111,10 @@ export class UmbDocumentTreeItemElement extends UmbTreeItemElementBase<UmbDocume
 				bottom: 0;
 				right: 0;
 				border-radius: 100%;
+			}
+
+			.draft {
+				opacity: 0.6;
 			}
 		`,
 	];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes issue #1663

Lower the document tree item opacity when the document is a draft.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
