### PR TITLE
Bugfix: Fix media tree root element

### DIFF
--- a/src/packages/documents/documents/tree/manifests.ts
+++ b/src/packages/documents/documents/tree/manifests.ts
@@ -51,7 +51,7 @@ const rootTreeItem: ManifestTreeItem = {
 	type: 'treeItem',
 	kind: 'default',
 	alias: 'Umb.TreeItem.Document.Root',
-	name: 'Document Tree Item',
+	name: 'Document Tree Root',
 	forEntityTypes: [UMB_DOCUMENT_ROOT_ENTITY_TYPE],
 };
 

--- a/src/packages/media/media/tree/manifests.ts
+++ b/src/packages/media/media/tree/manifests.ts
@@ -44,7 +44,15 @@ const treeItem: ManifestTreeItem = {
 	name: 'Media Tree Item',
 	element: () => import('./tree-item/media-tree-item.element.js'),
 	api: () => import('./tree-item/media-tree-item.context.js'),
-	forEntityTypes: [UMB_MEDIA_ROOT_ENTITY_TYPE, UMB_MEDIA_ENTITY_TYPE],
+	forEntityTypes: [UMB_MEDIA_ENTITY_TYPE],
+};
+
+const rootTreeItem: ManifestTreeItem = {
+	type: 'treeItem',
+	kind: 'default',
+	alias: 'Umb.TreeItem.Media.Root',
+	name: 'Media Tree Root',
+	forEntityTypes: [UMB_MEDIA_ROOT_ENTITY_TYPE],
 };
 
 export const manifests: Array<ManifestTypes> = [
@@ -52,5 +60,6 @@ export const manifests: Array<ManifestTypes> = [
 	treeStore,
 	tree,
 	treeItem,
+	rootTreeItem,
 	...reloadTreeItemChildrenManifests,
 ];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The media tree was throwing a js error when rendering the root (ex: in pickers). It is now fixed by using a default tree item for the media root.

## How to reproduce

* When you try to move a media item underneath a media "folder" the tree wouldn't show up in the picker.

## How to test
* Make sure you can see the media tree when trying to move a media item

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
