### PR TITLE
Bugfix: Import property-actions components

### DIFF
--- a/src/packages/core/entry-point.ts
+++ b/src/packages/core/entry-point.ts
@@ -6,6 +6,7 @@ import { UmbNotificationContext } from '@umbraco-cms/backoffice/notification';
 import { UmbModalManagerContext } from '@umbraco-cms/backoffice/modal';
 import { UmbExtensionsApiInitializer, type UmbEntryPointOnInit } from '@umbraco-cms/backoffice/extension-api';
 
+import './property-action/components/index.js';
 import './menu/components/index.js';
 import './extension-registry/components/index.js';
 

--- a/src/packages/core/property/property/property.element.ts
+++ b/src/packages/core/property/property/property.element.ts
@@ -302,7 +302,7 @@ export class UmbPropertyElement extends UmbLitElement {
 				.description=${this._description}
 				.orientation=${this._orientation ?? 'horizontal'}
 				?invalid=${this._invalid}>
-				${this._renderPropertyActionMenu()}
+				${this.#renderPropertyActionMenu()}
 				${this._variantDifference
 					? html`<uui-tag look="secondary" slot="description">${this._variantDifference}</uui-tag>`
 					: ''}
@@ -311,13 +311,15 @@ export class UmbPropertyElement extends UmbLitElement {
 		`;
 	}
 
-	private _renderPropertyActionMenu() {
-		return this._propertyEditorUiAlias
-			? html`<umb-property-action-menu
-					slot="action-menu"
-					id="action-menu"
-					.propertyEditorUiAlias=${this._propertyEditorUiAlias}></umb-property-action-menu>`
-			: nothing;
+	#renderPropertyActionMenu() {
+		if (!this._propertyEditorUiAlias) return nothing;
+		return html`
+			<umb-property-action-menu
+				slot="action-menu"
+				id="action-menu"
+				.propertyEditorUiAlias=${this._propertyEditorUiAlias}>
+			</umb-property-action-menu>
+		`;
 	}
 
 	static styles = [


### PR DESCRIPTION
## Description

Imports the property-actions components.

At some point the Property Actions feature was omitted since the components weren't being imported into client. This PR resolves that and Property Actions can be used again.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
