### PR TITLE
Chore: Relation Types UI amends

### DIFF
--- a/src/packages/relations/relation-types/collection/manifests.ts
+++ b/src/packages/relations/relation-types/collection/manifests.ts
@@ -10,6 +10,7 @@ const collectionManifest: ManifestCollection = {
 	kind: 'default',
 	alias: UMB_RELATION_TYPE_COLLECTION_ALIAS,
 	name: 'Relation Type Collection',
+	element: () => import('./relation-types-collection.element.js'),
 	meta: {
 		repositoryAlias: UMB_RELATION_TYPE_COLLECTION_REPOSITORY_ALIAS,
 	},

--- a/src/packages/relations/relation-types/collection/manifests.ts
+++ b/src/packages/relations/relation-types/collection/manifests.ts
@@ -10,7 +10,7 @@ const collectionManifest: ManifestCollection = {
 	kind: 'default',
 	alias: UMB_RELATION_TYPE_COLLECTION_ALIAS,
 	name: 'Relation Type Collection',
-	element: () => import('./relation-types-collection.element.js'),
+	element: () => import('./relation-type-collection.element.js'),
 	meta: {
 		repositoryAlias: UMB_RELATION_TYPE_COLLECTION_REPOSITORY_ALIAS,
 	},

--- a/src/packages/relations/relation-types/collection/relation-type-collection.element.ts
+++ b/src/packages/relations/relation-types/collection/relation-type-collection.element.ts
@@ -1,19 +1,19 @@
 import { customElement, html } from '@umbraco-cms/backoffice/external/lit';
 import { UmbCollectionDefaultElement } from '@umbraco-cms/backoffice/collection';
 
-@customElement('umb-relation-types-collection')
-export class UmbRelationTypesCollectionElement extends UmbCollectionDefaultElement {
-
+const elementName = 'umb-relation-type-collection';
+@customElement(elementName)
+export class UmbRelationTypeCollectionElement extends UmbCollectionDefaultElement {
 	// NOTE: Returns empty toolbar, so to remove the header padding.
 	protected renderToolbar() {
 		return html``;
 	}
 }
 
-export default UmbRelationTypesCollectionElement;
+export default UmbRelationTypeCollectionElement;
 
 declare global {
 	interface HTMLElementTagNameMap {
-		'umb-relation-types-collection': UmbRelationTypesCollectionElement;
+		[elementName]: UmbRelationTypeCollectionElement;
 	}
 }

--- a/src/packages/relations/relation-types/collection/relation-types-collection.element.ts
+++ b/src/packages/relations/relation-types/collection/relation-types-collection.element.ts
@@ -1,0 +1,19 @@
+import { customElement, html } from '@umbraco-cms/backoffice/external/lit';
+import { UmbCollectionDefaultElement } from '@umbraco-cms/backoffice/collection';
+
+@customElement('umb-relation-types-collection')
+export class UmbRelationTypesCollectionElement extends UmbCollectionDefaultElement {
+
+	// NOTE: Returns empty toolbar, so to remove the header padding.
+	protected renderToolbar() {
+		return html``;
+	}
+}
+
+export default UmbRelationTypesCollectionElement;
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-relation-types-collection': UmbRelationTypesCollectionElement;
+	}
+}

--- a/src/packages/relations/relation-types/workspace/relation-type-root/relation-type-root-workspace.element.ts
+++ b/src/packages/relations/relation-types/workspace/relation-type-root/relation-type-root-workspace.element.ts
@@ -5,9 +5,11 @@ import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 @customElement('umb-relation-type-root-workspace')
 export class UmbRelationTypeRootWorkspaceElement extends UmbLitElement {
 	render() {
-		return html`<umb-body-layout main-no-padding headline="Relations">
-			<umb-collection alias=${UMB_RELATION_TYPE_COLLECTION_ALIAS}></umb-collection>;
-		</umb-body-layout>`;
+		return html`
+			<umb-body-layout main-no-padding headline=${this.localize.term('relationType_relations')}>
+				<umb-collection alias=${UMB_RELATION_TYPE_COLLECTION_ALIAS}></umb-collection>;
+			</umb-body-layout>
+		`;
 	}
 }
 

--- a/src/packages/relations/relation-types/workspace/relation-type/views/relation-type-detail-workspace-view.element.ts
+++ b/src/packages/relations/relation-types/workspace/relation-type/views/relation-type-detail-workspace-view.element.ts
@@ -34,6 +34,9 @@ export class UmbRelationTypeDetailWorkspaceViewElement extends UmbLitElement imp
 	@state()
 	_totalPages = 1;
 
+	@state()
+	_loading = false;
+
 	#workspaceContext?: typeof UMB_RELATION_TYPE_WORKSPACE_CONTEXT.TYPE;
 	#relationCollectionRepository = new UmbRelationCollectionRepository(this);
 	#paginationManager = new UmbPaginationManager();
@@ -73,6 +76,8 @@ export class UmbRelationTypeDetailWorkspaceViewElement extends UmbLitElement imp
 	}
 
 	async #requestRelations() {
+		this._loading = true;
+
 		const relationTypeUnique = this.#workspaceContext?.getUnique();
 		if (!relationTypeUnique) throw new Error('Relation type unique is required');
 
@@ -87,6 +92,7 @@ export class UmbRelationTypeDetailWorkspaceViewElement extends UmbLitElement imp
 		if (data) {
 			this._relations = data.items;
 			this.#paginationManager.setTotalItems(data.total);
+			this._loading = false;
 		}
 	}
 
@@ -164,6 +170,7 @@ export class UmbRelationTypeDetailWorkspaceViewElement extends UmbLitElement imp
 	}
 
 	#renderRelations() {
+		if (this._loading) return html`<uui-loader></uui-loader>`;
 		return html`
 			<div>
 				<umb-table .config=${this._tableConfig} .columns=${this._tableColumns} .items=${this._tableItems}></umb-table>
@@ -205,6 +212,10 @@ export class UmbRelationTypeDetailWorkspaceViewElement extends UmbLitElement imp
 				gap: var(--uui-size-layout-1);
 				padding: var(--uui-size-layout-1);
 				grid-template-columns: 1fr 350px;
+			}
+
+			uui-loader {
+				text-align: center;
 			}
 
 			uui-pagination {


### PR DESCRIPTION
## Description

UI amends to the Relation Types workspace:

- Adds a toolbar, to remove the visual gap in the header
- Adds a `<uui-loader>` on the Relation Types workspace (collection)
- Localizes the headline in the Relation Type root workspace

## Types of changes

- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
