### PR TITLE
Bugfix: Picker inputs - moved `addValidator()` calls to `constructor()`

### DIFF
--- a/src/packages/core/components/input-entity/input-entity.element.ts
+++ b/src/packages/core/components/input-entity/input-entity.element.ts
@@ -94,12 +94,6 @@ export class UmbInputEntityElement extends UUIFormControlMixin(UmbLitElement, ''
 
 	constructor() {
 		super();
-	}
-
-	connectedCallback() {
-		super.connectedCallback();
-
-		if (!this.#pickerContext) return;
 
 		this.addValidator(
 			'rangeUnderflow',

--- a/src/packages/documents/documents/components/input-document/input-document.element.ts
+++ b/src/packages/documents/documents/components/input-document/input-document.element.ts
@@ -118,13 +118,6 @@ export class UmbInputDocumentElement extends UUIFormControlMixin(UmbLitElement, 
 				this._editDocumentPath = routeBuilder({});
 			});
 
-		this.observe(this.#pickerContext.selection, (selection) => (this.value = selection.join(',')), '_observeSelection');
-		this.observe(this.#pickerContext.selectedItems, (selectedItems) => (this._items = selectedItems), '_observerItems');
-	}
-
-	connectedCallback(): void {
-		super.connectedCallback();
-
 		this.addValidator(
 			'rangeUnderflow',
 			() => this.minMessage,
@@ -136,6 +129,9 @@ export class UmbInputDocumentElement extends UUIFormControlMixin(UmbLitElement, 
 			() => this.maxMessage,
 			() => !!this.max && this.#pickerContext.getSelection().length > this.max,
 		);
+
+		this.observe(this.#pickerContext.selection, (selection) => (this.value = selection.join(',')), '_observeSelection');
+		this.observe(this.#pickerContext.selectedItems, (selectedItems) => (this._items = selectedItems), '_observerItems');
 	}
 
 	protected getFormElement() {

--- a/src/packages/members/member-group/components/input-member-group/input-member-group.element.ts
+++ b/src/packages/members/member-group/components/input-member-group/input-member-group.element.ts
@@ -117,13 +117,6 @@ export class UmbInputMemberGroupElement extends UUIFormControlMixin(UmbLitElemen
 				this._editMemberGroupPath = routeBuilder({});
 			});
 
-		this.observe(this.#pickerContext.selection, (selection) => (this.value = selection.join(',')), '_observeSelection');
-		this.observe(this.#pickerContext.selectedItems, (selectedItems) => (this._items = selectedItems), '_observeItems');
-	}
-
-	connectedCallback(): void {
-		super.connectedCallback();
-
 		this.addValidator(
 			'rangeUnderflow',
 			() => this.minMessage,
@@ -135,6 +128,9 @@ export class UmbInputMemberGroupElement extends UUIFormControlMixin(UmbLitElemen
 			() => this.maxMessage,
 			() => !!this.max && this.#pickerContext.getSelection().length > this.max,
 		);
+
+		this.observe(this.#pickerContext.selection, (selection) => (this.value = selection.join(',')), '_observeSelection');
+		this.observe(this.#pickerContext.selectedItems, (selectedItems) => (this._items = selectedItems), '_observeItems');
 	}
 
 	protected getFormElement() {

--- a/src/packages/members/member/components/input-member/input-member.element.ts
+++ b/src/packages/members/member/components/input-member/input-member.element.ts
@@ -117,13 +117,6 @@ export class UmbInputMemberElement extends UUIFormControlMixin(UmbLitElement, ''
 				this._editMemberPath = routeBuilder({});
 			});
 
-		this.observe(this.#pickerContext.selection, (selection) => (this.value = selection.join(',')), '_observeSelection');
-		this.observe(this.#pickerContext.selectedItems, (selectedItems) => (this._items = selectedItems), '_observeItems');
-	}
-
-	connectedCallback(): void {
-		super.connectedCallback();
-
 		this.addValidator(
 			'rangeUnderflow',
 			() => this.minMessage,
@@ -135,6 +128,9 @@ export class UmbInputMemberElement extends UUIFormControlMixin(UmbLitElement, ''
 			() => this.maxMessage,
 			() => !!this.max && this.#pickerContext.getSelection().length > this.max,
 		);
+
+		this.observe(this.#pickerContext.selection, (selection) => (this.value = selection.join(',')), '_observeSelection');
+		this.observe(this.#pickerContext.selectedItems, (selectedItems) => (this._items = selectedItems), '_observeItems');
 	}
 
 	protected getFormElement() {


### PR DESCRIPTION
## Description

In the input components for some of the picker editors, the `addValidator()` was being made inside the `connectedCallback()`, this could lead to potential issues as the component may be added to the DOM multiple times. This PR moves the `addValidator()` calls to the `constructor()`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
