### PR TITLE
fix: turn off generated url encoding for `OpenAPI`

### DIFF
--- a/src/apps/app/app.element.ts
+++ b/src/apps/app/app.element.ts
@@ -225,6 +225,7 @@ export class UmbAppElement extends UmbLitElement {
 		// Instruct all requests to use the auth flow to get and use the access_token for all subsequent requests
 		OpenAPI.TOKEN = () => this.#authContext!.getLatestToken();
 		OpenAPI.WITH_CREDENTIALS = true;
+		OpenAPI.ENCODE_PATH = (path: string) => path;
 	}
 
 	#redirect() {

--- a/src/packages/core/auth/auth.context.ts
+++ b/src/packages/core/auth/auth.context.ts
@@ -253,6 +253,7 @@ export class UmbAuthContext extends UmbContextBase<UmbAuthContext> {
 			withCredentials: OpenAPI.WITH_CREDENTIALS,
 			credentials: OpenAPI.CREDENTIALS,
 			token: () => this.getLatestToken(),
+			encodePath: OpenAPI.ENCODE_PATH,
 		};
 	}
 

--- a/src/packages/core/auth/models/openApiConfiguration.ts
+++ b/src/packages/core/auth/models/openApiConfiguration.ts
@@ -29,4 +29,10 @@ export interface UmbOpenApiConfiguration {
 	 * @returns A resolver for the token to use for the Authorization header.
 	 */
 	readonly token: () => Promise<string>;
+
+	/**
+	 * The encoder to use for the request URLs.
+	 * @returns A resolver for the encoder to use for the request URLs.
+	 */
+	readonly encodePath?: (value: string) => string;
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/umbraco/Umbraco-CMS/issues/16431

The generated OpenAPI client runs `encodeURI` on all URLs, which works nicely except for files, where we query with a filepath. The problem is that `encodeURI` doesn't care about slashes, but it cares about many other things, so when we encode `/file.css` it becomes `%2Ftest.css` which then gets further encoded by OpenAPI to `%252Ftest.css`, which is handled well by Kestrel but not by IIS. This fix essentially turns off the built-in encoding from the OpenAPI client and relies on the implementor to encode everything manually, which we already do.

The problem is most apparent in "static files" which lead with a slash, which gets double-encoded (stylesheets, scripts, partials).