### PR TITLE
Bugfix: fix public access opened from the tree

### DIFF
--- a/src/packages/documents/documents/entity-actions/public-access/public-access.action.ts
+++ b/src/packages/documents/documents/entity-actions/public-access/public-access.action.ts
@@ -12,6 +12,7 @@ export class UmbDocumentPublicAccessEntityAction extends UmbEntityActionBase<nev
 	async execute() {
 		if (!this.args.unique) throw new Error('Unique is not available');
 		const modalManager = await this.getContext(UMB_MODAL_MANAGER_CONTEXT);
-		modalManager.open(this, UMB_PUBLIC_ACCESS_MODAL, { data: { unique: this.args.unique } });
+		const modal = modalManager.open(this, UMB_PUBLIC_ACCESS_MODAL, { data: { unique: this.args.unique } });
+		await modal.onSubmit();
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The entity action didn't await the modal finishing its flow before the action was done executed. It resulted in the section sidebar menu closing before the entity action opened its modal.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
