### PR TITLE
Bugfix: Close global search on outside click

### DIFF
--- a/src/packages/search/search-modal/search-modal.element.ts
+++ b/src/packages/search/search-modal/search-modal.element.ts
@@ -64,11 +64,26 @@ export class UmbSearchModalElement extends UmbLitElement {
 		super.connectedCallback();
 
 		this.addEventListener('keydown', this.#onKeydown);
+		document.addEventListener('click', this.#onDocumentClick); //TODO: Temp solution to close the modal on outside click. We need to look into a generic solution for this.
 
 		requestAnimationFrame(() => {
 			this.#focusInput();
 		});
 	}
+
+	disconnectedCallback(): void {
+		super.disconnectedCallback();
+
+		this.removeEventListener('keydown', this.#onKeydown);
+		document.removeEventListener('click', this.#onDocumentClick);
+	}
+
+	#onDocumentClick = (event: MouseEvent) => {
+		const path = event.composedPath();
+		if (path.includes(this)) return;
+
+		this.modalContext?.reject();
+	};
 
 	#observeProviders() {
 		new UmbExtensionsManifestInitializer(this, umbExtensionsRegistry, 'searchProvider', null, async (providers) => {


### PR DESCRIPTION
Fixes: https://github.com/umbraco/Umbraco.CMS.Backoffice/issues/1875
Temp solution to add light dismiss (closing on outside click) to the global search modal.
We should look into adding a property in UI Library that allows for native light dismiss on all our modals.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
