### PR TITLE
Feature: Member Type Descriptions

### DIFF
--- a/src/packages/members/member-type/workspace/member-type-workspace-editor.element.ts
+++ b/src/packages/members/member-type/workspace/member-type-workspace-editor.element.ts
@@ -1,6 +1,7 @@
 import { UMB_MEMBER_TYPE_WORKSPACE_CONTEXT } from './member-type-workspace.context-token.js';
 import type { UmbInputWithAliasElement } from '@umbraco-cms/backoffice/components';
 import { css, html, customElement, state, ifDefined } from '@umbraco-cms/backoffice/external/lit';
+import type { UUITextareaElement } from '@umbraco-cms/backoffice/external/uui';
 import { UmbLitElement, umbFocus } from '@umbraco-cms/backoffice/lit-element';
 import { UMB_ICON_PICKER_MODAL, UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
 
@@ -8,6 +9,9 @@ import { UMB_ICON_PICKER_MODAL, UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/b
 export class UmbMemberTypeWorkspaceEditorElement extends UmbLitElement {
 	@state()
 	private _name?: string;
+
+	@state()
+	private _description?: string;
 
 	@state()
 	private _alias?: string;
@@ -36,6 +40,11 @@ export class UmbMemberTypeWorkspaceEditorElement extends UmbLitElement {
 	#observeMemberType() {
 		if (!this.#workspaceContext) return;
 		this.observe(this.#workspaceContext.name, (name) => (this._name = name), '_observeName');
+		this.observe(
+			this.#workspaceContext.description,
+			(description) => (this._description = description),
+			'_observeDescription',
+		);
 		this.observe(this.#workspaceContext.alias, (alias) => (this._alias = alias), '_observeAlias');
 		this.observe(this.#workspaceContext.icon, (icon) => (this._icon = icon), '_observeIcon');
 		this.observe(this.#workspaceContext.isNew, (isNew) => (this._isNew = isNew), '_observeIsNew');
@@ -65,6 +74,10 @@ export class UmbMemberTypeWorkspaceEditorElement extends UmbLitElement {
 		this.#workspaceContext?.setAlias(event.target.alias ?? '');
 	}
 
+	#onDescriptionChange(event: InputEvent & { target: UUITextareaElement }) {
+		this.#workspaceContext?.setDescription(event.target.value.toString() ?? '');
+	}
+
 	render() {
 		return html`
 			<umb-workspace-editor alias="Umb.Workspace.MemberType">
@@ -73,15 +86,24 @@ export class UmbMemberTypeWorkspaceEditorElement extends UmbLitElement {
 						<uui-icon name="${ifDefined(this._icon)}" style="color: ${this._iconColorAlias}"></uui-icon>
 					</uui-button>
 
-					<umb-input-with-alias
-						id="name"
-						label="name"
-						value=${this._name}
-						alias=${this._alias}
-						?auto-generate-alias=${this._isNew}
-						@change="${this.#onNameAndAliasChange}"
-						${umbFocus()}>
-					</umb-input-with-alias>
+					<div id="editors">
+						<umb-input-with-alias
+							id="name"
+							label="name"
+							value=${this._name}
+							alias=${this._alias}
+							?auto-generate-alias=${this._isNew}
+							@change="${this.#onNameAndAliasChange}"
+							${umbFocus()}>
+						</umb-input-with-alias>
+
+						<uui-input
+							id="description"
+							.label=${this.localize.term('placeholders_enterDescription')}
+							.value=${this._description}
+							.placeholder=${this.localize.term('placeholders_enterDescription')}
+							@input=${this.#onDescriptionChange}></uui-input>
+					</div>
 				</div>
 			</umb-workspace-editor>
 		`;
@@ -100,10 +122,27 @@ export class UmbMemberTypeWorkspaceEditorElement extends UmbLitElement {
 				flex: 1 1 auto;
 			}
 
+			#editors {
+				display: flex;
+				flex: 1 1 auto;
+				flex-direction: column;
+				gap: var(--uui-size-space-1);
+			}
+
 			#name {
 				width: 100%;
 				flex: 1 1 auto;
 				align-items: center;
+			}
+
+			#description {
+				width: 100%;
+				--uui-input-height: var(--uui-size-8);
+				--uui-input-border-color: transparent;
+			}
+
+			#description:hover {
+				--uui-input-border-color: var(--uui-color-border);
 			}
 
 			#alias-lock {


### PR DESCRIPTION
## Description

Adds descriptions to member types.

NB! There are currently no usages for this description as we do not have the create options modal for members, because the member section is currently implemented as a section without folders or a menu tree, where that options modal would normally be used.

## How to test

1. Add a description to a member type
2. Verify the description is still set upon reload