### PR TITLE
Chore: Bump no cycle max depth to 6

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -39,7 +39,7 @@
 				"import/no-unresolved": "off",
 				"import/order": "warn",
 				"import/no-self-import": "error",
-				"import/no-cycle": ["error", { "maxDepth": 2, "allowUnsafeDynamicCyclicDependency": true }],
+				"import/no-cycle": ["error", { "maxDepth": 6, "allowUnsafeDynamicCyclicDependency": true }],
 				"local-rules/bad-type-import": "error",
 				"local-rules/enforce-element-suffix-on-element-class-name": "error",
 				"local-rules/enforce-umb-prefix-on-element-name": "error",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When PR #1897 and #1898 are merged. This PR should hopefully go through 🤞 

This PR bumps the `maxDepth` setting from `2` -> `6` for the eslint rule to check for circular dependencies. I am unsure how tough it will be for VS Code, but we will have to evaluate it after some time. The goal is to delete the max depth setting.

This will help us better prevent circular dependencies moving forward.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
