### PR TITLE
Feature: Document Type Descriptions

### DIFF
--- a/src/packages/documents/document-types/workspace/document-type-workspace-editor.element.ts
+++ b/src/packages/documents/document-types/workspace/document-type-workspace-editor.element.ts
@@ -3,6 +3,7 @@ import type { UmbInputWithAliasElement } from '@umbraco-cms/backoffice/component
 import { umbFocus, UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { css, html, customElement, state, ifDefined } from '@umbraco-cms/backoffice/external/lit';
 import { UMB_MODAL_MANAGER_CONTEXT, UMB_ICON_PICKER_MODAL } from '@umbraco-cms/backoffice/modal';
+import type { UUITextareaElement } from '@umbraco-cms/backoffice/external/uui';
 
 @customElement('umb-document-type-workspace-editor')
 export class UmbDocumentTypeWorkspaceEditorElement extends UmbLitElement {
@@ -11,6 +12,9 @@ export class UmbDocumentTypeWorkspaceEditorElement extends UmbLitElement {
 
 	@state()
 	private _alias?: string;
+
+	@state()
+	private _description?: string;
 
 	@state()
 	private _icon?: string;
@@ -33,6 +37,11 @@ export class UmbDocumentTypeWorkspaceEditorElement extends UmbLitElement {
 		if (!this.#workspaceContext) return;
 		this.observe(this.#workspaceContext.name, (name) => (this._name = name), '_observeName');
 		this.observe(this.#workspaceContext.alias, (alias) => (this._alias = alias), '_observeAlias');
+		this.observe(
+			this.#workspaceContext.description,
+			(description) => (this._description = description),
+			'_observeDescription',
+		);
 		this.observe(this.#workspaceContext.icon, (icon) => (this._icon = icon), '_observeIcon');
 		this.observe(this.#workspaceContext.isNew, (isNew) => (this._isNew = isNew), '_observeIsNew');
 	}
@@ -61,6 +70,10 @@ export class UmbDocumentTypeWorkspaceEditorElement extends UmbLitElement {
 		this.#workspaceContext?.setAlias(event.target.alias ?? '');
 	}
 
+	#onDescriptionChange(event: InputEvent & { target: UUITextareaElement }) {
+		this.#workspaceContext?.setDescription(event.target.value.toString() ?? '');
+	}
+
 	render() {
 		return html`
 			<umb-workspace-editor alias="Umb.Workspace.DocumentType">
@@ -69,15 +82,24 @@ export class UmbDocumentTypeWorkspaceEditorElement extends UmbLitElement {
 						<umb-icon name=${ifDefined(this._icon)}></umb-icon>
 					</uui-button>
 
-					<umb-input-with-alias
-						id="name"
-						label="name"
-						value=${this._name}
-						alias=${this._alias}
-						?auto-generate-alias=${this._isNew}
-						@change="${this.#onNameAndAliasChange}"
-						${umbFocus()}>
-					</umb-input-with-alias>
+					<div id="editors">
+						<umb-input-with-alias
+							id="name"
+							label="name"
+							value=${this._name}
+							alias=${this._alias}
+							?auto-generate-alias=${this._isNew}
+							@change="${this.#onNameAndAliasChange}"
+							${umbFocus()}>
+						</umb-input-with-alias>
+
+						<uui-input
+							id="description"
+							.label=${this.localize.term('placeholders_enterDescription')}
+							.value=${this._description}
+							.placeholder=${this.localize.term('placeholders_enterDescription')}
+							@input=${this.#onDescriptionChange}></uui-input>
+					</div>
 				</div>
 			</umb-workspace-editor>
 		`;
@@ -96,8 +118,25 @@ export class UmbDocumentTypeWorkspaceEditorElement extends UmbLitElement {
 				flex: 1 1 auto;
 			}
 
+			#editors {
+				display: flex;
+				flex: 1 1 auto;
+				flex-direction: column;
+				gap: var(--uui-size-space-1);
+			}
+
 			#name {
 				width: 100%;
+			}
+
+			#description {
+				width: 100%;
+				--uui-input-height: var(--uui-size-8);
+				--uui-input-border-color: transparent;
+			}
+
+			#description:hover {
+				--uui-input-border-color: var(--uui-color-border);
 			}
 
 			#icon {

--- a/src/packages/documents/documents/entity-actions/create/document-create-options-modal.element.ts
+++ b/src/packages/documents/documents/entity-actions/create/document-create-options-modal.element.ts
@@ -3,7 +3,7 @@ import type {
 	UmbDocumentCreateOptionsModalData,
 	UmbDocumentCreateOptionsModalValue,
 } from './document-create-options-modal.token.js';
-import { html, nothing, customElement, state, ifDefined, repeat, css } from '@umbraco-cms/backoffice/external/lit';
+import { html, customElement, state, ifDefined, repeat, css, when } from '@umbraco-cms/backoffice/external/lit';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 import {
@@ -128,16 +128,24 @@ export class UmbDocumentCreateOptionsModalElement extends UmbModalBaseElement<
 
 	#renderDocumentTypes() {
 		return html`<uui-box .headline=${this._headline}>
-			${this._allowedDocumentTypes.length === 0 ? html`<p>No allowed types</p>` : nothing}
-			${this._allowedDocumentTypes.map(
-				(documentType) => html`
-					<uui-menu-item
-						data-id=${ifDefined(documentType.unique)}
-						label="${documentType.name}"
-						@click=${() => this.#onSelectDocumentType(documentType.unique)}>
-						<umb-icon slot="icon" name=${documentType.icon || 'icon-circle-dotted'}></umb-icon>
-					</uui-menu-item>
-				`,
+			${when(
+				this._allowedDocumentTypes.length === 0,
+				() => html`<p>No allowed types</p>`,
+				() =>
+					repeat(
+						this._allowedDocumentTypes,
+						(documentType) => documentType.unique,
+						(documentType) =>
+							html` <uui-ref-node-document-type
+								data-id=${ifDefined(documentType.unique)}
+								.name=${documentType.name}
+								.alias=${documentType.description}
+								select-only
+								selectable
+								@selected=${() => this.#onSelectDocumentType(documentType.unique)}>
+								<umb-icon slot="icon" name=${documentType.icon || 'icon-circle-dotted'}></umb-icon>
+							</uui-ref-node-document-type>`,
+					),
 			)}
 		</uui-box>`;
 	}

--- a/src/packages/documents/documents/entity-actions/create/document-create-options-modal.element.ts
+++ b/src/packages/documents/documents/entity-actions/create/document-create-options-modal.element.ts
@@ -130,7 +130,13 @@ export class UmbDocumentCreateOptionsModalElement extends UmbModalBaseElement<
 		return html`<uui-box .headline=${this._headline}>
 			${when(
 				this._allowedDocumentTypes.length === 0,
-				() => html`<p>No allowed types</p>`,
+				() => html`
+					<umb-localize key="create_noDocumentTypes">
+						There are no allowed Document Types available for creating content here. You must enable these in
+						<strong>Document Types</strong> within the <strong>Settings</strong> section, by editing the
+						<strong>Allowed child node types</strong> under <strong>Permissions</strong>
+					</umb-localize>
+				`,
 				() =>
 					repeat(
 						this._allowedDocumentTypes,


### PR DESCRIPTION
## Description

This adds the description field to the document type editor. It also adds the description to the Document Create Options Modal.

This partly fixes https://github.com/umbraco/Umbraco-CMS/issues/16391

NB! We are now able to save descriptions, and not lose migrated data, however we still lack descriptions on the different item pickers because the item models do not carry the description with them.

## How to test

Add a description to a doc type:
<img width="815" alt="image" src="https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/752371/d9c41be4-c9d2-4636-8bc5-f72c4b0205cd">

Make sure it shows up in the options creator modal:
<img width="433" alt="image" src="https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/752371/865e74ac-948c-4245-9562-5be20e0f5754">
