### PR TITLE
Bugfix: Initial section

### DIFF
--- a/src/apps/backoffice/components/backoffice-main.element.ts
+++ b/src/apps/backoffice/components/backoffice-main.element.ts
@@ -64,22 +64,6 @@ export class UmbBackofficeMainElement extends UmbLitElement {
 				}
 			});
 
-		if (this._sections.length > 0) {
-			const fallbackSectionPath = UMB_SECTION_PATH_PATTERN.generateLocal({
-				sectionName: this._sections[0].manifest!.meta.pathname,
-			});
-			this._routes.push({
-				alias: '__redirect',
-				path: '/',
-				redirectTo: fallbackSectionPath,
-			});
-			this._routes.push({
-				alias: '__redirect',
-				path: '/section/',
-				redirectTo: fallbackSectionPath,
-			});
-		}
-
 		this.requestUpdate('_routes', oldValue);
 	}
 

--- a/src/packages/user/current-user/current-user.context.ts
+++ b/src/packages/user/current-user/current-user.context.ts
@@ -13,7 +13,7 @@ import { UMB_SECTION_PATH_PATTERN } from '@umbraco-cms/backoffice/section';
 export class UmbCurrentUserContext extends UmbContextBase<UmbCurrentUserContext> {
 	#currentUser = new UmbObjectState<UmbCurrentUserModel | undefined>(undefined);
 	readonly currentUser = this.#currentUser.asObservable();
-
+	readonly allowedSections = this.#currentUser.asObservablePart((user) => user?.allowedSections);
 	readonly unique = this.#currentUser.asObservablePart((user) => user?.unique);
 	readonly languageIsoCode = this.#currentUser.asObservablePart((user) => user?.languageIsoCode);
 	readonly hasDocumentRootAccess = this.#currentUser.asObservablePart((user) => user?.hasDocumentRootAccess);
@@ -99,7 +99,7 @@ export class UmbCurrentUserContext extends UmbContextBase<UmbCurrentUserContext>
 		if (!currentUser) return;
 
 		/* TODO: this solution is not bullet proof as we still rely on the "correct" section to be registered at this point in time so we can get the path.
-		 It probably would have been better if we used the section alias instead as the path. 
+		 It probably would have been better if we used the section alias instead as the path.
 		 Then we would have it available at all times and it also ensured a unique path. */
 		const sections = await this.observe(
 			umbExtensionsRegistry.byTypeAndAliases('section', currentUser.allowedSections),

--- a/src/packages/user/current-user/current-user.context.ts
+++ b/src/packages/user/current-user/current-user.context.ts
@@ -7,6 +7,8 @@ import { firstValueFrom } from '@umbraco-cms/backoffice/external/rxjs';
 import { UMB_AUTH_CONTEXT } from '@umbraco-cms/backoffice/auth';
 import { UmbObjectState } from '@umbraco-cms/backoffice/observable-api';
 import { umbLocalizationRegistry } from '@umbraco-cms/backoffice/localization';
+import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
+import { UMB_SECTION_PATH_PATTERN } from '@umbraco-cms/backoffice/section';
 
 export class UmbCurrentUserContext extends UmbContextBase<UmbCurrentUserContext> {
 	#currentUser = new UmbObjectState<UmbCurrentUserModel | undefined>(undefined);
@@ -43,6 +45,7 @@ export class UmbCurrentUserContext extends UmbContextBase<UmbCurrentUserContext>
 		if (asObservable) {
 			this.observe(asObservable(), (currentUser) => {
 				this.#currentUser?.setValue(currentUser);
+				this.#redirectToFirstAllowedSectionIfNeeded();
 			});
 		}
 	}
@@ -74,6 +77,36 @@ export class UmbCurrentUserContext extends UmbContextBase<UmbCurrentUserContext>
 				this.load();
 			}
 		});
+	}
+
+	async #redirectToFirstAllowedSectionIfNeeded() {
+		const url = new URL(window.location.href);
+
+		if (url.pathname === '/') {
+			const sectionManifest = await this.#firstAllowedSection();
+			if (!sectionManifest) return;
+
+			const fallbackSectionPath = UMB_SECTION_PATH_PATTERN.generateLocal({
+				sectionName: sectionManifest.meta.pathname,
+			});
+
+			history.pushState(null, '', fallbackSectionPath);
+		}
+	}
+
+	async #firstAllowedSection() {
+		const currentUser = this.#currentUser.getValue();
+		if (!currentUser) return;
+
+		/* TODO: this solution is not bullet proof as we still rely on the "correct" section to be registered at this point in time so we can get the path.
+		 It probably would have been better if we used the section alias instead as the path. 
+		 Then we would have it available at all times and it also ensured a unique path. */
+		const sections = await this.observe(
+			umbExtensionsRegistry.byTypeAndAliases('section', currentUser.allowedSections),
+			() => {},
+		).asPromise();
+
+		return sections[0];
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes the section you get redirected to when opening the backoffice at the "root" location: "/". 

The PR removes the "magic" fallback to the first section and instead relies on the first section the user is allowed to see.

This solution is not bulletproof as we still rely on the "correct" section to be registered when we look them up. Unfortunately, we need to get the metadata from the manifest to get the section path. Using the section manifest alias as the path would probably have been better than a custom path value. Then we would have it available at all times and it also ensured a unique path.

Unfortunately, it also removes the redirect from a section that doesn't exist to the first one. But as we currently don't know what and when a section exists in the system then we don't know when the correct time is to redirect anyway.

## How to test:
* Check that deep links still works.
* Check that the "/" path redirects to the first allowed section.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
