### PR TITLE
Bugfix: Audit log are missing a few translations

### DIFF
--- a/src/assets/lang/en.ts
+++ b/src/assets/lang/en.ts
@@ -177,6 +177,7 @@ export default {
 		save: 'Media saved',
 	},
 	auditTrails: {
+		assigndomain: 'Domain assigned: %0%',
 		atViewingFor: 'Viewing for',
 		delete: 'Content deleted',
 		unpublish: 'Content unpublished',
@@ -193,6 +194,7 @@ export default {
 		custom: '%0%',
 		contentversionpreventcleanup: 'Cleanup disabled for version: %0%',
 		contentversionenablecleanup: 'Cleanup enabled for version: %0%',
+		smallAssignDomain: 'Assign Domain',
 		smallCopy: 'Copy',
 		smallPublish: 'Publish',
 		smallPublishVariant: 'Publish',

--- a/src/packages/documents/documents/workspace/views/info/document-workspace-view-info-history.element.ts
+++ b/src/packages/documents/documents/workspace/views/info/document-workspace-view-info-history.element.ts
@@ -125,11 +125,15 @@ export class UmbDocumentWorkspaceViewInfoHistoryElement extends UmbLitElement {
 							const userName = user?.name ?? 'Unknown';
 							const avatarUrl = user && Array.isArray(user.avatarUrls) ? user.avatarUrls[1] : undefined;
 
-							return html`<umb-history-item .name=${userName} detail=${this.localize.date(item.timestamp, TimeOptions)}>
+							return html`<umb-history-item
+								.name=${userName}
+								.detail=${this.localize.date(item.timestamp, TimeOptions)}>
 								<uui-avatar slot="avatar" .name="${userName}" img-src=${ifDefined(avatarUrl)}></uui-avatar>
 
 								<span class="log-type">
-									<uui-tag look=${style.look} color=${style.color}> ${this.localize.term(text.label)} </uui-tag>
+									<uui-tag look=${style.look} color=${style.color}>
+										${this.localize.term(text.label, item.parameters)}
+									</uui-tag>
 									${this.localize.term(text.desc, item.parameters)}
 								</span>
 							</umb-history-item>`;

--- a/src/packages/documents/documents/workspace/views/info/utils.ts
+++ b/src/packages/documents/documents/workspace/views/info/utils.ts
@@ -15,8 +15,6 @@ interface HistoryData {
 	text: HistoryLocalizeKeys;
 }
 
-// Return label, color, look, desc
-
 /**
  * @description Helper function to get look and color for uui-tag and localization keys for the label and description.
  * @param type AuditTypeModel
@@ -30,23 +28,41 @@ export function getDocumentHistoryTagStyleAndText(type: UmbDocumentAuditLogType)
 				text: { label: 'auditTrails_smallSave', desc: 'auditTrails_save' },
 			};
 
+		case UmbDocumentAuditLog.SAVE_VARIANT:
+			return {
+				style: { look: 'primary', color: 'default' },
+				text: { label: 'auditTrails_smallSaveVariant', desc: 'auditTrails_savevariant' },
+			};
+
 		case UmbDocumentAuditLog.PUBLISH:
 			return {
 				style: { look: 'primary', color: 'positive' },
-				text: { label: 'content_publish', desc: 'auditTrails_publish' },
+				text: { label: 'auditTrails_smallPublish', desc: 'auditTrails_publish' },
 			};
 
 		case UmbDocumentAuditLog.UNPUBLISH:
 			return {
 				style: { look: 'primary', color: 'warning' },
-				text: { label: 'content_unpublish', desc: 'auditTrails_unpublish' },
+				text: { label: 'auditTrails_smallUnpublish', desc: 'auditTrails_unpublish' },
+			};
+
+		case UmbDocumentAuditLog.PUBLISH_VARIANT:
+			return {
+				style: { look: 'primary', color: 'positive' },
+				text: { label: 'auditTrails_smallPublishVariant', desc: 'auditTrails_publishvariant' },
+			};
+
+		case UmbDocumentAuditLog.UNPUBLISH_VARIANT:
+			return {
+				style: { look: 'primary', color: 'warning' },
+				text: { label: 'auditTrails_smallUnpublishVariant', desc: 'auditTrails_unpublishvariant' },
 			};
 
 		case UmbDocumentAuditLog.CONTENT_VERSION_ENABLE_CLEANUP:
 			return {
 				style: { look: 'secondary', color: 'default' },
 				text: {
-					label: 'contentTypeEditor_historyCleanupEnableCleanup',
+					label: 'auditTrails_smallContentVersionEnableCleanup',
 					desc: 'auditTrails_contentversionenablecleanup',
 				},
 			};
@@ -55,15 +71,69 @@ export function getDocumentHistoryTagStyleAndText(type: UmbDocumentAuditLogType)
 			return {
 				style: { look: 'secondary', color: 'default' },
 				text: {
-					label: 'contentTypeEditor_historyCleanupPreventCleanup',
+					label: 'auditTrails_smallContentVersionPreventCleanup',
 					desc: 'auditTrails_contentversionpreventcleanup',
 				},
 			};
 
+		case UmbDocumentAuditLog.ASSIGN_DOMAIN:
+			return {
+				style: { look: 'secondary', color: 'default' },
+				text: { label: 'auditTrails_smallAssignDomain', desc: 'auditTrails_assigndomain' },
+			};
+
+		case UmbDocumentAuditLog.COPY:
+			return {
+				style: { look: 'secondary', color: 'default' },
+				text: { label: 'auditTrails_smallCopy', desc: 'auditTrails_copy' },
+			};
+
+		case UmbDocumentAuditLog.MOVE:
+			return {
+				style: { look: 'secondary', color: 'default' },
+				text: { label: 'auditTrails_smallMove', desc: 'auditTrails_move' },
+			};
+
+		case UmbDocumentAuditLog.DELETE:
+			return {
+				style: { look: 'secondary', color: 'danger' },
+				text: { label: 'auditTrails_smallDelete', desc: 'auditTrails_delete' },
+			};
+
+		case UmbDocumentAuditLog.ROLL_BACK:
+			return {
+				style: { look: 'secondary', color: 'default' },
+				text: { label: 'auditTrails_smallRollBack', desc: 'auditTrails_rollback' },
+			};
+
+		case UmbDocumentAuditLog.SEND_TO_PUBLISH:
+			return {
+				style: { look: 'secondary', color: 'positive' },
+				text: { label: 'auditTrails_smallSendToPublish', desc: 'auditTrails_sendtopublish' },
+			};
+
+		case UmbDocumentAuditLog.SEND_TO_PUBLISH_VARIANT:
+			return {
+				style: { look: 'secondary', color: 'positive' },
+				text: { label: 'auditTrails_smallSendToPublishVariant', desc: 'auditTrails_sendtopublishvariant' },
+			};
+
+		case UmbDocumentAuditLog.SORT:
+			return {
+				style: { look: 'secondary', color: 'default' },
+				text: { label: 'auditTrails_smallSort', desc: 'auditTrails_sort' },
+			};
+
+		case UmbDocumentAuditLog.CUSTOM:
+			return {
+				style: { look: 'placeholder', color: 'default' },
+				text: { label: 'auditTrails_custom', desc: '' },
+			};
+
 		default:
 			return {
-				style: { look: 'placeholder', color: 'danger' },
-				text: { label: type, desc: 'TODO' },
+				style: { look: 'placeholder', color: 'default' },
+				text: { label: type, desc: '' },
 			};
 	}
 }

--- a/src/packages/media/media/workspace/views/info/media-workspace-view-info-history.element.ts
+++ b/src/packages/media/media/workspace/views/info/media-workspace-view-info-history.element.ts
@@ -107,11 +107,13 @@ export class UmbMediaWorkspaceViewInfoHistoryElement extends UmbLitElement {
 
 							return html`<umb-history-item
 								.name=${user?.name ?? 'Unknown'}
-								detail=${this.localize.date(item.timestamp, TimeOptions)}>
+								.detail=${this.localize.date(item.timestamp, TimeOptions)}>
 								<uui-avatar slot="avatar" .name="${userName}" img-src=${ifDefined(avatarUrl)}></uui-avatar>
 
 								<span class="log-type">
-									<uui-tag look=${style.look} color=${style.color}> ${this.localize.term(text.label)} </uui-tag>
+									<uui-tag look=${style.look} color=${style.color}>
+										${this.localize.term(text.label, item.parameters)}
+									</uui-tag>
 									${this.localize.term(text.desc, item.parameters)}
 								</span>
 							</umb-history-item>`;


### PR DESCRIPTION
## Description

Maps up the rest of the audit items with translation keys.

Fixes https://github.com/umbraco/Umbraco-CMS/issues/16293