### PR TITLE
Bugfix: Fix Input Rich Media importing its own moudule

### DIFF
--- a/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
+++ b/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
@@ -1,14 +1,14 @@
-import { UmbImagingRepository } from '@umbraco-cms/backoffice/imaging';
+import { UmbInputMediaElement } from '../input-media/index.js';
+import { UmbMediaItemRepository } from '../../repository/index.js';
 import { UMB_IMAGE_CROPPER_EDITOR_MODAL, UMB_MEDIA_PICKER_MODAL } from '../../modals/index.js';
 import type { UmbCropModel, UmbMediaPickerPropertyValue } from '../../property-editors/index.js';
 import type { UmbMediaItemModel } from '../../repository/index.js';
-import { UmbMediaItemRepository } from '../../repository/index.js';
 import type { UmbUploadableFileModel } from '../../dropzone/index.js';
-import { UmbInputMediaElement } from '../input-media/index.js';
 import { customElement, html, ifDefined, nothing, property, repeat, state } from '@umbraco-cms/backoffice/external/lit';
 import { umbConfirmModal, UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbId } from '@umbraco-cms/backoffice/id';
+import { UmbImagingRepository } from '@umbraco-cms/backoffice/imaging';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbModalRouteRegistrationController } from '@umbraco-cms/backoffice/router';
 import { UmbSorterController } from '@umbraco-cms/backoffice/sorter';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Input rich media is using its own import alias to import local dependencies. This PR updates them to relative imports.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)