### PR TITLE
Focus delete button in content type property

### DIFF
--- a/src/packages/core/content-type/workspace/views/design/content-type-design-editor-property.element.ts
+++ b/src/packages/core/content-type/workspace/views/design/content-type-design-editor-property.element.ts
@@ -484,11 +484,12 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 				position: absolute;
 				top: var(--uui-size-space-2);
 				right: var(--uui-size-space-2);
-				display: none;
+				visibility: hidden;
 			}
 			#editor:hover uui-action-bar,
-			#editor:focus uui-action-bar {
-				display: block;
+			#editor:focus uui-action-bar,
+			#editor:focus-within uui-action-bar {
+				visibility: visible;
 			}
 
 			a {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This fixes https://github.com/umbraco/Umbraco.CMS.Backoffice/issues/1905 or at least it is now possible to remove the property using keyboard.

In reverse order it doesn't seem to focus delete button like in block list/grid configuration, but better that what we have at the moment.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

**Block List Configuration**

https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/2919859/43bd8288-4e4e-43dc-861b-c2f212ccf498


**Content Type Editor**

https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/2919859/6a263c18-7be7-46a5-b3f4-d8206b59ff9d





## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
