### PR TITLE
Bugfix: navigating between workspaces throws errors

### DIFF
--- a/src/external/router-slot/model.ts
+++ b/src/external/router-slot/model.ts
@@ -25,7 +25,7 @@ export type Guard<D = any, P = any> = (info: IRoutingInfo<D, P>) => boolean | Pr
 export type Cancel = () => boolean;
 
 export type PageComponent = HTMLElement | undefined;
-export type ModuleResolver = Promise<{ default: any /*PageComponent*/ }>;
+export type ModuleResolver = Promise<{ default?: any /*PageComponent*/; element?: any /*PageComponent*/ }>;
 export type Class<T extends PageComponent = PageComponent> = { new (...args: any[]): T };
 export type Component =
 	| Class

--- a/src/external/router-slot/util/router.ts
+++ b/src/external/router-slot/util/router.ts
@@ -74,7 +74,7 @@ export function matchRoute<D = any>(route: IRoute<D>, path: string | PathFragmen
 						default:
 							return new RegExp(`^[\/]?${routePath}(?:\/|$)`);
 					}
-			  })();
+				})();
 
 	// Check if there's a match
 	const match = path.match(regex);
@@ -147,8 +147,13 @@ export async function resolvePageComponent(route: IComponentRoute, info: IRoutin
 
 	// Instantiate the component
 	let component!: PageComponent;
+
 	if (!(moduleClassOrPage instanceof HTMLElement)) {
-		component = new (moduleClassOrPage.default ? moduleClassOrPage.default : moduleClassOrPage)() as PageComponent;
+		component = new (moduleClassOrPage.default
+			? moduleClassOrPage.default
+			: moduleClassOrPage.element
+				? moduleClassOrPage.element
+				: moduleClassOrPage)() as PageComponent;
 	} else {
 		component = moduleClassOrPage as PageComponent;
 	}

--- a/src/packages/core/section/section-default.element.ts
+++ b/src/packages/core/section/section-default.element.ts
@@ -91,7 +91,10 @@ export class UmbSectionDefaultElement extends UmbLitElement implements UmbSectio
 								extensionController.manifest.meta?.path ||
 								aliasToPath(extensionController.manifest.alias),
 							// TODO: look into removing the "as PageComponent" type hack
-							component: extensionController.manifest.element as PageComponent,
+							// be aware that this is kind of a hack to pass the manifest element to the router. But as the two resolve components
+							// in a similar way. I currently find it more safe to let the router do the component resolving instead
+							// of replicating it as a custom resolver here.
+							component: extensionController.manifest.element as PageComponent | PromiseLike<PageComponent>,
 							setup: (element: PageComponent, info: IRoutingInfo) => {
 								api?.setup?.(element, info);
 							},

--- a/src/packages/core/section/section-default.element.ts
+++ b/src/packages/core/section/section-default.element.ts
@@ -90,6 +90,7 @@ export class UmbSectionDefaultElement extends UmbLitElement implements UmbSectio
 								api?.getPath?.() ||
 								extensionController.manifest.meta?.path ||
 								aliasToPath(extensionController.manifest.alias),
+							// TODO: look into removing the "as PageComponent" type hack
 							component: extensionController.manifest.element as PageComponent,
 							setup: (element: PageComponent, info: IRoutingInfo) => {
 								api?.setup?.(element, info);

--- a/src/packages/core/workspace/workspace.element.ts
+++ b/src/packages/core/workspace/workspace.element.ts
@@ -23,7 +23,7 @@ export class UmbWorkspaceElement extends UmbLitElement {
 	}
 }
 
-export default UmbWorkspaceElement;
+export { UmbWorkspaceElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use the router component resolver to handle the route component instead of the ExtensionElemenInitializer cached component.

This is a tiny bit hacky, as the "correct" solution would be to make a custom route resolver that handles it. But as we are in control of both libs and they work almost the same I have just passed the manifest element prop directly to the router. Then the router will correctly construct the element and update the DOM.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
