### PR TITLE
Bugfix: Cultures & Hostnames modal, close on Save

### DIFF
--- a/src/packages/documents/documents/entity-actions/culture-and-hostnames/modal/culture-and-hostnames-modal.element.ts
+++ b/src/packages/documents/documents/entity-actions/culture-and-hostnames/modal/culture-and-hostnames-modal.element.ts
@@ -3,12 +3,12 @@ import type {
 	UmbCultureAndHostnamesModalData,
 	UmbCultureAndHostnamesModalValue,
 } from './culture-and-hostnames-modal.token.js';
-import { html, customElement, state, css, repeat, query } from '@umbraco-cms/backoffice/external/lit';
-import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
-import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
-import type { UmbLanguageDetailModel } from '@umbraco-cms/backoffice/language';
+import { css, customElement, html, query, repeat, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLanguageCollectionRepository } from '@umbraco-cms/backoffice/language';
+import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
+import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import type { DomainPresentationModel } from '@umbraco-cms/backoffice/external/backend-api';
+import type { UmbLanguageDetailModel } from '@umbraco-cms/backoffice/language';
 import type { UUIInputEvent, UUIPopoverContainerElement, UUISelectEvent } from '@umbraco-cms/backoffice/external/uui';
 
 @customElement('umb-culture-and-hostnames-modal')
@@ -61,10 +61,11 @@ export class UmbCultureAndHostnamesModalElement extends UmbModalBaseElement<
 	async #handleSave() {
 		this.value = { defaultIsoCode: this._defaultIsoCode, domains: this._domains };
 		await this.#documentRepository.updateCultureAndHostnames(this.#unique!, this.value);
+		this.modalContext?.submit();
 	}
 
-	#handleClose() {
-		this.modalContext?.submit();
+	#handleCancel() {
+		this.modalContext?.reject();
 	}
 
 	// Events
@@ -114,74 +115,81 @@ export class UmbCultureAndHostnamesModalElement extends UmbModalBaseElement<
 				<uui-button
 					slot="actions"
 					id="close"
-					label=${this.localize.term('general_close')}
-					@click="${this.#handleClose}"></uui-button>
+					label=${this.localize.term('general_cancel')}
+					@click=${this.#handleCancel}></uui-button>
 				<uui-button
 					slot="actions"
 					id="save"
 					look="primary"
 					color="positive"
 					label=${this.localize.term('buttons_save')}
-					@click="${this.#handleSave}"></uui-button>
+					@click=${this.#handleSave}></uui-button>
 			</umb-body-layout>
 		`;
 	}
 
 	#renderCultureSection() {
-		return html`<uui-box headline=${this.localize.term('assignDomain_setLanguage')}>
-			<uui-label for="select">${this.localize.term('assignDomain_language')}</uui-label>
-			<uui-combobox
-				id="select"
-				label=${this.localize.term('assignDomain_language')}
-				.value=${(this._defaultIsoCode as string) ?? 'inherit'}
-				@change=${this.#onChangeLanguage}>
-				<uui-combobox-list>
-					<uui-combobox-list-option .value=${'inherit'}>
-						${this.localize.term('assignDomain_inherit')}
-					</uui-combobox-list-option>
-					${this.#renderLanguageModelOptions()}
-				</uui-combobox-list>
-			</uui-combobox>
-		</uui-box>`;
+		return html`
+			<uui-box headline=${this.localize.term('assignDomain_setLanguage')}>
+				<uui-label for="select">${this.localize.term('assignDomain_language')}</uui-label>
+				<uui-combobox
+					id="select"
+					label=${this.localize.term('assignDomain_language')}
+					.value=${(this._defaultIsoCode as string) ?? 'inherit'}
+					@change=${this.#onChangeLanguage}>
+					<uui-combobox-list>
+						<uui-combobox-list-option .value=${'inherit'}>
+							${this.localize.term('assignDomain_inherit')}
+						</uui-combobox-list-option>
+						${this.#renderLanguageModelOptions()}
+					</uui-combobox-list>
+				</uui-combobox>
+			</uui-box>
+		`;
 	}
 
 	#renderDomainSection() {
-		return html`<uui-box headline=${this.localize.term('assignDomain_setDomains')}>
-			<umb-localize key="assignDomain_domainHelpWithVariants">
-				Valid domain names are: "example.com", "www.example.com", "example.com:8080", or "https://www.example.com/".<br />Furthermore
-				also one-level paths in domains are supported, eg. "example.com/en" or "/en".
-			</umb-localize>
-			${this.#renderDomains()} ${this.#renderAddNewDomainButton()}
-		</uui-box>`;
+		return html`
+			<uui-box headline=${this.localize.term('assignDomain_setDomains')}>
+				<umb-localize key="assignDomain_domainHelpWithVariants">
+					Valid domain names are: "example.com", "www.example.com", "example.com:8080", or
+					"https://www.example.com/".<br />Furthermore also one-level paths in domains are supported, eg.
+					"example.com/en" or "/en".
+				</umb-localize>
+				${this.#renderDomains()} ${this.#renderAddNewDomainButton()}
+			</uui-box>
+		`;
 	}
 
 	#renderDomains() {
 		if (!this._domains?.length) return;
-		return html`<div id="domains">
-			${repeat(
-				this._domains,
-				(domain) => domain.isoCode,
-				(domain, index) => html`
-					<uui-input
-						label=${this.localize.term('assignDomain_domain')}
-						.value=${domain.domainName}
-						@change=${(e: UUIInputEvent) => this.#onChangeDomainHostname(e, index)}></uui-input>
-					<uui-combobox
-						.value=${domain.isoCode as string}
-						label=${this.localize.term('assignDomain_language')}
-						@change=${(e: UUISelectEvent) => this.#onChangeDomainLanguage(e, index)}>
-						<uui-combobox-list> ${this.#renderLanguageModelOptions()} </uui-combobox-list>
-					</uui-combobox>
-					<uui-button
-						look="outline"
-						color="danger"
-						label=${this.localize.term('assignDomain_remove')}
-						@click=${() => this.#onRemoveDomain(index)}>
-						<uui-icon name="icon-trash"></uui-icon>
-					</uui-button>
-				`,
-			)}
-		</div>`;
+		return html`
+			<div id="domains">
+				${repeat(
+					this._domains,
+					(domain) => domain.isoCode,
+					(domain, index) => html`
+						<uui-input
+							label=${this.localize.term('assignDomain_domain')}
+							.value=${domain.domainName}
+							@change=${(e: UUIInputEvent) => this.#onChangeDomainHostname(e, index)}></uui-input>
+						<uui-combobox
+							.value=${domain.isoCode as string}
+							label=${this.localize.term('assignDomain_language')}
+							@change=${(e: UUISelectEvent) => this.#onChangeDomainLanguage(e, index)}>
+							<uui-combobox-list> ${this.#renderLanguageModelOptions()} </uui-combobox-list>
+						</uui-combobox>
+						<uui-button
+							look="outline"
+							color="danger"
+							label=${this.localize.term('assignDomain_remove')}
+							@click=${() => this.#onRemoveDomain(index)}>
+							<uui-icon name="icon-trash"></uui-icon>
+						</uui-button>
+					`,
+				)}
+			</div>
+		`;
 	}
 
 	#renderLanguageModelOptions() {
@@ -193,26 +201,28 @@ export class UmbCultureAndHostnamesModalElement extends UmbModalBaseElement<
 	}
 
 	#renderAddNewDomainButton() {
-		return html`<uui-button-group>
-			<uui-button
-				label=${this.localize.term('assignDomain_addNew')}
-				look="placeholder"
-				@click=${() => this.#onAddDomain()}></uui-button>
-			<uui-button
-				id="dropdown"
-				label=${this.localize.term('buttons_select')}
-				look="placeholder"
-				popovertarget="more-options">
-				<uui-icon name="icon-navigation-down"></uui-icon>
-			</uui-button>
-			<uui-popover-container id="more-options" placement="bottom-end">
-				<umb-popover-layout>
-					<uui-button
-						label=${this.localize.term('assignDomain_addCurrent')}
-						@click=${() => this.#onAddDomain(true)}></uui-button>
-				</umb-popover-layout>
-			</uui-popover-container>
-		</uui-button-group> `;
+		return html`
+			<uui-button-group>
+				<uui-button
+					label=${this.localize.term('assignDomain_addNew')}
+					look="placeholder"
+					@click=${() => this.#onAddDomain()}></uui-button>
+				<uui-button
+					id="dropdown"
+					label=${this.localize.term('buttons_select')}
+					look="placeholder"
+					popovertarget="more-options">
+					<uui-icon name="icon-navigation-down"></uui-icon>
+				</uui-button>
+				<uui-popover-container id="more-options" placement="bottom-end">
+					<umb-popover-layout>
+						<uui-button
+							label=${this.localize.term('assignDomain_addCurrent')}
+							@click=${() => this.#onAddDomain(true)}></uui-button>
+					</umb-popover-layout>
+				</uui-popover-container>
+			</uui-button-group>
+		`;
 	}
 
 	static styles = [


### PR DESCRIPTION
## Description

In a document's Culture and Hostnames modal, after adding domains and clicking on Save, the overlay did not close.
This PR resolves that, (with some additional code/markup amends).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
