### PR TITLE
Chore: EsLint Rule No relative import to import map module

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -48,6 +48,7 @@
 				"local-rules/prefer-import-aliases": "error",
 				"local-rules/prefer-static-styles-last": "warn",
 				"local-rules/umb-class-prefix": "error",
+				"local-rules/no-relative-import-to-import-map-module": "error",
 				"local-rules/enforce-umbraco-external-imports": [
 					"error",
 					{

--- a/devops/eslint/rules/no-relative-import-to-import-map-module.cjs
+++ b/devops/eslint/rules/no-relative-import-to-import-map-module.cjs
@@ -1,0 +1,98 @@
+// TODO: figure out how to automatically generate this list of module paths
+const modulePathIdentifiers = [
+	'/core/action/',
+	'/core/audit-log/',
+	'/core/auth/',
+	'/core/collection/',
+	'/core/components/',
+	'/core/content-type/',
+	'/core/content/',
+	'/core/culture/',
+	'/core/debug/',
+	'/core/entity-action/',
+	'/core/entity-bulk-action/',
+	'/core/entity/',
+	'/core/event/',
+	'/core/extension-registry/',
+	'/core/icon-registry/',
+	'/core/id/',
+	'/core/lit-element/',
+	'/core/localization/',
+	'/core/menu/',
+	'/core/modal/',
+	'/core/models/',
+	'/core/notification/',
+	'/core/picker-input/',
+	'/core/property/',
+	'/core/property-editor/',
+	'/core/recycle-bin/',
+	'/core/repository/',
+	'/core/resources/',
+	'/core/router/',
+	'/core/section/',
+	'/core/server-file-system/',
+	'/core/settings/',
+	'/core/sorter/',
+	'/core/store/',
+	'/core/style/',
+	'/core/temporary-file/',
+	'/core/themes/',
+	'/core/tree/',
+	'/core/utils/',
+	'/core/validation/',
+	'/core/variant/',
+	'/core/workspace/',
+	'/class-api/',
+	'/context-api/',
+	'/controller-api/',
+	'/element-api/',
+	'/extension-api/',
+	'/formatting-api/',
+	'/localization-api/',
+	'/observable-api/',
+	'/backend-api/',
+	'/base64-js/',
+	'/diff/',
+	'/dompurify/',
+	'/lit/',
+	'/marked/',
+	'/monaco-editor/',
+	'/openid/',
+	'/router-slot/',
+	'/rxjs/',
+	'/tinymce/',
+	'/uui/',
+	'/uuid/',
+];
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'Prevent relative import to a module that is in the import map.',
+			category: 'Best Practices',
+			recommended: true,
+		},
+		schema: [],
+		messages: {
+			unexpectedValue: 'Relative import paths should include "{{value}}".',
+		},
+	},
+	create: function (context) {
+		return {
+			ImportDeclaration(node) {
+				const importPath = node.source.value;
+
+				if (importPath.startsWith('./') || importPath.startsWith('../')) {
+					if (modulePathIdentifiers.some((moduleName) => importPath.includes(moduleName))) {
+						context.report({
+							node,
+							message: 'Use the correct import map alias instead of a relative import path: ' + importPath,
+						});
+					}
+				}
+			},
+		};
+	},
+};

--- a/devops/eslint/rules/no-relative-import-to-import-map-module.cjs
+++ b/devops/eslint/rules/no-relative-import-to-import-map-module.cjs
@@ -82,6 +82,11 @@ module.exports = {
 	create: function (context) {
 		return {
 			ImportDeclaration(node) {
+				// exclude test  and story files
+				if (context.filename.endsWith('.test.ts') || context.filename.endsWith('.stories.ts')) {
+					return {};
+				}
+
 				const importPath = node.source.value;
 
 				if (importPath.startsWith('./') || importPath.startsWith('../')) {

--- a/devops/eslint/rules/no-relative-import-to-import-map-module.cjs
+++ b/devops/eslint/rules/no-relative-import-to-import-map-module.cjs
@@ -1,69 +1,22 @@
-// TODO: figure out how to automatically generate this list of module paths
-const modulePathIdentifiers = [
-	'/core/action/',
-	'/core/audit-log/',
-	'/core/auth/',
-	'/core/collection/',
-	'/core/components/',
-	'/core/content-type/',
-	'/core/content/',
-	'/core/culture/',
-	'/core/debug/',
-	'/core/entity-action/',
-	'/core/entity-bulk-action/',
-	'/core/entity/',
-	'/core/event/',
-	'/core/extension-registry/',
-	'/core/icon-registry/',
-	'/core/id/',
-	'/core/lit-element/',
-	'/core/localization/',
-	'/core/menu/',
-	'/core/modal/',
-	'/core/models/',
-	'/core/notification/',
-	'/core/picker-input/',
-	'/core/property/',
-	'/core/property-editor/',
-	'/core/recycle-bin/',
-	'/core/repository/',
-	'/core/resources/',
-	'/core/router/',
-	'/core/section/',
-	'/core/server-file-system/',
-	'/core/settings/',
-	'/core/sorter/',
-	'/core/store/',
-	'/core/style/',
-	'/core/temporary-file/',
-	'/core/themes/',
-	'/core/tree/',
-	'/core/utils/',
-	'/core/validation/',
-	'/core/variant/',
-	'/core/workspace/',
-	'/class-api/',
-	'/context-api/',
-	'/controller-api/',
-	'/element-api/',
-	'/extension-api/',
-	'/formatting-api/',
-	'/localization-api/',
-	'/observable-api/',
-	'/backend-api/',
-	'/base64-js/',
-	'/diff/',
-	'/dompurify/',
-	'/lit/',
-	'/marked/',
-	'/monaco-editor/',
-	'/openid/',
-	'/router-slot/',
-	'/rxjs/',
-	'/tinymce/',
-	'/uui/',
-	'/uuid/',
-];
+const fs = require('fs');
+const path = require('path');
+
+const getDirectories = (source) =>
+	fs
+		.readdirSync(source, { withFileTypes: true })
+		.filter((dirent) => dirent.isDirectory())
+		.map((dirent) => dirent.name);
+
+// TODO: get the correct list of modules. This is a temporary solution where we assume that a directory is equivalent to a module
+// TODO: include package modules in this list
+const coreRoot = path.join(__dirname, '../../../', 'src/packages/core');
+const externalRoot = path.join(__dirname, '../../../', 'src/external');
+const libsRoot = path.join(__dirname, '../../../', 'src/libs');
+const coreModules = getDirectories(coreRoot).map((dir) => `/core/${dir}/`);
+const externalModules = getDirectories(externalRoot).map((dir) => `/${dir}/`);
+const libsModules = getDirectories(libsRoot).map((dir) => `/${dir}/`);
+
+const modulePathIdentifiers = [...coreModules, ...externalModules, ...libsModules];
 
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {

--- a/eslint-local-rules.cjs
+++ b/eslint-local-rules.cjs
@@ -10,6 +10,7 @@ const noDirectApiImportRule = require('./devops/eslint/rules/no-direct-api-impor
 const preferImportAliasesRule = require('./devops/eslint/rules/prefer-import-aliases.cjs');
 const preferStaticStylesLastRule = require('./devops/eslint/rules/prefer-static-styles-last.cjs');
 const umbClassPrefixRule = require('./devops/eslint/rules/umb-class-prefix.cjs');
+const noRelativeImportToImportMapModule = require('./devops/eslint/rules/no-relative-import-to-import-map-module.cjs');
 
 module.exports = {
 	'bad-type-import': badTypeImportRule,
@@ -22,4 +23,5 @@ module.exports = {
 	'prefer-import-aliases': preferImportAliasesRule,
 	'prefer-static-styles-last': preferStaticStylesLastRule,
 	'umb-class-prefix': umbClassPrefixRule,
+	'no-relative-import-to-import-map-module': noRelativeImportToImportMapModule,
 };

--- a/src/libs/class-api/class.interface.ts
+++ b/src/libs/class-api/class.interface.ts
@@ -3,7 +3,7 @@ import type {
 	UmbContextConsumerController,
 	UmbContextProviderController,
 	UmbContextToken,
-} from '../context-api/index.js';
+} from '@umbraco-cms/backoffice/context-api';
 import type { UmbControllerAlias, UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import type { ObserverCallback, UmbObserverController } from '@umbraco-cms/backoffice/observable-api';
 import type { Observable } from '@umbraco-cms/backoffice/external/rxjs';

--- a/src/libs/class-api/context-base.class.ts
+++ b/src/libs/class-api/context-base.class.ts
@@ -1,7 +1,7 @@
-import type { UmbContextToken } from '../context-api/index.js';
-import type { UmbControllerHost } from '../controller-api/index.js';
 import type { UmbContext } from './context.interface.js';
 import { UmbControllerBase } from './controller-base.class.js';
+import type { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
 /**
  * This base provides the necessary for a class to become a context-api controller.

--- a/src/libs/class-api/context.interface.ts
+++ b/src/libs/class-api/context.interface.ts
@@ -1,3 +1,3 @@
-import type { UmbController } from '../controller-api/controller.interface.js';
+import type { UmbController } from '@umbraco-cms/backoffice/controller-api';
 
 export interface UmbContext extends UmbController {}

--- a/src/libs/class-api/controller-base.class.ts
+++ b/src/libs/class-api/controller-base.class.ts
@@ -1,5 +1,5 @@
-import type { UmbController } from '../controller-api/controller.interface.js';
 import { UmbClassMixin } from './class.mixin.js';
+import type { UmbController } from '@umbraco-cms/backoffice/controller-api';
 import type { ClassConstructor } from '@umbraco-cms/backoffice/extension-api';
 
 /**

--- a/src/libs/controller-api/controller-host.mixin.ts
+++ b/src/libs/controller-api/controller-host.mixin.ts
@@ -1,6 +1,6 @@
-import type { ClassConstructor } from '../extension-api/types/utils.js';
 import type { UmbControllerHost } from './controller-host.interface.js';
 import type { UmbController } from './controller.interface.js';
+import type { ClassConstructor } from '@umbraco-cms/backoffice/extension-api';
 
 interface UmbControllerHostBaseDeclaration extends Omit<UmbControllerHost, 'getHostElement'> {
 	hostConnected(): void;

--- a/src/libs/element-api/element.interface.ts
+++ b/src/libs/element-api/element.interface.ts
@@ -1,4 +1,4 @@
-import type { UmbControllerHostElement } from '../controller-api/controller-host-element.interface.js';
+import type { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
 import type { UmbLocalizationController } from '@umbraco-cms/backoffice/localization-api';
 import type { UmbClassInterface } from '@umbraco-cms/backoffice/class-api';
 

--- a/src/packages/property-editors/collection/property-editor-ui-collection.element.ts
+++ b/src/packages/property-editors/collection/property-editor-ui-collection.element.ts
@@ -1,4 +1,4 @@
-import type { UmbPropertyEditorConfigCollection } from '../../core/property-editor/config/index.js';
+import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
 import { html, customElement, property, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UMB_DOCUMENT_COLLECTION_ALIAS } from '@umbraco-cms/backoffice/document';

--- a/src/packages/property-editors/date-picker/property-editor-ui-date-picker.element.ts
+++ b/src/packages/property-editors/date-picker/property-editor-ui-date-picker.element.ts
@@ -1,5 +1,5 @@
-import { UmbPropertyValueChangeEvent } from '../../core/property-editor/index.js';
-import type { UmbPropertyEditorConfigCollection } from '../../core/property-editor/index.js';
+import { UmbPropertyValueChangeEvent } from '@umbraco-cms/backoffice/property-editor';
+import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
 import { html, customElement, property, state, ifDefined } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { UmbInputDateElement } from '@umbraco-cms/backoffice/components';

--- a/src/packages/property-editors/multiple-text-string/property-editor-ui-multiple-text-string.element.ts
+++ b/src/packages/property-editors/multiple-text-string/property-editor-ui-multiple-text-string.element.ts
@@ -1,4 +1,4 @@
-import { UmbPropertyValueChangeEvent } from '../../core/property-editor/index.js';
+import { UmbPropertyValueChangeEvent } from '@umbraco-cms/backoffice/property-editor';
 import { customElement, html, property, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { UmbChangeEvent } from '@umbraco-cms/backoffice/event';

--- a/src/packages/property-editors/number-range/property-editor-ui-number-range.element.ts
+++ b/src/packages/property-editors/number-range/property-editor-ui-number-range.element.ts
@@ -1,4 +1,4 @@
-import type { UmbInputNumberRangeElement } from '../../core/components/input-number-range/input-number-range.element.js';
+import type { UmbInputNumberRangeElement } from '@umbraco-cms/backoffice/components';
 import { customElement, html, property, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
@@ -6,8 +6,6 @@ import { UmbPropertyValueChangeEvent } from '@umbraco-cms/backoffice/property-ed
 import type { UmbNumberRangeValueType } from '@umbraco-cms/backoffice/models';
 import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
 import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extension-registry';
-
-import '../../core/components/input-number-range/input-number-range.element.js';
 
 /**
  * @element umb-property-editor-ui-number-range

--- a/src/packages/property-editors/radio-button-list/property-editor-ui-radio-button-list.element.ts
+++ b/src/packages/property-editors/radio-button-list/property-editor-ui-radio-button-list.element.ts
@@ -1,11 +1,9 @@
-import type { UmbInputRadioButtonListElement } from '../../core/components/input-radio-button-list/input-radio-button-list.element.js';
+import type { UmbInputRadioButtonListElement } from '@umbraco-cms/backoffice/components';
 import { html, customElement, property, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbPropertyValueChangeEvent } from '@umbraco-cms/backoffice/property-editor';
 import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
 import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extension-registry';
-
-import '../../core/components/input-radio-button-list/input-radio-button-list.element.js';
 
 /**
  * @element umb-property-editor-ui-radio-button-list

--- a/src/packages/property-editors/slider/property-editor-ui-slider.element.ts
+++ b/src/packages/property-editors/slider/property-editor-ui-slider.element.ts
@@ -1,4 +1,4 @@
-import type { UmbInputSliderElement } from '../../core/components/input-slider/input-slider.element.js';
+import type { UmbInputSliderElement } from '@umbraco-cms/backoffice/components';
 import { customElement, html, property, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbPropertyValueChangeEvent } from '@umbraco-cms/backoffice/property-editor';

--- a/src/packages/property-editors/toggle/property-editor-ui-toggle.element.ts
+++ b/src/packages/property-editors/toggle/property-editor-ui-toggle.element.ts
@@ -1,4 +1,4 @@
-import type { UmbInputToggleElement } from '../../core/components/input-toggle/input-toggle.element.js';
+import type { UmbInputToggleElement } from '@umbraco-cms/backoffice/components';
 import { customElement, html, property, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbPropertyValueChangeEvent } from '@umbraco-cms/backoffice/property-editor';

--- a/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
+++ b/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
@@ -1,9 +1,9 @@
-import { loadManifestApi } from '../../../../libs/extension-api/functions/load-manifest-api.function.js';
 import { availableLanguages } from './input-tiny-mce.languages.js';
 import { defaultFallbackConfig } from './input-tiny-mce.defaults.js';
 import { pastePreProcessHandler } from './input-tiny-mce.handlers.js';
 import { uriAttributeSanitizer } from './input-tiny-mce.sanitizer.js';
 import type { TinyMcePluginArguments, UmbTinyMcePluginBase } from './tiny-mce-plugin.js';
+import { loadManifestApi } from '@umbraco-cms/backoffice/extension-api';
 import { css, customElement, html, property, query, state } from '@umbraco-cms/backoffice/external/lit';
 import { firstValueFrom } from '@umbraco-cms/backoffice/external/rxjs';
 import { getProcessedImageUrl } from '@umbraco-cms/backoffice/utils';

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -34,7 +34,7 @@ export default {
 			},
 		}),
 		commonjs({
-			include: ['node_modules/base64-js/**/*', 'node_modules/tinymce/**/*']
+			include: ['node_modules/base64-js/**/*', 'node_modules/tinymce/**/*'],
 		}),
 		esbuildPlugin({ ts: true, tsconfig: './tsconfig.json', target: 'auto', json: true }),
 	],
@@ -53,6 +53,9 @@ export default {
 				<link rel="stylesheet" href="src/css/user-defined.css">
 				<link rel="stylesheet" href="node_modules/@umbraco-ui/uui-css/dist/uui-css.css">
 				<link rel="stylesheet" href="src/css/umb-css.css">
+				<script type="module">
+					import '@umbraco-cms/backoffice/components';
+				</script>
 			</head>
       <body>
         <script type="module" src="${testFramework}"></script>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds an es lint rule to help us import modules with an import alias instead of a relative import. The relative import becomes problematic when we start bundling each module because then the module will include the relatively imported code instead of leaving the import as an external dependency.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
