### PR TITLE
Bugfix: Document Type Workspace, localizes the name and alias input placeholders

### DIFF
--- a/src/packages/core/components/input-with-alias/input-with-alias.element.ts
+++ b/src/packages/core/components/input-with-alias/input-with-alias.element.ts
@@ -6,7 +6,7 @@ import { type UUIInputElement, UUIInputEvent } from '@umbraco-cms/backoffice/ext
 import { generateAlias } from '@umbraco-cms/backoffice/utils';
 
 @customElement('umb-input-with-alias')
-export class UmbInputWithAliasElement extends UmbFormControlMixin<string>(UmbLitElement) {
+export class UmbInputWithAliasElement extends UmbFormControlMixin<string, typeof UmbLitElement>(UmbLitElement) {
 	@property({ type: String })
 	label: string = '';
 
@@ -68,9 +68,13 @@ export class UmbInputWithAliasElement extends UmbFormControlMixin<string>(UmbLit
 	}
 
 	render() {
-		// Localizations: [NL]
 		return html`
-			<uui-input id="name" placeholder="Enter a name..." label=${this.label} .value=${this.value} @input="${this.#onNameChange}">
+			<uui-input
+				id="name"
+				placeholder=${this.localize.term('placeholders_entername')}
+				label=${this.label}
+				.value=${this.value}
+				@input=${this.#onNameChange}>
 				<!-- TODO: should use UUI-LOCK-INPUT, but that does not fire an event when its locked/unlocked -->
 				<uui-input
 					name="alias"
@@ -78,7 +82,7 @@ export class UmbInputWithAliasElement extends UmbFormControlMixin<string>(UmbLit
 					label="alias"
 					@input=${this.#onAliasChange}
 					.value=${this.alias}
-					placeholder="Enter alias..."
+					placeholder=${this.localize.term('placeholders_enterAlias')}
 					?disabled=${this._aliasLocked && !this.aliasReadonly}
 					?readonly=${this.aliasReadonly}>
 					<!-- TODO: validation for bad characters -->

--- a/src/packages/core/components/input-with-alias/input-with-alias.element.ts
+++ b/src/packages/core/components/input-with-alias/input-with-alias.element.ts
@@ -68,13 +68,14 @@ export class UmbInputWithAliasElement extends UmbFormControlMixin<string, typeof
 	}
 
 	render() {
+		const nameLabel = this.label ?? this.localize.term('placeholders_entername');
 		const aliasLabel = this.localize.term('placeholders_enterAlias');
 
 		return html`
 			<uui-input
 				id="name"
-				placeholder=${this.localize.term('placeholders_entername')}
-				label=${this.label}
+				placeholder=${nameLabel}
+				label=${nameLabel}
 				.value=${this.value}
 				@input=${this.#onNameChange}>
 				<!-- TODO: should use UUI-LOCK-INPUT, but that does not fire an event when its locked/unlocked -->

--- a/src/packages/core/components/input-with-alias/input-with-alias.element.ts
+++ b/src/packages/core/components/input-with-alias/input-with-alias.element.ts
@@ -68,6 +68,8 @@ export class UmbInputWithAliasElement extends UmbFormControlMixin<string, typeof
 	}
 
 	render() {
+		const aliasLabel = this.localize.term('placeholders_enterAlias');
+
 		return html`
 			<uui-input
 				id="name"
@@ -79,10 +81,10 @@ export class UmbInputWithAliasElement extends UmbFormControlMixin<string, typeof
 				<uui-input
 					name="alias"
 					slot="append"
-					label="alias"
+					label=${aliasLabel}
 					@input=${this.#onAliasChange}
 					.value=${this.alias}
-					placeholder=${this.localize.term('placeholders_enterAlias')}
+					placeholder=${aliasLabel}
 					?disabled=${this._aliasLocked && !this.aliasReadonly}
 					?readonly=${this.aliasReadonly}>
 					<!-- TODO: validation for bad characters -->

--- a/src/packages/documents/document-types/workspace/document-type-workspace-editor.element.ts
+++ b/src/packages/documents/document-types/workspace/document-type-workspace-editor.element.ts
@@ -85,7 +85,7 @@ export class UmbDocumentTypeWorkspaceEditorElement extends UmbLitElement {
 					<div id="editors">
 						<umb-input-with-alias
 							id="name"
-							label="name"
+							label=${this.localize.term('placeholders_entername')}
 							value=${this._name}
 							alias=${this._alias}
 							?auto-generate-alias=${this._isNew}

--- a/src/packages/media/media-types/workspace/media-type-workspace-editor.element.ts
+++ b/src/packages/media/media-types/workspace/media-type-workspace-editor.element.ts
@@ -89,7 +89,7 @@ export class UmbMediaTypeWorkspaceEditorElement extends UmbLitElement {
 				<div id="editors">
 					<umb-input-with-alias
 						id="name"
-						label="name"
+						label=${this.localize.term('placeholders_entername')}
 						value=${this._name}
 						alias=${this._alias}
 						?auto-generate-alias=${this._isNew}

--- a/src/packages/members/member-type/workspace/member-type-workspace-editor.element.ts
+++ b/src/packages/members/member-type/workspace/member-type-workspace-editor.element.ts
@@ -89,7 +89,7 @@ export class UmbMemberTypeWorkspaceEditorElement extends UmbLitElement {
 					<div id="editors">
 						<umb-input-with-alias
 							id="name"
-							label="name"
+							label=${this.localize.term('placeholders_entername')}
 							value=${this._name}
 							alias=${this._alias}
 							?auto-generate-alias=${this._isNew}

--- a/src/packages/user/user-group/workspace/user-group-workspace-editor.element.ts
+++ b/src/packages/user/user-group/workspace/user-group-workspace-editor.element.ts
@@ -216,7 +216,7 @@ export class UmbUserGroupWorkspaceEditorElement extends UmbLitElement {
 
 				<umb-input-with-alias
 					id="name"
-					label=${this.localize.term('general_name')}
+					label=${this.localize.term('placeholders_entername')}
 					.value=${this._name}
 					alias=${ifDefined(this._alias)}
 					?auto-generate-alias=${this._isNew}


### PR DESCRIPTION
## Description

In the Document Type Workspace, the "Enter a name..." and "Enter an alias..." placeholder labels for the inputs were hardcoded to English. This PR updates with the localization keys.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
