### PR TITLE
Reset data-type configs when switching property editor

### DIFF
--- a/src/packages/core/property/property/property.element.ts
+++ b/src/packages/core/property/property/property.element.ts
@@ -237,8 +237,6 @@ export class UmbPropertyElement extends UmbLitElement {
 					(value) => {
 						// Set the value on the element:
 						this._element!.value = value;
-						// Set the value on the context as well, to ensure that any default values are stored right away:
-						this.#propertyContext.setValue(value);
 						if (this.#validationMessageBinder) {
 							this.#validationMessageBinder.value = value;
 						}

--- a/src/packages/data-type/repository/detail/data-type-detail.repository.ts
+++ b/src/packages/data-type/repository/detail/data-type-detail.repository.ts
@@ -2,7 +2,6 @@ import type { UmbDataTypeDetailModel } from '../../types.js';
 import { UmbDataTypeServerDataSource } from './data-type-detail.server.data-source.js';
 import type { UmbDataTypeDetailStore } from './data-type-detail.store.js';
 import { UMB_DATA_TYPE_DETAIL_STORE_CONTEXT } from './data-type-detail.store.js';
-import { UmbApi } from '@umbraco-cms/backoffice/extension-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbDetailRepositoryBase } from '@umbraco-cms/backoffice/repository';
 export class UmbDataTypeDetailRepository extends UmbDetailRepositoryBase<UmbDataTypeDetailModel> {

--- a/src/packages/data-type/workspace/data-type-workspace.context.ts
+++ b/src/packages/data-type/workspace/data-type-workspace.context.ts
@@ -144,7 +144,8 @@ export class UmbDataTypeWorkspaceContext
 					await this.#observePropertyEditorSchemaAlias();
 				}
 
-				if (this.getIsNew()) {
+				const oldPropertyEditorUIAlias = this.#persistedData.getValue()?.editorUiAlias;
+				if (this.getIsNew() || oldPropertyEditorUIAlias !== propertyEditorUiAlias) {
 					this.#transferConfigDefaultData();
 				}
 				this._mergeConfigProperties();

--- a/src/packages/data-type/workspace/data-type-workspace.context.ts
+++ b/src/packages/data-type/workspace/data-type-workspace.context.ts
@@ -29,6 +29,7 @@ import {
 	UmbRequestReloadChildrenOfEntityEvent,
 	UmbRequestReloadStructureForEntityEvent,
 } from '@umbraco-cms/backoffice/entity-action';
+import { UMB_PROPERTY_EDITOR_SCHEMA_ALIAS_DEFAULT } from '@umbraco-cms/backoffice/property-editor';
 
 type EntityType = UmbDataTypeDetailModel;
 export class UmbDataTypeWorkspaceContext
@@ -127,10 +128,13 @@ export class UmbDataTypeWorkspaceContext
 		this._mergeConfigProperties();
 	}
 
+	#lastPropertyEditorUIAlias?: string | null;
 	#observePropertyEditorUIAlias() {
 		this.observe(
 			this.propertyEditorUiAlias,
 			async (propertyEditorUiAlias) => {
+				const previousPropertyEditorUIAlias = this.#lastPropertyEditorUIAlias;
+				this.#lastPropertyEditorUIAlias = propertyEditorUiAlias;
 				// we only want to react on the change if the alias is set or null. When it is undefined something is still loading
 				if (propertyEditorUiAlias === undefined) return;
 
@@ -144,8 +148,10 @@ export class UmbDataTypeWorkspaceContext
 					await this.#observePropertyEditorSchemaAlias();
 				}
 
-				const oldPropertyEditorUIAlias = this.#persistedData.getValue()?.editorUiAlias;
-				if (this.getIsNew() || oldPropertyEditorUIAlias !== propertyEditorUiAlias) {
+				if (
+					this.getIsNew() ||
+					(previousPropertyEditorUIAlias && previousPropertyEditorUIAlias !== propertyEditorUiAlias)
+				) {
 					this.#transferConfigDefaultData();
 				}
 				this._mergeConfigProperties();

--- a/src/packages/data-type/workspace/data-type-workspace.context.ts
+++ b/src/packages/data-type/workspace/data-type-workspace.context.ts
@@ -1,5 +1,5 @@
 import { UmbDataTypeDetailRepository } from '../repository/detail/data-type-detail.repository.js';
-import type { UmbDataTypeDetailModel } from '../types.js';
+import type { UmbDataTypeDetailModel, UmbDataTypePropertyModel } from '../types.js';
 import { UmbDataTypeWorkspaceEditorElement } from './data-type-workspace-editor.element.js';
 import type { UmbPropertyDatasetContext } from '@umbraco-cms/backoffice/property';
 import type {
@@ -14,7 +14,6 @@ import {
 } from '@umbraco-cms/backoffice/workspace';
 import {
 	appendToFrozenArray,
-	mergeObservables,
 	UmbArrayState,
 	UmbObjectState,
 	UmbStringState,
@@ -25,7 +24,6 @@ import type {
 	PropertyEditorSettingsProperty,
 } from '@umbraco-cms/backoffice/extension-registry';
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
-import { UMB_PROPERTY_EDITOR_SCHEMA_ALIAS_DEFAULT } from '@umbraco-cms/backoffice/property-editor';
 import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
 import {
 	UmbRequestReloadChildrenOfEntityEvent,
@@ -64,9 +62,6 @@ export class UmbDataTypeWorkspaceContext
 		(a, b) => (a.weight || 0) - (b.weight || 0),
 	);
 	readonly properties = this.#properties.asObservable();
-
-	#defaults = new UmbArrayState<PropertyEditorSettingsDefaultData>([], (entry) => entry.alias);
-	readonly defaults = this.#defaults.asObservable();
 
 	#propertyEditorSchemaSettingsDefaultData: Array<PropertyEditorSettingsDefaultData> = [];
 	#propertyEditorUISettingsDefaultData: Array<PropertyEditorSettingsDefaultData> = [];
@@ -123,6 +118,13 @@ export class UmbDataTypeWorkspaceContext
 		super.resetState();
 		this.#persistedData.setValue(undefined);
 		this.#currentData.setValue(undefined);
+		this.#propertyEditorSchemaSettingsProperties = [];
+		this.#propertyEditorUISettingsProperties = [];
+		this.#propertyEditorSchemaSettingsDefaultData = [];
+		this.#propertyEditorUISettingsDefaultData = [];
+		this.#settingsDefaultData = undefined;
+
+		this._mergeConfigProperties();
 	}
 
 	#observePropertyEditorUIAlias() {
@@ -142,8 +144,10 @@ export class UmbDataTypeWorkspaceContext
 					await this.#observePropertyEditorSchemaAlias();
 				}
 
+				if (this.getIsNew()) {
+					this.#transferConfigDefaultData();
+				}
 				this._mergeConfigProperties();
-				this._mergeConfigDefaultData();
 			},
 			'editorUiAlias',
 		);
@@ -152,21 +156,18 @@ export class UmbDataTypeWorkspaceContext
 	#observePropertyEditorSchemaAlias() {
 		return this.observe(
 			this.propertyEditorSchemaAlias,
-			async (propertyEditorSchemaAlias) => {
-				if (!propertyEditorSchemaAlias) {
-					this.setPropertyEditorSchemaAlias(UMB_PROPERTY_EDITOR_SCHEMA_ALIAS_DEFAULT);
-					return;
-				}
-
-				await this.#setPropertyEditorSchemaConfig(propertyEditorSchemaAlias);
+			(propertyEditorSchemaAlias) => {
+				this.#setPropertyEditorSchemaConfig(propertyEditorSchemaAlias);
 			},
 			'schemaAlias',
 		).asPromise();
 	}
 
-	#setPropertyEditorSchemaConfig(propertyEditorSchemaAlias: string) {
-		return this.observe(
-			umbExtensionsRegistry.byTypeAndAlias('propertyEditorSchema', propertyEditorSchemaAlias),
+	#setPropertyEditorSchemaConfig(propertyEditorSchemaAlias?: string) {
+		this.observe(
+			propertyEditorSchemaAlias
+				? umbExtensionsRegistry.byTypeAndAlias('propertyEditorSchema', propertyEditorSchemaAlias)
+				: undefined,
 			(manifest) => {
 				// Maps properties to have a weight, so they can be sorted
 				this.#propertyEditorSchemaSettingsProperties = (manifest?.meta.settings?.properties ?? []).map((x, i) => ({
@@ -177,7 +178,7 @@ export class UmbDataTypeWorkspaceContext
 				this.#propertyEditorSchemaConfigDefaultUIAlias = manifest?.meta.defaultPropertyEditorUiAlias || null;
 			},
 			'schema',
-		).asPromise();
+		);
 	}
 
 	#setPropertyEditorUIConfig(propertyEditorUIAlias: string) {
@@ -208,14 +209,20 @@ export class UmbDataTypeWorkspaceContext
 		}
 	}
 
-	private _mergeConfigDefaultData() {
+	#transferConfigDefaultData() {
 		if (!this.#propertyEditorSchemaSettingsDefaultData || !this.#propertyEditorUISettingsDefaultData) return;
+
+		const data = this.#currentData.getValue();
+		if (!data) return;
 
 		this.#settingsDefaultData = [
 			...this.#propertyEditorSchemaSettingsDefaultData,
 			...this.#propertyEditorUISettingsDefaultData,
-		];
-		this.#defaults.setValue(this.#settingsDefaultData);
+		] satisfies Array<UmbDataTypePropertyModel>;
+		// We check for satisfied type, because we will be directly transferring them to become value. Future note, if they are not satisfied, we need to transfer alias and value. [NL]
+
+		this.#persistedData.update({ values: this.#settingsDefaultData });
+		this.#currentData.update({ values: this.#settingsDefaultData });
 	}
 
 	public getPropertyDefaultValue(alias: string) {
@@ -258,6 +265,7 @@ export class UmbDataTypeWorkspaceContext
 		this.#getDataPromise = request;
 		let { data } = await request;
 		if (!data) return undefined;
+
 		if (this.modalContext) {
 			data = { ...data, ...this.modalContext.data.preset };
 		}
@@ -295,19 +303,8 @@ export class UmbDataTypeWorkspaceContext
 
 	async propertyValueByAlias<ReturnType = unknown>(propertyAlias: string) {
 		await this.#getDataPromise;
-
-		return mergeObservables(
-			[
-				this.#currentData.asObservablePart(
-					(data) => data?.values?.find((x) => x.alias === propertyAlias)?.value as ReturnType,
-				),
-				this.#defaults.asObservablePart(
-					(defaults) => defaults?.find((x) => x.alias === propertyAlias)?.value as ReturnType,
-				),
-			],
-			([value, defaultValue]) => {
-				return value ?? defaultValue;
-			},
+		return this.#currentData.asObservablePart(
+			(data) => data?.values?.find((x) => x.alias === propertyAlias)?.value as ReturnType,
 		);
 	}
 
@@ -379,7 +376,6 @@ export class UmbDataTypeWorkspaceContext
 		this.#persistedData.destroy();
 		this.#currentData.destroy();
 		this.#properties.destroy();
-		this.#defaults.destroy();
 		this.#propertyEditorUiIcon.destroy();
 		this.#propertyEditorUiName.destroy();
 		this.repository.destroy();

--- a/src/packages/data-type/workspace/data-type-workspace.context.ts
+++ b/src/packages/data-type/workspace/data-type-workspace.context.ts
@@ -128,7 +128,9 @@ export class UmbDataTypeWorkspaceContext
 		this._mergeConfigProperties();
 	}
 
+	// Hold the last set property editor ui alias, so we know when it changes, so we can reset values. [NL]
 	#lastPropertyEditorUIAlias?: string | null;
+
 	#observePropertyEditorUIAlias() {
 		this.observe(
 			this.propertyEditorUiAlias,

--- a/src/packages/data-type/workspace/views/details/data-type-details-workspace-view.element.ts
+++ b/src/packages/data-type/workspace/views/details/data-type-details-workspace-view.element.ts
@@ -77,6 +77,13 @@ export class UmbDataTypeDetailsWorkspaceViewEditElement extends UmbLitElement im
 						: this.#renderChooseButton()}
 				</umb-property-layout>
 			</uui-box>
+			${this.#renderSettings()}
+		`;
+	}
+
+	#renderSettings() {
+		if (!this._propertyEditorUiAlias || !this._propertyEditorSchemaAlias) return nothing;
+		return html`
 			<uui-box headline=${this.localize.term('general_settings')}>
 				<umb-property-editor-config></umb-property-editor-config>
 			</uui-box>

--- a/src/packages/documents/documents/workspace/document-workspace.context.ts
+++ b/src/packages/documents/documents/workspace/document-workspace.context.ts
@@ -367,6 +367,7 @@ export class UmbDocumentWorkspaceContext
 		);
 	}
 	// TODO: Re-evaluate if this is begin used, i wrote this as part of a POC... [NL]
+	/*
 	async propertyIndexByAlias(
 		propertyAlias: string,
 		variantId?: UmbVariantId,
@@ -375,6 +376,7 @@ export class UmbDocumentWorkspaceContext
 			data?.values?.findIndex((x) => x?.alias === propertyAlias && (variantId ? variantId.compare(x) : true)),
 		);
 	}
+	*/
 
 	/**
 	 * Get the current value of the property with the given alias and variantId.


### PR DESCRIPTION
Revert some potentially bad code and correcting the way we set default values in data-type workspace

The code to be reverted is of this PR:https://github.com/umbraco/Umbraco.CMS.Backoffice/pull/1760
That code seems to work fine, but could lead to unexpected results and would be hard to debug in the future.
Also the scenario that was built on top of was wrong, which leads to the rest of the changes of this PR.

In data-type configuration editor, Instead of setting a default value when a value is undefined, we now will only set the default values when a data-type is new or when the property editor is changed.

problem with old approach was that if new default came along after the creation of a data-type then you might get that set without your awareness.

before this PR your values was also not reset when changing a property editor, which could have lead to bad configurations.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
