### PR TITLE
V14/bugfix/bad slider configuration

### DIFF
--- a/src/packages/property-editors/slider/Umbraco.Slider.ts
+++ b/src/packages/property-editors/slider/Umbraco.Slider.ts
@@ -24,7 +24,6 @@ export const manifest: ManifestPropertyEditorSchema = {
 			defaultData: [
 				{ alias: 'minVal', value: 0 },
 				{ alias: 'maxVal', value: 100 },
-				{ alias: 'step', value: 1 },
 			],
 		},
 	},

--- a/src/packages/property-editors/slider/Umbraco.Slider.ts
+++ b/src/packages/property-editors/slider/Umbraco.Slider.ts
@@ -23,7 +23,8 @@ export const manifest: ManifestPropertyEditorSchema = {
 			],
 			defaultData: [
 				{ alias: 'minVal', value: 0 },
-				{ alias: 'maxVal', value: 0 },
+				{ alias: 'maxVal', value: 100 },
+				{ alias: 'step', value: 1 },
 			],
 		},
 	},

--- a/src/packages/property-editors/slider/manifests.ts
+++ b/src/packages/property-editors/slider/manifests.ts
@@ -50,7 +50,7 @@ export const manifests: Array<ManifestTypes> = [
 					},
 					{
 						alias: 'step',
-						value: 0,
+						value: 1,
 					},
 				],
 			},

--- a/src/packages/property-editors/slider/property-editor-ui-slider.element.ts
+++ b/src/packages/property-editors/slider/property-editor-ui-slider.element.ts
@@ -19,10 +19,10 @@ export class UmbPropertyEditorUISliderElement extends UmbLitElement implements U
 	_enableRange = false;
 
 	@state()
-	_initVal1?: number;
+	_initVal1: number = 0;
 
 	@state()
-	_initVal2?: number;
+	_initVal2: number = 1;
 
 	@state()
 	_step = 1;
@@ -37,21 +37,23 @@ export class UmbPropertyEditorUISliderElement extends UmbLitElement implements U
 		if (!config) return;
 
 		this._enableRange = Boolean(config.getValueByAlias('enableRange')) ?? false;
-		this._initVal1 = Number(config.getValueByAlias('initVal1'));
-		this._initVal2 = Number(config.getValueByAlias('initVal2'));
 
-		// Make sure that step is higher than 0.
+		// Make sure that step is higher than 0 (decimals ok).
 		const step = (config.getValueByAlias('step') ?? 1) as number;
 		this._step = step > 0 ? step : 1;
+
+		this._initVal1 = Number(config.getValueByAlias('initVal1')) ?? 0;
+		this._initVal2 = Number(config.getValueByAlias('initVal2')) ?? this._initVal1 + this._step;
 
 		this._min = Number(config.getValueByAlias('minVal')) ?? 0;
 		this._max = Number(config.getValueByAlias('maxVal')) ?? 100;
 
 		if (this._min === this._max) {
-			// Why is the configuration giving us a 0 as default, rather than just undefined..?
-
-			console.log(this._min, this._max, this._step, this._initVal1, this._initVal2);
-			throw new Error('Property Editor Slider: min and max are currently equal. Please change your configuration.');
+			this._max = this._min + 100;
+			//TODO Maybe we want to show some kind of error element rather than trying to fix the mistake made by the user...?
+			throw new Error(
+				`Property Editor Slider: min and max are currently equal. Please change your data type configuration. To render the slider correctly, we changed this slider to: min = ${this._min}, max = ${this._max}`,
+			);
 		}
 	}
 
@@ -68,8 +70,8 @@ export class UmbPropertyEditorUISliderElement extends UmbLitElement implements U
 	render() {
 		return html`
 			<umb-input-slider
-				.valueLow=${this.value?.from ?? this._initVal1 ?? 0}
-				.valueHigh=${this.value?.to ?? this._initVal2 ?? this._step}
+				.valueLow=${this.value?.from ?? this._initVal1}
+				.valueHigh=${this.value?.to ?? this._initVal2}
 				.step=${this._step}
 				.min=${this._min}
 				.max=${this._max}

--- a/src/packages/property-editors/slider/property-editor-ui-slider.element.ts
+++ b/src/packages/property-editors/slider/property-editor-ui-slider.element.ts
@@ -5,13 +5,15 @@ import { UmbPropertyValueChangeEvent } from '@umbraco-cms/backoffice/property-ed
 import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
 import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extension-registry';
 
+export type UmbSliderValue = { from: number; to: number } | undefined;
+
 /**
  * @element umb-property-editor-ui-slider
  */
 @customElement('umb-property-editor-ui-slider')
 export class UmbPropertyEditorUISliderElement extends UmbLitElement implements UmbPropertyEditorUiElement {
 	@property({ type: Object })
-	value: { to?: number; from?: number } | undefined = undefined;
+	value: UmbSliderValue | undefined;
 
 	@state()
 	_enableRange = false;
@@ -37,9 +39,20 @@ export class UmbPropertyEditorUISliderElement extends UmbLitElement implements U
 		this._enableRange = Boolean(config.getValueByAlias('enableRange')) ?? false;
 		this._initVal1 = Number(config.getValueByAlias('initVal1'));
 		this._initVal2 = Number(config.getValueByAlias('initVal2'));
-		this._step = Number(config.getValueByAlias('step')) ?? 1;
+
+		// Make sure that step is higher than 0.
+		const step = (config.getValueByAlias('step') ?? 1) as number;
+		this._step = step > 0 ? step : 1;
+
 		this._min = Number(config.getValueByAlias('minVal')) ?? 0;
 		this._max = Number(config.getValueByAlias('maxVal')) ?? 100;
+
+		if (this._min === this._max) {
+			// Why is the configuration giving us a 0 as default, rather than just undefined..?
+
+			console.log(this._min, this._max, this._step, this._initVal1, this._initVal2);
+			throw new Error('Property Editor Slider: min and max are currently equal. Please change your configuration.');
+		}
 	}
 
 	#getValueObject(value: string) {
@@ -56,7 +69,7 @@ export class UmbPropertyEditorUISliderElement extends UmbLitElement implements U
 		return html`
 			<umb-input-slider
 				.valueLow=${this.value?.from ?? this._initVal1 ?? 0}
-				.valueHigh=${this.value?.to ?? this._initVal2 ?? 0}
+				.valueHigh=${this.value?.to ?? this._initVal2 ?? this._step}
 				.step=${this._step}
 				.min=${this._min}
 				.max=${this._max}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Fixed render slider bugs when bad configuration
- Added default values to the datatype slider

Fixes the frontend part of https://github.com/umbraco/Umbraco-CMS/issues/16437
Perhaps backend needs some logic to make sure the configuration isn't bad.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

