### PR TITLE
Fix: Block Grid Editor - Adjust columnSpan to context

### DIFF
--- a/src/packages/block/block-grid/context/block-grid-entry.context.ts
+++ b/src/packages/block/block-grid/context/block-grid-entry.context.ts
@@ -206,9 +206,9 @@ export class UmbBlockGridEntryContext
 
 		// Secure columnSpan fits options:
 		this.observe(
-			observeMultiple([this.layout, this.columnSpan, this.relevantColumnSpanOptions, this._entries.layoutColumns]),
-			([layout, columnSpan, relevantColumnSpanOptions, layoutColumns]) => {
-				if (!layout || !layoutColumns) return;
+			observeMultiple([this.columnSpan, this.relevantColumnSpanOptions, this._entries.layoutColumns]),
+			([columnSpan, relevantColumnSpanOptions, layoutColumns]) => {
+				if (!layoutColumns) return;
 				const newColumnSpan = this.#calcColumnSpan(
 					columnSpan ?? layoutColumns,
 					relevantColumnSpanOptions,

--- a/src/packages/block/block/context/block-entry.context.ts
+++ b/src/packages/block/block/context/block-entry.context.ts
@@ -146,15 +146,15 @@ export abstract class UmbBlockEntryContext<
 		// Consume block manager:
 		this.consumeContext(blockManagerContextToken, (manager) => {
 			this._manager = manager;
-			this.#gotManager();
 			this._gotManager();
+			this.#gotManager();
 		});
 
 		// Consume block entries:
 		this.consumeContext(blockEntriesContextToken, (entries) => {
 			this._entries = entries;
-			this.#gotEntries();
 			this._gotEntries();
+			this.#gotEntries();
 		});
 
 		// Observe UDI:


### PR DESCRIPTION
This was slightly broken as the adjustment was corrected before the right data was available.

So before, if you had a two column layout block (Two areas of 6 columns)
And a Simple Block than can span 3 and 6 columns, then putting it in the left area, scaling it to 3 columns. and then moving it to the other areas. Would result in it scaling up to 6 columns. where keeping the 3 columns was the expected outcome.

This pr fixes that.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
