### PR TITLE
Bugfix: Clean up event listeners when collection context is destroyed

### DIFF
--- a/src/packages/core/collection/collection.element.ts
+++ b/src/packages/core/collection/collection.element.ts
@@ -1,8 +1,8 @@
-import type { UmbCollectionConfiguration, UmbCollectionContext } from './types.js';
+import type { UmbCollectionConfiguration } from './types.js';
 import { customElement, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbExtensionElementAndApiSlotElementBase } from '@umbraco-cms/backoffice/extension-registry';
 import type { ManifestCollection } from '@umbraco-cms/backoffice/extension-registry';
-import type { UmbExtensionElementAndApiInitializer } from '@umbraco-cms/backoffice/extension-api';
+import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
 
 @customElement('umb-collection')
 export class UmbCollectionElement extends UmbExtensionElementAndApiSlotElementBase<ManifestCollection> {
@@ -24,25 +24,17 @@ export class UmbCollectionElement extends UmbExtensionElementAndApiSlotElementBa
 	}
 	#config?: UmbCollectionConfiguration;
 
+	protected apiChanged(api: UmbApi | undefined): void {
+		super.apiChanged(api);
+		this.#setConfig();
+	}
+
 	#setConfig() {
 		if (!this.#config || !this._api) return;
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
 		this._api.setConfig(this.#config);
 	}
-
-	protected extensionChanged = (
-		isPermitted: boolean,
-		controller: UmbExtensionElementAndApiInitializer<ManifestCollection>,
-	) => {
-		// TODO: [v15] Once `UmbCollectionContext` extends `UmbApi`, then we can remove this type casting. [LK]
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore
-		this._api = isPermitted ? (controller.api as unknown as UmbCollectionContext) : undefined;
-		this._element = isPermitted ? controller.component : undefined;
-		this.requestUpdate('_element');
-		this.#setConfig();
-	};
 }
 
 declare global {

--- a/src/packages/core/collection/collection.element.ts
+++ b/src/packages/core/collection/collection.element.ts
@@ -4,7 +4,8 @@ import { UmbExtensionElementAndApiSlotElementBase } from '@umbraco-cms/backoffic
 import type { ManifestCollection } from '@umbraco-cms/backoffice/extension-registry';
 import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
 
-@customElement('umb-collection')
+const elementName = 'umb-collection';
+@customElement(elementName)
 export class UmbCollectionElement extends UmbExtensionElementAndApiSlotElementBase<ManifestCollection> {
 	getExtensionType() {
 		return 'collection';
@@ -39,6 +40,6 @@ export class UmbCollectionElement extends UmbExtensionElementAndApiSlotElementBa
 
 declare global {
 	interface HTMLElementTagNameMap {
-		'umb-collection': UmbCollectionElement;
+		[elementName]: UmbCollectionElement;
 	}
 }

--- a/src/packages/core/collection/default/collection-default.context.ts
+++ b/src/packages/core/collection/default/collection-default.context.ts
@@ -152,7 +152,9 @@ export class UmbDefaultCollectionContext<
 		}
 	}
 
-	#observeRepository(repositoryAlias: string) {
+	#observeRepository(repositoryAlias?: string) {
+		if (!repositoryAlias) throw new Error('Tree must have a repository alias.');
+
 		new UmbExtensionApiInitializer<ManifestRepository<UmbCollectionRepository>>(
 			this,
 			umbExtensionsRegistry,
@@ -184,25 +186,12 @@ export class UmbDefaultCollectionContext<
 		return this.#config;
 	}
 
-	/**
-	 * Sets the manifest for the collection.
-	 * @param {ManifestCollection} manifest
-	 * @memberof UmbCollectionContext
-	 */
-	public setManifest(manifest: ManifestCollection | undefined) {
+	public set manifest(manifest: ManifestCollection | undefined) {
 		if (this.#manifest === manifest) return;
 		this.#manifest = manifest;
-
-		if (!this.#manifest) return;
-		this.#observeRepository(this.#manifest.meta.repositoryAlias);
+		this.#observeRepository(this.#manifest?.meta.repositoryAlias);
 	}
-
-	/**
-	 * Returns the manifest for the collection.
-	 * @return {ManifestCollection}
-	 * @memberof UmbCollectionContext
-	 */
-	public getManifest() {
+	public get manifest() {
 		return this.#manifest;
 	}
 
@@ -293,5 +282,29 @@ export class UmbDefaultCollectionContext<
 		);
 
 		super.destroy();
+	}
+
+	/**
+	 * Sets the manifest for the collection.
+	 * @param {ManifestCollection} manifest
+	 * @memberof UmbCollectionContext
+	 * @deprecated Use set the `.manifest` property instead.
+	 */
+	public setManifest(manifest: ManifestCollection | undefined) {
+		if (this.#manifest === manifest) return;
+		this.#manifest = manifest;
+
+		if (!this.#manifest) return;
+		this.#observeRepository(this.#manifest.meta.repositoryAlias);
+	}
+
+	/**
+	 * Returns the manifest for the collection.
+	 * @return {ManifestCollection}
+	 * @memberof UmbCollectionContext
+	 * @deprecated Use get the `.manifest` property instead.
+	 */
+	public getManifest() {
+		return this.#manifest;
 	}
 }

--- a/src/packages/core/extension-registry/collection/repository/extension-collection.repository.ts
+++ b/src/packages/core/extension-registry/collection/repository/extension-collection.repository.ts
@@ -43,8 +43,6 @@ export class UmbExtensionCollectionRepository
 		const data = { items, total };
 		return { data };
 	}
-
-	destroy(): void {}
 }
 
 export { UmbExtensionCollectionRepository as api };

--- a/src/packages/core/extension-registry/extension-element-and-api-slot-element-base.ts
+++ b/src/packages/core/extension-registry/extension-element-and-api-slot-element-base.ts
@@ -52,21 +52,44 @@ export abstract class UmbExtensionElementAndApiSlotElementBase<
 			umbExtensionsRegistry,
 			this._alias,
 			[this],
-			this.extensionChanged,
+			this.#extensionChanged,
 			this.getDefaultElementName(),
 		);
 		this.#extensionController.elementProps = this.#props;
 	}
 
-	protected extensionChanged = (
-		isPermitted: boolean,
-		controller: UmbExtensionElementAndApiInitializer<ManifestType>,
-	) => {
-		this._api = isPermitted ? controller.api : undefined;
-		this._element = isPermitted ? controller.component : undefined;
-		this.requestUpdate('_element');
+	#extensionChanged = (isPermitted: boolean, controller: UmbExtensionElementAndApiInitializer<ManifestType>) => {
+		this.apiChanged(isPermitted ? controller.api : undefined);
+		this.elementChanged(isPermitted ? controller.component : undefined);
 	};
 
+	/**
+	 * Called when the API is changed.
+	 * @protected
+	 * @param {(ManifestType['API_TYPE'] | undefined)} api
+	 * @memberof UmbExtensionElementAndApiSlotElementBase
+	 */
+	protected apiChanged(api: ManifestType['API_TYPE'] | undefined) {
+		this._api = api;
+	}
+
+	/**
+	 * Called when the element is changed.
+	 * @protected
+	 * @param {(ManifestType['ELEMENT_TYPE'] | undefined)} element
+	 * @memberof UmbExtensionElementAndApiSlotElementBase
+	 */
+	protected elementChanged(element: ManifestType['ELEMENT_TYPE'] | undefined) {
+		this._element = element;
+		this.requestUpdate('_element');
+	}
+
+	/**
+	 * Render the element.
+	 * @protected
+	 * @return {*}
+	 * @memberof UmbExtensionElementAndApiSlotElementBase
+	 */
 	protected render() {
 		return this._element;
 	}

--- a/src/packages/core/extension-registry/extension-element-and-api-slot-element-base.ts
+++ b/src/packages/core/extension-registry/extension-element-and-api-slot-element-base.ts
@@ -36,6 +36,9 @@ export abstract class UmbExtensionElementAndApiSlotElementBase<
 	#extensionController?: UmbExtensionElementAndApiInitializer<ManifestType>;
 
 	@state()
+	_api: ManifestType['API_TYPE'] | undefined;
+
+	@state()
 	_element: ManifestType['ELEMENT_TYPE'] | undefined;
 
 	abstract getExtensionType(): string;
@@ -49,13 +52,17 @@ export abstract class UmbExtensionElementAndApiSlotElementBase<
 			umbExtensionsRegistry,
 			this._alias,
 			[this],
-			this.#extensionChanged,
+			this.extensionChanged,
 			this.getDefaultElementName(),
 		);
 		this.#extensionController.elementProps = this.#props;
 	}
 
-	#extensionChanged = (isPermitted: boolean, controller: UmbExtensionElementAndApiInitializer<ManifestType>) => {
+	protected extensionChanged = (
+		isPermitted: boolean,
+		controller: UmbExtensionElementAndApiInitializer<ManifestType>,
+	) => {
+		this._api = isPermitted ? controller.api : undefined;
 		this._element = isPermitted ? controller.component : undefined;
 		this.requestUpdate('_element');
 	};

--- a/src/packages/data-type/collection/repository/data-type-collection.repository.ts
+++ b/src/packages/data-type/collection/repository/data-type-collection.repository.ts
@@ -37,8 +37,6 @@ export class UmbDataTypeCollectionRepository extends UmbRepositoryBase implement
 
 		return { data, error, asObservable: () => this.#itemStore!.items(uniques) };
 	}
-
-	destroy(): void {}
 }
 
 export default UmbDataTypeCollectionRepository;

--- a/src/packages/dictionary/collection/repository/dictionary-collection.repository.ts
+++ b/src/packages/dictionary/collection/repository/dictionary-collection.repository.ts
@@ -1,21 +1,21 @@
 import type { UmbDictionaryCollectionFilterModel } from '../types.js';
 import { UmbDictionaryCollectionServerDataSource } from './dictionary-collection.server.data-source.js';
 import type { UmbDictionaryCollectionDataSource } from './types.js';
+import { UmbRepositoryBase } from '@umbraco-cms/backoffice/repository';
 import type { UmbCollectionRepository } from '@umbraco-cms/backoffice/collection';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
-export class UmbDictionaryCollectionRepository implements UmbCollectionRepository {
+export class UmbDictionaryCollectionRepository extends UmbRepositoryBase implements UmbCollectionRepository {
 	#collectionSource: UmbDictionaryCollectionDataSource;
 
 	constructor(host: UmbControllerHost) {
+		super(host);
 		this.#collectionSource = new UmbDictionaryCollectionServerDataSource(host);
 	}
 
 	async requestCollection(filter: UmbDictionaryCollectionFilterModel) {
 		return this.#collectionSource.getCollection(filter);
 	}
-
-	destroy(): void {}
 }
 
 export default UmbDictionaryCollectionRepository;

--- a/src/packages/documents/documents/collection/repository/document-collection.repository.ts
+++ b/src/packages/documents/documents/collection/repository/document-collection.repository.ts
@@ -16,8 +16,6 @@ export class UmbDocumentCollectionRepository extends UmbRepositoryBase implement
 	async requestCollection(query: UmbDocumentCollectionFilterModel) {
 		return this.#collectionSource.getCollection(query);
 	}
-
-	destroy(): void {}
 }
 
 export default UmbDocumentCollectionRepository;

--- a/src/packages/language/collection/repository/language-collection.repository.ts
+++ b/src/packages/language/collection/repository/language-collection.repository.ts
@@ -1,21 +1,21 @@
 import type { UmbLanguageCollectionFilterModel } from '../types.js';
 import { UmbLanguageCollectionServerDataSource } from './language-collection.server.data-source.js';
 import type { UmbLanguageCollectionDataSource } from './types.js';
+import { UmbRepositoryBase } from '@umbraco-cms/backoffice/repository';
 import type { UmbCollectionRepository } from '@umbraco-cms/backoffice/collection';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
-export class UmbLanguageCollectionRepository implements UmbCollectionRepository {
+export class UmbLanguageCollectionRepository extends UmbRepositoryBase implements UmbCollectionRepository {
 	#collectionSource: UmbLanguageCollectionDataSource;
 
 	constructor(host: UmbControllerHost) {
+		super(host);
 		this.#collectionSource = new UmbLanguageCollectionServerDataSource(host);
 	}
 
 	async requestCollection(filter: UmbLanguageCollectionFilterModel) {
 		return this.#collectionSource.getCollection(filter);
 	}
-
-	destroy(): void {}
 }
 
 export default UmbLanguageCollectionRepository;

--- a/src/packages/media/media/collection/repository/media-collection.repository.ts
+++ b/src/packages/media/media/collection/repository/media-collection.repository.ts
@@ -23,8 +23,6 @@ export class UmbMediaCollectionRepository extends UmbRepositoryBase implements U
 	async requestCollection(query: UmbMediaCollectionFilterModel) {
 		return this.#collectionSource.getCollection(query);
 	}
-
-	destroy(): void {}
 }
 
 export default UmbMediaCollectionRepository;

--- a/src/packages/members/member-group/collection/repository/member-group-collection.repository.ts
+++ b/src/packages/members/member-group/collection/repository/member-group-collection.repository.ts
@@ -1,21 +1,21 @@
 import type { UmbMemberGroupCollectionFilterModel } from '../types.js';
 import { UmbMemberGroupCollectionServerDataSource } from './member-group-collection.server.data-source.js';
 import type { UmbMemberGroupCollectionDataSource } from './types.js';
+import { UmbRepositoryBase } from '@umbraco-cms/backoffice/repository';
 import type { UmbCollectionRepository } from '@umbraco-cms/backoffice/collection';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
-export class UmbMemberGroupCollectionRepository implements UmbCollectionRepository {
+export class UmbMemberGroupCollectionRepository extends UmbRepositoryBase implements UmbCollectionRepository {
 	#collectionSource: UmbMemberGroupCollectionDataSource;
 
 	constructor(host: UmbControllerHost) {
+		super(host);
 		this.#collectionSource = new UmbMemberGroupCollectionServerDataSource(host);
 	}
 
 	async requestCollection(filter: UmbMemberGroupCollectionFilterModel) {
 		return this.#collectionSource.getCollection(filter);
 	}
-
-	destroy(): void {}
 }
 
 export default UmbMemberGroupCollectionRepository;

--- a/src/packages/relations/relation-types/collection/repository/relation-type-collection.repository.ts
+++ b/src/packages/relations/relation-types/collection/repository/relation-type-collection.repository.ts
@@ -1,21 +1,21 @@
 import type { UmbRelationTypeCollectionFilterModel } from '../types.js';
 import { UmbRelationTypeCollectionServerDataSource } from './relation-type-collection.server.data-source.js';
 import type { UmbRelationTypeCollectionDataSource } from './types.js';
+import { UmbRepositoryBase } from '@umbraco-cms/backoffice/repository';
 import type { UmbCollectionRepository } from '@umbraco-cms/backoffice/collection';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
-export class UmbRelationTypeCollectionRepository implements UmbCollectionRepository {
+export class UmbRelationTypeCollectionRepository extends UmbRepositoryBase implements UmbCollectionRepository {
 	#collectionSource: UmbRelationTypeCollectionDataSource;
 
 	constructor(host: UmbControllerHost) {
+		super(host);
 		this.#collectionSource = new UmbRelationTypeCollectionServerDataSource(host);
 	}
 
 	async requestCollection(filter: UmbRelationTypeCollectionFilterModel) {
 		return this.#collectionSource.getCollection(filter);
 	}
-
-	destroy(): void {}
 }
 
 export default UmbRelationTypeCollectionRepository;

--- a/src/packages/relations/relations/collection/repository/relation-collection.repository.ts
+++ b/src/packages/relations/relations/collection/repository/relation-collection.repository.ts
@@ -1,21 +1,21 @@
 import type { UmbRelationCollectionFilterModel } from '../types.js';
 import { UmbRelationCollectionServerDataSource } from './relation-collection.server.data-source.js';
 import type { UmbRelationCollectionDataSource } from './types.js';
+import { UmbRepositoryBase } from '@umbraco-cms/backoffice/repository';
 import type { UmbCollectionRepository } from '@umbraco-cms/backoffice/collection';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
-export class UmbRelationCollectionRepository implements UmbCollectionRepository {
+export class UmbRelationCollectionRepository extends UmbRepositoryBase implements UmbCollectionRepository {
 	#collectionSource: UmbRelationCollectionDataSource;
 
 	constructor(host: UmbControllerHost) {
+		super(host);
 		this.#collectionSource = new UmbRelationCollectionServerDataSource(host);
 	}
 
 	async requestCollection(filter: UmbRelationCollectionFilterModel) {
 		return this.#collectionSource.getCollection(filter);
 	}
-
-	destroy(): void {}
 }
 
 export default UmbRelationCollectionRepository;

--- a/src/packages/webhook/collection/repository/webhook-collection.repository.ts
+++ b/src/packages/webhook/collection/repository/webhook-collection.repository.ts
@@ -1,21 +1,21 @@
 import type { UmbWebhookCollectionFilterModel } from '../types.js';
 import { UmbWebhookCollectionServerDataSource } from './webhook-collection.server.data-source.js';
 import type { UmbWebhookCollectionDataSource } from './types.js';
+import { UmbRepositoryBase } from '@umbraco-cms/backoffice/repository';
 import type { UmbCollectionRepository } from '@umbraco-cms/backoffice/collection';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
-export class UmbWebhookCollectionRepository implements UmbCollectionRepository {
+export class UmbWebhookCollectionRepository extends UmbRepositoryBase implements UmbCollectionRepository {
 	#collectionSource: UmbWebhookCollectionDataSource;
 
 	constructor(host: UmbControllerHost) {
+		super(host);
 		this.#collectionSource = new UmbWebhookCollectionServerDataSource(host);
 	}
 
 	async requestCollection(filter: UmbWebhookCollectionFilterModel) {
 		return this.#collectionSource.getCollection(filter);
 	}
-
-	destroy(): void {}
 }
 
 export default UmbWebhookCollectionRepository;


### PR DESCRIPTION
## Description

Refactored `UmbCollectionElement` to reuse `UmbExtensionElementAndApiSlotElementBase`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)