### PR TITLE
Bugfix: Media info links, corrected localization for no links

### DIFF
--- a/src/packages/media/media/workspace/views/info/media-workspace-view-info.element.ts
+++ b/src/packages/media/media/workspace/views/info/media-workspace-view-info.element.ts
@@ -123,11 +123,10 @@ export class UmbMediaWorkspaceViewInfoElement extends UmbLitElement {
 			return html`
 				${repeat(
 					this._urls,
-					(url) => url.culture,
+					(url) => url.url,
 					(url) => html`
 						<a href=${url.url} target="_blank" class="link-item with-href">
-							<span class="link-language">${url.culture}</span>
-							<span class="link-content"> ${url.url}</span>
+							<span class="link-content">${url.url}</span>
 							<uui-icon name="icon-out"></uui-icon>
 						</a>
 					`,
@@ -136,8 +135,7 @@ export class UmbMediaWorkspaceViewInfoElement extends UmbLitElement {
 		} else {
 			return html`
 				<div class="link-item">
-					<span class="link-language">en-EN</span>
-					<span class="link-content italic"><umb-localize key="content_parentNotPublishedAnomaly"></umb-localize></span>
+					<span class="link-content italic"><umb-localize key="content_noMediaLink"></umb-localize></span>
 				</div>
 			`;
 		}
@@ -217,7 +215,7 @@ export class UmbMediaWorkspaceViewInfoElement extends UmbLitElement {
 			.link-item {
 				padding: var(--uui-size-space-4) var(--uui-size-space-6);
 				display: grid;
-				grid-template-columns: auto 1fr auto;
+				grid-template-columns: 1fr auto;
 				gap: var(--uui-size-6);
 				color: inherit;
 				text-decoration: none;


### PR DESCRIPTION
## Description

In the Media info tab, when there are no links the message was incorrect as it was referencing the wrong localization key.
This PR corrects the localization key. Also removed the culture from being displayed, as media doesn't (currently) have variants.

This fixes https://github.com/umbraco/Umbraco-CMS/issues/16395.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
