### PR TITLE
Bugfix: Property description, sets `max-width` for child items

### DIFF
--- a/src/packages/core/property/property-layout/property-layout.element.ts
+++ b/src/packages/core/property/property-layout/property-layout.element.ts
@@ -130,6 +130,10 @@ export class UmbPropertyLayoutElement extends UmbLitElement {
 				color: var(--uui-color-text-alt);
 			}
 
+			#description * {
+				max-width: 100%;
+			}
+
 			#editorColumn {
 				margin-top: var(--uui-size-space-3);
 			}


### PR DESCRIPTION
## Description

In a property description, when an `<img>` tag is rendered (from Markdown syntax), if the width was wider than the overflow, it would be cut off.  This PR adds a style rule to set the `max-width: 100%` for any child elements.

![Screenshot 2024-05-30 105537](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/209066/ab4e2749-d456-4073-916e-52f922bdbb7f)

This is a partial fix for https://github.com/umbraco/Umbraco-CMS/issues/16499.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
