### PR TITLE
Bugfix: Property descriptions should use uui-scroll-container

### DIFF
--- a/src/packages/core/property/property-layout/property-layout.element.ts
+++ b/src/packages/core/property/property-layout/property-layout.element.ts
@@ -126,7 +126,6 @@ export class UmbPropertyLayoutElement extends UmbLitElement {
 
 			#description {
 				color: var(--uui-color-text-alt);
-				overflow-x: auto;
 			}
 
 			#editorColumn {

--- a/src/packages/core/property/property-layout/property-layout.element.ts
+++ b/src/packages/core/property/property-layout/property-layout.element.ts
@@ -62,12 +62,14 @@ export class UmbPropertyLayoutElement extends UmbLitElement {
 		// TODO: Only show alias on label if user has access to DocumentType within settings:
 		return html`
 			<div id="headerColumn">
-				<uui-label title=${this.alias}>
+				<uui-label id="label" title=${this.alias}>
 					${this.localize.string(this.label)}
 					${when(this.invalid, () => html`<uui-badge color="danger" attention>!</uui-badge>`)}
 				</uui-label>
 				<slot name="action-menu"></slot>
-				<div id="description">${unsafeHTML(localizeAndTransform(this, this.description))}</div>
+				<uui-scroll-container id="description">
+					${unsafeHTML(localizeAndTransform(this, this.description))}
+				</uui-scroll-container>
 				<slot name="description"></slot>
 			</div>
 			<div id="editorColumn">
@@ -113,11 +115,11 @@ export class UmbPropertyLayoutElement extends UmbLitElement {
 			}
 			/*}*/
 
-			uui-label {
+			#label {
 				position: relative;
-				overflow-x: auto;
+				word-break: break-word;
 			}
-			:host([invalid]) uui-label {
+			:host([invalid]) #label {
 				color: var(--uui-color-danger);
 			}
 			uui-badge {


### PR DESCRIPTION
## Description

Instead of `overflow-x` we should use `uui-scroll-container` which preserves some styling choices.

I have also made sure that the title field works with very long word.

I also considered using `word-break: break-word` on the description, but as we don't know what's in there and it now has a scroll container, I don't think it's a good idea to limit the width of regular text to the outer width of the box.

**Before**

![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/752371/df7cadfb-eb7d-4adc-a8de-77202f6f38d7)


**After**

![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/752371/6201c7d3-26a2-4b2b-8a92-f5b4b39af553)
