### PR TITLE
Feature: Extendable section routes

### DIFF
--- a/src/packages/core/extension-registry/models/index.ts
+++ b/src/packages/core/extension-registry/models/index.ts
@@ -69,6 +69,7 @@ import type { ManifestAppEntryPoint } from './app-entry-point.model.js';
 import type { ManifestBackofficeEntryPoint } from './backoffice-entry-point.model.js';
 import type { ManifestEntryPoint } from './entry-point.model.js';
 import type { ManifestMonacoMarkdownEditorAction } from './monaco-markdown-editor-action.model.js';
+import type { ManifestSectionRoute } from './section-route.model.js';
 import type { ManifestBase, ManifestBundle, ManifestCondition } from '@umbraco-cms/backoffice/extension-api';
 
 export type * from './app-entry-point.model.js';
@@ -196,6 +197,7 @@ export type ManifestTypes =
 	| ManifestSectionSidebarApp
 	| ManifestSectionSidebarAppMenuKind
 	| ManifestSectionView
+	| ManifestSectionRoute
 	| ManifestStore
 	| ManifestTheme
 	| ManifestTinyMcePlugin

--- a/src/packages/core/extension-registry/models/section-route.model.ts
+++ b/src/packages/core/extension-registry/models/section-route.model.ts
@@ -1,0 +1,12 @@
+import type { UmbRouteEntry } from '../../router/types.js';
+import type { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
+import type { ManifestElementAndApi } from '@umbraco-cms/backoffice/extension-api';
+
+export interface ManifestSectionRoute extends ManifestElementAndApi<UmbControllerHostElement, UmbRouteEntry> {
+	type: 'sectionRoute';
+	meta: MetaSectionRoute;
+}
+
+export interface MetaSectionRoute {
+	path?: string;
+}

--- a/src/packages/core/router/index.ts
+++ b/src/packages/core/router/index.ts
@@ -8,3 +8,4 @@ export * from './router-slot.element.js';
 export * from './path-pattern.class.js';
 export * from './modal-registration/modal-route-registration.interface.js';
 export * from './modal-registration/modal-route-registration.controller.js';
+export * from './types.js';

--- a/src/packages/core/router/types.ts
+++ b/src/packages/core/router/types.ts
@@ -1,0 +1,7 @@
+import type { IRoutingInfo, PageComponent } from '@umbraco-cms/backoffice/external/router-slot';
+import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
+
+export interface UmbRouteEntry extends UmbApi {
+	getPath?(): string;
+	setup?(element: PageComponent, info: IRoutingInfo): void;
+}

--- a/src/packages/core/utils/path/path-encode.function.ts
+++ b/src/packages/core/utils/path/path-encode.function.ts
@@ -1,1 +1,3 @@
-export const encodeFilePath = (path: string) => encodeURIComponent(path).replace('.', '-');
+export const encodeFilePath = (path: string) => encodeURIComponent(path).replaceAll('.', '-');
+
+export const aliasToPath = (path: string) => encodeFilePath(path);

--- a/src/packages/core/workspace/manifests.ts
+++ b/src/packages/core/workspace/manifests.ts
@@ -1,12 +1,14 @@
 import { manifests as componentManifests } from './components/manifests.js';
-import { manifests as workspaceKinds } from './kinds/manifests.js';
-import { manifests as workspaceModals } from './modals/manifests.js';
-import { manifests as workspaceConditions } from './conditions/manifests.js';
+import { manifests as sectionRouteManifests } from './section-routes/manifests.js';
+import { manifests as workspaceConditionManifests } from './conditions/manifests.js';
+import { manifests as workspaceKindManifest } from './kinds/manifests.js';
+import { manifests as workspaceModalManifest } from './modals/manifests.js';
 import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
 export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
-	...workspaceConditions,
-	...workspaceKinds,
 	...componentManifests,
-	...workspaceModals,
+	...sectionRouteManifests,
+	...workspaceConditionManifests,
+	...workspaceKindManifest,
+	...workspaceModalManifest,
 ];

--- a/src/packages/core/workspace/section-routes/manifests.ts
+++ b/src/packages/core/workspace/section-routes/manifests.ts
@@ -1,0 +1,11 @@
+import type { ManifestTypes } from '@umbraco-cms/backoffice/extension-registry';
+
+export const manifests: Array<ManifestTypes> = [
+	{
+		type: 'sectionRoute',
+		alias: 'Umb.SectionRoute.Workspace',
+		name: 'Section Workspace Route',
+		element: () => import('../workspace.element.js'),
+		api: () => import('./workspace-section-route.api.js'),
+	},
+];

--- a/src/packages/core/workspace/section-routes/manifests.ts
+++ b/src/packages/core/workspace/section-routes/manifests.ts
@@ -4,7 +4,7 @@ export const manifests: Array<ManifestTypes> = [
 	{
 		type: 'sectionRoute',
 		alias: 'Umb.SectionRoute.Workspace',
-		name: 'Section Workspace Route',
+		name: 'Workspace Section Route',
 		element: () => import('../workspace.element.js'),
 		api: () => import('./workspace-section-route.route-entry.js'),
 	},

--- a/src/packages/core/workspace/section-routes/manifests.ts
+++ b/src/packages/core/workspace/section-routes/manifests.ts
@@ -6,6 +6,6 @@ export const manifests: Array<ManifestTypes> = [
 		alias: 'Umb.SectionRoute.Workspace',
 		name: 'Section Workspace Route',
 		element: () => import('../workspace.element.js'),
-		api: () => import('./workspace-section-route.api.js'),
+		api: () => import('./workspace-section-route.route-entry.js'),
 	},
 ];

--- a/src/packages/core/workspace/section-routes/workspace-section-route.route-entry.ts
+++ b/src/packages/core/workspace/section-routes/workspace-section-route.route-entry.ts
@@ -1,0 +1,18 @@
+import { UMB_WORKSPACE_PATH_PATTERN } from '../paths.js';
+import type { UmbWorkspaceElement } from '../workspace.element.js';
+import type { IRoutingInfo, PageComponent, UmbRouteEntry } from '@umbraco-cms/backoffice/router';
+import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
+
+export class UmbWorkspaceSectionRouteEntry implements UmbApi, UmbRouteEntry {
+	getPath(): string {
+		return UMB_WORKSPACE_PATH_PATTERN.toString();
+	}
+
+	setup(element: PageComponent, info: IRoutingInfo) {
+		(element as UmbWorkspaceElement).entityType = info.match.params.entityType;
+	}
+
+	destroy(): void {}
+}
+
+export { UmbWorkspaceSectionRouteEntry as api };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description


This PR introduces a new extension point to the default section element. Section routes make it possible to add custom routes to all sections. We use it ourselves to register the workspace route. This is the solution To fix up a circular dependency between the section and workspace route constants.

***Manifest example***
``` js
const manifest = {
 type: 'sectionRoute',
 alias: 'Umb.SectionRoute.Workspace',
 name: 'Workspace Section Route',
 element: () => import('../workspace.element.js'),
 api: () => import('./workspace-section-route.route-entry.js'),
 meta: {
  path: '/some-path' // optional
 }
};
```

***API example***
``` ts
export class UmbWorkspaceSectionRouteEntry implements UmbApi, UmbRouteEntry {
 getPath(): string {
  return UMB_WORKSPACE_PATH_PATTERN.toString();
 }

 setup(element: PageComponent, info: IRoutingInfo) {
  (element as UmbWorkspaceElement).entityType = info.match.params.entityType;
 }

 destroy(): void {}
}

export { UmbWorkspaceSectionRouteEntry as api };
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
