### PR TITLE
Bugfix: Media workspace info references correct localization

### DIFF
--- a/src/packages/media/media/workspace/views/info/media-workspace-view-info-reference.element.ts
+++ b/src/packages/media/media/workspace/views/info/media-workspace-view-info-reference.element.ts
@@ -135,7 +135,7 @@ export class UmbMediaWorkspaceViewInfoReferenceElement extends UmbLitElement {
 	}
 
 	#renderItems() {
-		if (!this._items?.length) return html`<p>${this.localize.term('references_DataTypeNoReferences')}</p>`;
+		if (!this._items?.length) return html`<p>${this.localize.term('references_itemHasNoReferences')}</p>`;
 		return html`
 			<uui-table>
 				<uui-table-head>

--- a/src/packages/media/media/workspace/views/info/media-workspace-view-info-reference.element.ts
+++ b/src/packages/media/media/workspace/views/info/media-workspace-view-info-reference.element.ts
@@ -135,7 +135,7 @@ export class UmbMediaWorkspaceViewInfoReferenceElement extends UmbLitElement {
 	}
 
 	#renderItems() {
-		if (!this._items?.length) return html`<p>${this.localize.term('references_itemHasNoReferences')}</p>`;
+		if (!this._items?.length) return html`<p><umb-localize key="references_itemHasNoReferences">This item has no references.</umb-localize></p>`;
 		return html`
 			<uui-table>
 				<uui-table-head>


### PR DESCRIPTION
## Description

When a Media item hasn't been references elsewhere, the text in the workspace info references panel displayed `"This Data Type has no references."`, as it was using the incorrect localization key. This PR corrects the localization key.

Fixes https://github.com/umbraco/Umbraco-CMS/issues/16485

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
