### PR TITLE
Fix: editing block in Area

### DIFF
--- a/src/packages/block/block-rte/workspace/block-rte-workspace.modal-token.ts
+++ b/src/packages/block/block-rte/workspace/block-rte-workspace.modal-token.ts
@@ -1,16 +1,10 @@
-import type {
-	UmbBlockLayoutBaseModel,
-	UmbBlockViewPropsType,
-	UmbBlockWorkspaceData,
-} from '@umbraco-cms/backoffice/block';
-import type { UmbWorkspaceModalData } from '@umbraco-cms/backoffice/modal';
+import type { UmbBlockWorkspaceData } from '@umbraco-cms/backoffice/block';
+import type { UmbWorkspaceModalData, UmbWorkspaceModalValue } from '@umbraco-cms/backoffice/modal';
 import { UmbModalToken } from '@umbraco-cms/backoffice/modal';
 
 export interface UmbBlockRteWorkspaceData extends UmbBlockWorkspaceData<object> {}
 
-export type UmbBlockRteWorkspaceValue = Array<UmbBlockViewPropsType<UmbBlockLayoutBaseModel>>;
-
-export const UMB_BLOCK_RTE_WORKSPACE_MODAL = new UmbModalToken<UmbBlockRteWorkspaceData, UmbBlockRteWorkspaceValue>(
+export const UMB_BLOCK_RTE_WORKSPACE_MODAL = new UmbModalToken<UmbBlockRteWorkspaceData, UmbWorkspaceModalValue>(
 	'Umb.Modal.Workspace',
 	{
 		modal: {
@@ -20,4 +14,4 @@ export const UMB_BLOCK_RTE_WORKSPACE_MODAL = new UmbModalToken<UmbBlockRteWorksp
 		data: { entityType: 'block', preset: {}, originData: {} },
 		// Recast the type, so the entityType data prop is not required:
 	},
-) as UmbModalToken<Omit<UmbWorkspaceModalData, 'entityType'>, UmbBlockRteWorkspaceValue>;
+) as UmbModalToken<Omit<UmbWorkspaceModalData, 'entityType'>, UmbWorkspaceModalValue>;

--- a/src/packages/block/block/context/block-entries.context.ts
+++ b/src/packages/block/block/context/block-entries.context.ts
@@ -1,13 +1,13 @@
 import type { UmbBlockDataType, UmbBlockLayoutBaseModel } from '../types.js';
-import { UMB_BLOCK_WORKSPACE_MODAL } from '../workspace/block-workspace.modal-token.js';
-import type { UmbBlockDataObjectModel, UmbBlockManagerContext } from './block-manager.context.js';
+import type { UmbBlockWorkspaceData } from '../workspace/block-workspace.modal-token.js';
 import { UMB_BLOCK_ENTRIES_CONTEXT } from './block-entries.context-token.js';
+import type { UmbBlockDataObjectModel, UmbBlockManagerContext } from './block-manager.context.js';
+import { type Observable, UmbArrayState, UmbBasicState, UmbStringState } from '@umbraco-cms/backoffice/observable-api';
+import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
 import type { UmbBlockTypeBaseModel } from '@umbraco-cms/backoffice/block-type';
 import type { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
-import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
-import { type Observable, UmbArrayState, UmbBasicState, UmbStringState } from '@umbraco-cms/backoffice/observable-api';
-import { type UmbModalRouteBuilder, UmbModalRouteRegistrationController } from '@umbraco-cms/backoffice/router';
+import type { UmbModalRouteBuilder } from '@umbraco-cms/backoffice/router';
 
 export abstract class UmbBlockEntriesContext<
 	BlockManagerContextTokenType extends UmbContextToken<BlockManagerContextType, BlockManagerContextType>,
@@ -21,13 +21,11 @@ export abstract class UmbBlockEntriesContext<
 	_manager?: BlockManagerContextType;
 	_retrieveManager;
 
-	_workspaceModal: UmbModalRouteRegistrationController;
-
 	protected _catalogueRouteBuilderState = new UmbBasicState<UmbModalRouteBuilder | undefined>(undefined);
 	readonly catalogueRouteBuilder = this._catalogueRouteBuilderState.asObservable();
 
-	#workspacePath = new UmbStringState(undefined);
-	workspacePath = this.#workspacePath.asObservable();
+	protected _workspacePath = new UmbStringState(undefined);
+	workspacePath = this._workspacePath.asObservable();
 
 	public abstract readonly canCreate: Observable<boolean>;
 
@@ -42,34 +40,7 @@ export abstract class UmbBlockEntriesContext<
 		this._retrieveManager = this.consumeContext(blockManagerContextToken, (blockGridManager) => {
 			this._manager = blockGridManager;
 			this._gotBlockManager();
-
-			this.observe(
-				this._manager.propertyAlias,
-				(alias) => {
-					this._workspaceModal.setUniquePathValue('propertyAlias', alias);
-				},
-				'observePropertyAlias',
-			);
-			this.observe(
-				this._manager.variantId,
-				(variantId) => {
-					// TODO: This might not be the property variant ID, but the content variant ID. Check up on what makes most sense?
-					this._workspaceModal.setUniquePathValue('variantId', variantId?.toString());
-				},
-				'observePropertyVariantId',
-			);
 		}).asPromise();
-
-		this._workspaceModal = new UmbModalRouteRegistrationController(this, UMB_BLOCK_WORKSPACE_MODAL)
-			.addUniquePaths(['propertyAlias', 'variantId'])
-			.addAdditionalPath('block')
-			.onSetup(() => {
-				return { data: { entityType: 'block', preset: {} }, modal: { size: 'medium' } };
-			})
-			.observeRouteBuilder((routeBuilder) => {
-				const newPath = routeBuilder({});
-				this.#workspacePath.setValue(newPath);
-			});
 	}
 
 	async getManager() {
@@ -100,14 +71,14 @@ export abstract class UmbBlockEntriesContext<
 	public abstract create(
 		contentElementTypeKey: string,
 		layoutEntry?: Omit<BlockLayoutType, 'contentUdi'>,
-		modalData?: typeof UMB_BLOCK_WORKSPACE_MODAL.DATA,
+		modalData?: UmbBlockWorkspaceData,
 	): Promise<UmbBlockDataObjectModel<BlockLayoutType> | undefined>;
 
 	abstract insert(
 		layoutEntry: BlockLayoutType,
 		content: UmbBlockDataType,
 		settings: UmbBlockDataType | undefined,
-		modalData: typeof UMB_BLOCK_WORKSPACE_MODAL.DATA,
+		modalData: UmbBlockWorkspaceData,
 	): Promise<boolean>;
 	//edit?
 	//editSettings

--- a/src/packages/block/block/workspace/block-workspace.context.ts
+++ b/src/packages/block/block/workspace/block-workspace.context.ts
@@ -324,7 +324,7 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 			} else {
 				// Update data:
 
-				this.#blockManager.setOneLayout(layoutData, this.#modalContext?.data as UmbBlockWorkspaceData);
+				this.#blockManager.setOneLayout(layoutData, this.#modalContext.data as UmbBlockWorkspaceData);
 				if (contentData) {
 					this.#blockManager.setOneContent(contentData);
 				}


### PR DESCRIPTION
Fixes a problem where a Block Modal does not have enough data about the area of which the editing is taking place, resulting in the Block begin appended to the root, not in the area.

To fix this I move the workspace modal registration into each implementation to ensure type awareness — This can maybe be optimised later, but for now it gives clarity.
Simply because the problem was that the modal did not knew about the areaKay or parentUnique, which resulted in the update taking place in the root.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

Create similar scenario like this. Explore when adding another Block and editing that block, a copy will be placed in the root.
![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/6791648/c1fa3215-e0ce-4936-8a77-df94d7206c2d)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
