### PR TITLE
Bugfix: Document Picker: Ensures `max = 1`

### DIFF
--- a/src/packages/documents/documents/property-editors/document-picker/property-editor-ui-document-picker.element.ts
+++ b/src/packages/documents/documents/property-editors/document-picker/property-editor-ui-document-picker.element.ts
@@ -19,7 +19,7 @@ export class UmbPropertyEditorUIDocumentPickerElement extends UmbLitElement impl
 		const minMax = config.getValueByAlias<NumberRangeValueType>('validationLimit');
 		if (minMax) {
 			this._min = minMax.min && minMax.min > 0 ? minMax.min : 0;
-			this._max = minMax.max && minMax.max > 0 ? minMax.max : Infinity;
+			this._max = minMax.max && minMax.max > 0 ? minMax.max : 1;
 		}
 
 		this._startNodeId = config.getValueByAlias('startNodeId');
@@ -29,8 +29,10 @@ export class UmbPropertyEditorUIDocumentPickerElement extends UmbLitElement impl
 	@state()
 	private _min = 0;
 
+	// NOTE: The legacy "Content Picker" property-editor only supported 1 item,
+	// so that's why it's being enforced here. We'll evolve this in a future version. [LK]
 	@state()
-	private _max = Infinity;
+	private _max = 1;
 
 	@state()
 	private _startNodeId?: string;


### PR DESCRIPTION
## Description

To support the legacy data format of the [Content Picker](https://docs.umbraco.com/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/content-picker), and the backend will only accept a single `Guid` (`string`) value, not a comma-separated string, so we need to enforce that `max = 1`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
