### PR TITLE
The document `Custom` status is not translated correctly

### DIFF
--- a/devops/localization/unused-language-keys.js
+++ b/devops/localization/unused-language-keys.js
@@ -26,7 +26,7 @@ const mainMap = buildMap(mainKeys);
 const keys = Array.from(mainMap.keys());
 const usedKeys = new Set();
 
-const elementAndControllerFiles = await glob(`${__dirname}/../../src/**/*.ts`);
+const elementAndControllerFiles = await glob(`${__dirname}/../../src/**/*.ts`, { filesOnly: true });
 
 console.log(`Checking ${elementAndControllerFiles.length} files for unused keys`);
 

--- a/src/packages/documents/documents/workspace/views/info/utils.ts
+++ b/src/packages/documents/documents/workspace/views/info/utils.ts
@@ -127,7 +127,7 @@ export function getDocumentHistoryTagStyleAndText(type: UmbDocumentAuditLogType)
 		case UmbDocumentAuditLog.CUSTOM:
 			return {
 				style: { look: 'placeholder', color: 'default' },
-				text: { label: 'auditTrails_custom', desc: '' },
+				text: { label: 'auditTrails_smallCustom', desc: 'auditTrails_custom' },
 			};
 
 		default:


### PR DESCRIPTION
## Description

Adds missing localization variable for the "Custom" status and improves the Node.js devops script to find unused keys.