### PR TITLE
Bugfix: Restore custom validation on property editors

### DIFF
--- a/src/assets/lang/en.ts
+++ b/src/assets/lang/en.ts
@@ -1682,6 +1682,7 @@ export default {
 		elementDoesNotSupport: 'This is not applicable for an Element Type',
 		propertyHasChanges: 'You have made changes to this property. Are you sure you want to discard them?',
 		displaySettingsHeadline: 'Appearance',
+		displaySettingsLabelOnLeft: 'Label to the left',
 		displaySettingsLabelOnTop: 'Label above (full-width)',
 		confirmDeleteTabMessage: 'Are you sure you want to delete the tab <strong>%0%</strong>?',
 		confirmDeleteGroupMessage: 'Are you sure you want to delete the group <strong>%0%</strong>?',
@@ -2034,6 +2035,7 @@ export default {
 	},
 	validation: {
 		validation: 'Validation',
+		validateNothing: 'No validation',
 		validateAsEmail: 'Validate as an email address',
 		validateAsNumber: 'Validate as a number',
 		validateAsUrl: 'Validate as a URL',

--- a/src/packages/core/content-type/modals/property-type-settings/property-type-settings-modal.element.ts
+++ b/src/packages/core/content-type/modals/property-type-settings/property-type-settings-modal.element.ts
@@ -85,15 +85,11 @@ export class UmbPropertyTypeSettingsModalElement extends UmbModalBaseElement<
 				return option.selected;
 			});
 			if (newlySelected === undefined) {
-				this._customValidationOptions[4].selected = true;
-				this.updateValue({
-					validation: { ...this.value.validation, regEx: this._customValidationOptions[4].value },
-				});
-			} else {
-				this.updateValue({
-					validation: { ...this.value.validation, regEx: regEx },
-				});
+				this._customValidationOptions[this._customValidationOptions.length - 1].selected = true;
 			}
+			this.updateValue({
+				validation: { ...this.value.validation, regEx },
+			});
 		}
 	}
 
@@ -175,10 +171,6 @@ export class UmbPropertyTypeSettingsModalElement extends UmbModalBaseElement<
 		const value = event.target.value.toString();
 		const regEx = value !== '!NOVALIDATION!' ? value : null;
 
-		this._customValidationOptions.forEach((option) => {
-			option.selected = option.value === regEx;
-		});
-		this.requestUpdate('_customValidationOptions');
 		this.updateValue({
 			validation: { ...this.value.validation, regEx },
 		});

--- a/src/packages/core/content-type/modals/property-type-settings/property-type-settings-modal.element.ts
+++ b/src/packages/core/content-type/modals/property-type-settings/property-type-settings-modal.element.ts
@@ -23,25 +23,25 @@ export class UmbPropertyTypeSettingsModalElement extends UmbModalBaseElement<
 	// TODO: Or should they come from a extension point? [NL]
 	@state() private _customValidationOptions: Array<Option> = [
 		{
-			name: 'No validation',
+			name: this.localize.term('validation_validateNothing'),
 			value: '!NOVALIDATION!',
 			selected: true,
 		},
 		{
-			name: 'Validate as an email address',
+			name: this.localize.term('validation_validateAsEmail'),
 			value: '[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+',
 		},
 		{
-			name: 'Validate as a number',
+			name: this.localize.term('validation_validateAsNumber'),
 			value: '^[0-9]*$',
 		},
 		{
-			name: 'Validate as an URL',
+			name: this.localize.term('validation_validateAsUrl'),
 			value: 'https?://[a-zA-Z0-9-.]+\\.[a-zA-Z]{2,}',
 		},
 		{
-			name: '...or enter a custom validation',
-			value: '',
+			name: this.localize.term('validation_enterCustomValidation'),
+			value: '.+',
 		},
 	];
 
@@ -232,10 +232,10 @@ export class UmbPropertyTypeSettingsModalElement extends UmbModalBaseElement<
 									<uui-input
 										id="name-input"
 										name="name"
-										label="property name (TODO: Localize)"
+										label=${this.localize.term('placeholders_entername')}
 										@input=${this.#onNameChange}
 										.value=${this.value.name}
-										placeholder="Enter a name..."
+										placeholder=${this.localize.term('placeholders_entername')}
 										${umbFocus()}>
 										<!-- TODO: validation for bad characters -->
 									</uui-input>
@@ -244,7 +244,8 @@ export class UmbPropertyTypeSettingsModalElement extends UmbModalBaseElement<
 										name="alias"
 										@input=${this.#onAliasChange}
 										.value=${this.value.alias}
-										placeholder="Enter alias..."
+										label=${this.localize.term('placeholders_enterAlias')}
+										placeholder=${this.localize.term('placeholders_enterAlias')}
 										?disabled=${this._aliasLocked}>
 										<!-- TODO: validation for bad characters -->
 										<div @click=${this.#onToggleAliasLock} @keydown=${() => ''} id="alias-lock" slot="prepend">
@@ -255,7 +256,8 @@ export class UmbPropertyTypeSettingsModalElement extends UmbModalBaseElement<
 										id="description-input"
 										name="description"
 										@input=${this.#onDescriptionChange}
-										placeholder="Enter description..."
+										label=${this.localize.term('placeholders_enterDescription')}
+										placeholder=${this.localize.term('placeholders_enterDescription')}
 										.value=${this.value.description}></uui-textarea>
 								</div>
 								<umb-data-type-flow-input
@@ -263,15 +265,19 @@ export class UmbPropertyTypeSettingsModalElement extends UmbModalBaseElement<
 									@change=${this.#onDataTypeIdChange}></umb-data-type-flow-input>
 								<hr />
 								<div class="container">
-									<b>Validation</b>
+									<b><umb-localize key="validation_validation">Validation</umb-localize></b>
 									${this.#renderMandatory()}
-									<p style="margin-bottom: 0">Custom validation</p>
+									<p style="margin-bottom: 0">
+										<umb-localize key="validation_customValidation">Custom validation</umb-localize>
+									</p>
 									${this.#renderCustomValidation()}
 								</div>
 								<hr />
 								${this.#renderVariationControls()}
 								<div class="container">
-									<b style="margin-bottom: var(--uui-size-space-3)">Appearance</b>
+									<b style="margin-bottom: var(--uui-size-space-3)">
+										<umb-localize key="contentTypeEditor_displaySettingsHeadline">Appearance</umb-localize>
+									</b>
 									<div id="appearances">${this.#renderAlignLeftIcon()} ${this.#renderAlignTopIcon()}</div>
 								</div>
 							</uui-box>
@@ -299,7 +305,9 @@ export class UmbPropertyTypeSettingsModalElement extends UmbModalBaseElement<
 				<rect y="22" width="64" height="9" rx="4" fill="currentColor" fill-opacity="0.4" />
 				<rect x="106" width="94" height="60" rx="5" fill="currentColor" fill-opacity="0.4" />
 			</svg>
-			<label class="appearance-label"> Label on the left </label>
+			<label class="appearance-label">
+				<umb-localize key="contentTypeEditor_displaySettingsLabelOnLeft">Label to the left</umb-localize>
+			</label>
 		</button>`;
 	}
 
@@ -314,14 +322,18 @@ export class UmbPropertyTypeSettingsModalElement extends UmbModalBaseElement<
 					<rect y="22" width="64" height="9" rx="4" fill="currentColor" fill-opacity="0.4" />
 					<rect y="42" width="140" height="36" rx="5" fill="currentColor" fill-opacity="0.4" />
 				</svg>
-				<label class="appearance-label"> Label on top </label>
+				<label class="appearance-label">
+					<umb-localize key="contentTypeEditor_displaySettingsLabelOnTop">Label above (full-width)</umb-localize>
+				</label>
 			</button>
 		`;
 	}
 
 	#renderMandatory() {
 		return html`<div style="display: flex; justify-content: space-between">
-				<label for="mandatory">Field is mandatory</label>
+				<label for="mandatory">
+					<umb-localize key="validation_fieldIsMandatory">Field is mandatory</umb-localize>
+				</label>
 				<uui-toggle
 					@change=${this.#onMandatoryChange}
 					id="mandatory"
@@ -335,7 +347,8 @@ export class UmbPropertyTypeSettingsModalElement extends UmbModalBaseElement<
 						@change=${this.#onMandatoryMessageChange}
 						style="margin-top: var(--uui-size-space-1)"
 						id="mandatory-message"
-						placeholder="Enter a custom validation error message (optional)"></uui-input>`
+						placeholder=${this.localize.term('validation_mandatoryMessage')}
+						label=${this.localize.term('validation_mandatoryMessage')}></uui-input>`
 				: ''}`;
 	}
 
@@ -351,10 +364,14 @@ export class UmbPropertyTypeSettingsModalElement extends UmbModalBaseElement<
 							name="pattern"
 							style="margin-bottom: var(--uui-size-space-1); margin-top: var(--uui-size-space-5);"
 							@change=${this.#onValidationRegExChange}
+							placeholder=${this.localize.term('validation_validationRegExp')}
+							label=${this.localize.term('validation_validationRegExp')}
 							.value=${this.value.validation?.regEx ?? ''}></uui-input>
 						<uui-textarea
 							name="pattern-message"
 							@change=${this.#onValidationMessageChange}
+							placeholder=${this.localize.term('validation_validationRegExpMessage')}
+							label=${this.localize.term('validation_validationRegExpMessage')}
 							.value=${this.value.validation?.regExMessage ?? ''}></uui-textarea>
 					`
 				: nothing} `;
@@ -363,7 +380,7 @@ export class UmbPropertyTypeSettingsModalElement extends UmbModalBaseElement<
 	#renderVariationControls() {
 		return this._contentTypeVariesByCulture || this._contentTypeVariesBySegment
 			? html` <div class="container">
-						<b>Variation</b>
+						<b><umb-localize key="contentTypeEditor_variantsHeading">Allow variations</umb-localize></b>
 						${this._contentTypeVariesByCulture ? this.#renderVaryByCulture() : ''}
 					</div>
 					<hr />`
@@ -373,7 +390,7 @@ export class UmbPropertyTypeSettingsModalElement extends UmbModalBaseElement<
 		return html`<uui-toggle
 			@change=${this.#onVaryByCultureChange}
 			.checked=${this.value.variesByCulture ?? false}
-			label="Vary by culture"></uui-toggle> `;
+			label=${this.localize.term('contentTypeEditor_cultureVariantLabel')}></uui-toggle> `;
 	}
 
 	static styles = [


### PR DESCRIPTION
## Description
If there is a custom regex for validation on a property editor, and we cannot match it with our existing regex'es, it is always a custom one, and we should just show it to the user.

Also added localization to the area.

Also added a default "custom validation" regex string, so the user doesn't save an empty regex. This also lets the uui-select underneath actually show it as selected (for some reason it cannot immediately select an empty value, which I think is a bug in UUI).

Fixes https://github.com/umbraco/Umbraco-CMS/issues/16356

## How to test
1. Create a property editor on a document and choose one of the predefined validations, e.g. validate as number
2. Test that the regex is saved, and after reload, that it is still visible
3. Now change it to "...or enter a custom validation" and set a custom regex and save
4. Check that the custom regex is shown in the UI after a reload and that "...or enter a custom validation" is still selected