### PR TITLE
Bugfix: Media Collection (Section View) missing layouts

### DIFF
--- a/src/packages/media/media/section-view/media-section-view.element.ts
+++ b/src/packages/media/media/section-view/media-section-view.element.ts
@@ -64,6 +64,7 @@ export class UmbMediaSectionViewElement extends UmbLitElement {
 			unique: '',
 			dataTypeId: '',
 			allowedEntityBulkActions: config?.getValueByAlias<UmbCollectionBulkActionPermissions>('bulkActionPermissions'),
+			layouts: config?.getValueByAlias('layouts'),
 			orderBy: config?.getValueByAlias('orderBy') ?? 'updateDate',
 			orderDirection: config?.getValueByAlias('orderDirection') ?? 'asc',
 			pageSize: Number(config?.getValueByAlias('pageSize')) ?? 50,


### PR DESCRIPTION
## Description

There was a bug on the Media section (default view) with the Collection's configured layouts not being displayed (defaulting to loading from the `collectionView` manifests, for Media).

This PR fixes this by including the `layouts` configuration.

Partial fix for https://github.com/umbraco/Umbraco-CMS/issues/16374

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
