### PR TITLE
Bugfix: Collection: determine if `filter.skip` has preconfigured value

### DIFF
--- a/src/packages/core/collection/default/collection-default.context.ts
+++ b/src/packages/core/collection/default/collection-default.context.ts
@@ -120,11 +120,14 @@ export class UmbDefaultCollectionContext<
 			this.pagination.setPageSize(this.#config.pageSize);
 		}
 
+		const filterValue = this.#filter.getValue() as FilterModelType;
+
 		this.#filter.setValue({
 			...this.#defaultFilter,
 			...this.#config,
 			...this.#filter.getValue(),
-			skip: 0,
+			...filterValue,
+			skip: filterValue.skip ?? 0,
 			take: this.#config.pageSize,
 		});
 

--- a/src/packages/core/collection/default/collection-default.context.ts
+++ b/src/packages/core/collection/default/collection-default.context.ts
@@ -125,7 +125,6 @@ export class UmbDefaultCollectionContext<
 		this.#filter.setValue({
 			...this.#defaultFilter,
 			...this.#config,
-			...this.#filter.getValue(),
 			...filterValue,
 			skip: filterValue.skip ?? 0,
 			take: this.#config.pageSize,


### PR DESCRIPTION
## Description

In the default Collection context, determine if `filter.skip` has a preconfigured value.

/cc @nathanwoulfe 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
