### PR TITLE
Fix `blockEditorCustomView` manifest

### DIFF
--- a/src/packages/core/extension-registry/models/block-editor-custom-view.model.ts
+++ b/src/packages/core/extension-registry/models/block-editor-custom-view.model.ts
@@ -2,5 +2,5 @@ import type { UmbPropertyEditorUiElement } from '../interfaces/index.js';
 import type { ManifestElement } from '@umbraco-cms/backoffice/extension-api';
 
 export interface ManifestBlockEditorCustomView extends ManifestElement<UmbPropertyEditorUiElement> {
-	type: 'bockEditorCustomView';
+	type: 'blockEditorCustomView';
 }


### PR DESCRIPTION
Fix a spelling mistake so custom views can be added with a correct manifest

## Description

The `block-editor-custom-view.model.ts` has a spelling mistake, looking for manifests with type `bockEditorCustomView` instead of `blockEditorCustomView`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

Bug fix so custom views for blocks can be implemented correctly

## How to test?

Instead of setting the type manually like so:
```ts
const blockEditorCustomView: ManifestElement<UmbPropertyEditorUiElement> = {
  type: 'blockEditorCustomView',
  alias: 'BlockPreview.CustomView',
  name: 'BlockPreview',
  element: () => import('./block-preview.custom-view.js')
}
```

You should be able to then use the correct manifest:
```ts
const blockEditorCustomView: ManifestBlockEditorCustomView = {
  alias: 'BlockPreview.CustomView',
  name: 'BlockPreview',
  element: () => import('./block-preview.custom-view.js')
}
```

## Screenshots (if appropriate)

## Checklist

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
