### PR TITLE
Bugfix: Content Type workspace header UI cosmetics

### DIFF
--- a/src/packages/core/components/input-with-alias/input-with-alias.element.ts
+++ b/src/packages/core/components/input-with-alias/input-with-alias.element.ts
@@ -31,36 +31,37 @@ export class UmbInputWithAliasElement extends UmbFormControlMixin<string, typeof
 	}
 
 	#onNameChange(e: UUIInputEvent) {
-		if (e instanceof UUIInputEvent) {
-			const target = e.composedPath()[0] as UUIInputElement;
+		if (!(e instanceof UUIInputEvent)) return;
 
-			if (typeof target?.value === 'string') {
-				const oldName = this.value;
-				const oldAlias = this.alias ?? '';
-				this.value = e.target.value.toString();
-				if (this.autoGenerateAlias && this._aliasLocked) {
-					// If locked we will update the alias, but only if it matches the generated alias of the old name [NL]
-					const expectedOldAlias = generateAlias(oldName ?? '');
-					// Only update the alias if the alias matches a generated alias of the old name (otherwise the alias is considered one written by the user.) [NL]
-					if (expectedOldAlias === oldAlias) {
-						this.alias = generateAlias(this.value);
-					}
+		const target = e.composedPath()[0] as UUIInputElement;
+
+		if (typeof target?.value === 'string') {
+			const oldName = this.value;
+			const oldAlias = this.alias ?? '';
+			this.value = e.target.value.toString();
+			if (this.autoGenerateAlias && this._aliasLocked) {
+				// If locked we will update the alias, but only if it matches the generated alias of the old name [NL]
+				const expectedOldAlias = generateAlias(oldName ?? '');
+				// Only update the alias if the alias matches a generated alias of the old name (otherwise the alias is considered one written by the user.) [NL]
+				if (expectedOldAlias === oldAlias) {
+					this.alias = generateAlias(this.value);
 				}
-				this.dispatchEvent(new UmbChangeEvent());
 			}
+
+			this.dispatchEvent(new UmbChangeEvent());
 		}
 	}
 
 	#onAliasChange(e: UUIInputEvent) {
-		if (e instanceof UUIInputEvent) {
-			const target = e.composedPath()[0] as UUIInputElement;
-			if (typeof target?.value === 'string') {
-				this.alias = target.value;
-				console.log(this.alias);
-				this.dispatchEvent(new UmbChangeEvent());
-			}
-		}
 		e.stopPropagation();
+		if (!(e instanceof UUIInputEvent)) return;
+
+		const target = e.composedPath()[0] as UUIInputElement;
+
+		if (typeof target?.value === 'string') {
+			this.alias = target.value;
+			this.dispatchEvent(new UmbChangeEvent());
+		}
 	}
 
 	#onToggleAliasLock() {
@@ -80,20 +81,23 @@ export class UmbInputWithAliasElement extends UmbFormControlMixin<string, typeof
 				@input=${this.#onNameChange}>
 				<!-- TODO: should use UUI-LOCK-INPUT, but that does not fire an event when its locked/unlocked -->
 				<uui-input
+					auto-width
 					name="alias"
 					slot="append"
 					label=${aliasLabel}
-					@input=${this.#onAliasChange}
 					.value=${this.alias}
 					placeholder=${aliasLabel}
 					?disabled=${this._aliasLocked && !this.aliasReadonly}
-					?readonly=${this.aliasReadonly}>
+					?readonly=${this.aliasReadonly}
+					@input=${this.#onAliasChange}>
 					<!-- TODO: validation for bad characters -->
 					${this.aliasReadonly
 						? nothing
-						: html`<div @click=${this.#onToggleAliasLock} @keydown=${() => ''} id="alias-lock" slot="prepend">
-								<uui-icon name=${this._aliasLocked ? 'icon-lock' : 'icon-unlocked'}></uui-icon>
-							</div>`}
+						: html`
+								<div @click=${this.#onToggleAliasLock} @keydown=${() => ''} id="alias-lock" slot="prepend">
+									<uui-icon name=${this._aliasLocked ? 'icon-lock' : 'icon-unlocked'}></uui-icon>
+								</div>
+							`}
 				</uui-input>
 			</uui-input>
 		`;
@@ -104,6 +108,10 @@ export class UmbInputWithAliasElement extends UmbFormControlMixin<string, typeof
 			width: 100%;
 			flex: 1 1 auto;
 			align-items: center;
+		}
+
+		#name > uui-input {
+			max-width: 50%;
 		}
 
 		:host(:invalid:not([pristine])) {

--- a/src/packages/core/content-type/workspace/views/design/content-type-design-editor-properties.element.ts
+++ b/src/packages/core/content-type/workspace/views/design/content-type-design-editor-properties.element.ts
@@ -1,17 +1,27 @@
-import './content-type-design-editor-property.element.js';
 import { UMB_CONTENT_TYPE_WORKSPACE_CONTEXT } from '../../content-type-workspace.context-token.js';
-import type { UmbContentTypeDesignEditorPropertyElement } from './content-type-design-editor-property.element.js';
 import { UMB_CONTENT_TYPE_DESIGN_EDITOR_CONTEXT } from './content-type-design-editor.context.js';
+import type { UmbContentTypeDesignEditorPropertyElement } from './content-type-design-editor-property.element.js';
+import {
+	css,
+	customElement,
+	html,
+	ifDefined,
+	property,
+	repeat,
+	state,
+	when,
+} from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import { css, html, customElement, property, state, repeat, ifDefined } from '@umbraco-cms/backoffice/external/lit';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
-import type { UmbContentTypeModel, UmbPropertyTypeModel } from '@umbraco-cms/backoffice/content-type';
 import {
 	UmbContentTypePropertyStructureHelper,
 	UMB_PROPERTY_TYPE_SETTINGS_MODAL,
 } from '@umbraco-cms/backoffice/content-type';
+import type { UmbContentTypeModel, UmbPropertyTypeModel } from '@umbraco-cms/backoffice/content-type';
 import { type UmbSorterConfig, UmbSorterController } from '@umbraco-cms/backoffice/sorter';
 import { type UmbModalRouteBuilder, UmbModalRouteRegistrationController } from '@umbraco-cms/backoffice/router';
+
+import './content-type-design-editor-property.element.js';
 
 const SORTER_CONFIG: UmbSorterConfig<UmbPropertyTypeModel, UmbContentTypeDesignEditorPropertyElement> = {
 	getUniqueOfElement: (element) => {
@@ -201,15 +211,16 @@ export class UmbContentTypeDesignEditorPropertiesElement extends UmbLitElement {
 						)}
 					</div>
 
-					${!this._sortModeActive
-						? html`<uui-button
+					${when(
+						!this._sortModeActive,
+						() => html`
+							<uui-button
+								id="btn-add"
+								href=${ifDefined(this._modalRouteBuilderNewProperty?.({ sortOrder: -1 }))}
 								label=${this.localize.term('contentTypeEditor_addProperty')}
-								id="add"
-								look="placeholder"
-								href=${ifDefined(this._modalRouteBuilderNewProperty?.({ sortOrder: -1 }))}>
-								<umb-localize key="contentTypeEditor_addProperty">Add property</umb-localize>
-							</uui-button> `
-						: ''}
+								look="placeholder"></uui-button>
+						`,
+					)}
 				`
 			: '';
 	}
@@ -217,8 +228,9 @@ export class UmbContentTypeDesignEditorPropertiesElement extends UmbLitElement {
 	static styles = [
 		UmbTextStyles,
 		css`
-			#add {
+			#btn-add {
 				width: 100%;
+				--uui-button-height: var(--uui-size-14);
 			}
 
 			#property-list[sort-mode-active]:not(:has(umb-content-type-design-editor-property)) {

--- a/src/packages/core/content-type/workspace/views/design/content-type-design-editor-tab.element.ts
+++ b/src/packages/core/content-type/workspace/views/design/content-type-design-editor-tab.element.ts
@@ -1,19 +1,17 @@
 import { UMB_CONTENT_TYPE_WORKSPACE_CONTEXT } from '../../content-type-workspace.context-token.js';
-import type { UmbContentTypeWorkspaceViewEditGroupElement } from './content-type-design-editor-group.element.js';
 import { UMB_CONTENT_TYPE_DESIGN_EDITOR_CONTEXT } from './content-type-design-editor.context.js';
+import type { UmbContentTypeWorkspaceViewEditGroupElement } from './content-type-design-editor-group.element.js';
+import { css, customElement, html, nothing, property, repeat, state } from '@umbraco-cms/backoffice/external/lit';
+import { UmbContentTypeContainerStructureHelper } from '@umbraco-cms/backoffice/content-type';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import { css, html, customElement, property, state, repeat, nothing } from '@umbraco-cms/backoffice/external/lit';
-import {
-	UmbContentTypeContainerStructureHelper,
-	type UmbContentTypeModel,
-	type UmbPropertyTypeContainerModel,
-} from '@umbraco-cms/backoffice/content-type';
+import { UmbModalRouteRegistrationController } from '@umbraco-cms/backoffice/router';
+import { UmbSorterController } from '@umbraco-cms/backoffice/sorter';
+import { UMB_WORKSPACE_MODAL } from '@umbraco-cms/backoffice/modal';
+import type { UmbContentTypeModel, UmbPropertyTypeContainerModel } from '@umbraco-cms/backoffice/content-type';
+import type { UmbSorterConfig } from '@umbraco-cms/backoffice/sorter';
 
 import './content-type-design-editor-properties.element.js';
 import './content-type-design-editor-group.element.js';
-import { type UmbSorterConfig, UmbSorterController } from '@umbraco-cms/backoffice/sorter';
-import { UMB_WORKSPACE_MODAL } from '@umbraco-cms/backoffice/modal';
-import { UmbModalRouteRegistrationController } from '@umbraco-cms/backoffice/router';
 
 const SORTER_CONFIG: UmbSorterConfig<UmbPropertyTypeContainerModel, UmbContentTypeWorkspaceViewEditGroupElement> = {
 	getUniqueOfElement: (element) => element.group?.id,
@@ -120,6 +118,7 @@ export class UmbContentTypeDesignEditorTabElement extends UmbLitElement {
 					this._editContentTypePath = routeBuilder({});
 				});
 		});
+
 		this.consumeContext(UMB_CONTENT_TYPE_DESIGN_EDITOR_CONTEXT, (context) => {
 			this.observe(
 				context.isSorting,
@@ -134,6 +133,7 @@ export class UmbContentTypeDesignEditorTabElement extends UmbLitElement {
 				'_observeIsSorting',
 			);
 		});
+
 		this.observe(
 			this.#groupStructureHelper.mergedContainers,
 			(groups) => {
@@ -142,6 +142,7 @@ export class UmbContentTypeDesignEditorTabElement extends UmbLitElement {
 			},
 			null,
 		);
+
 		this.observe(
 			this.#groupStructureHelper.hasProperties,
 			(hasProperties) => {
@@ -194,13 +195,13 @@ export class UmbContentTypeDesignEditorTabElement extends UmbLitElement {
 
 	#renderAddGroupButton() {
 		if (this._sortModeActive) return;
-		return html`<uui-button
-			label=${this.localize.term('contentTypeEditor_addGroup')}
-			id="add"
-			look="placeholder"
-			@click=${this.#onAddGroup}>
-			${this.localize.term('contentTypeEditor_addGroup')}
-		</uui-button>`;
+		return html`
+			<uui-button
+				id="btn-add"
+				label=${this.localize.term('contentTypeEditor_addGroup')}
+				look="placeholder"
+				@click=${this.#onAddGroup}></uui-button>
+		`;
 	}
 
 	static styles = [
@@ -213,12 +214,9 @@ export class UmbContentTypeDesignEditorTabElement extends UmbLitElement {
 				visibility: hidden;
 			}
 
-			#add {
+			#btn-add {
 				width: 100%;
-			}
-
-			#add:first-child {
-				margin-top: var(--uui-size-layout-1);
+				--uui-button-height: var(--uui-size-24);
 			}
 
 			uui-box,

--- a/src/packages/core/content-type/workspace/views/design/content-type-design-editor.element.ts
+++ b/src/packages/core/content-type/workspace/views/design/content-type-design-editor.element.ts
@@ -556,7 +556,7 @@ export class UmbContentTypeDesignEditorElement extends UmbLitElement implements 
 
 			#header {
 				width: 100%;
-				min-height: var(--uui-size-15);
+				min-height: var(--uui-size-16);
 				display: flex;
 				align-items: center;
 				justify-content: space-between;

--- a/src/packages/core/content-type/workspace/views/design/content-type-design-editor.element.ts
+++ b/src/packages/core/content-type/workspace/views/design/content-type-design-editor.element.ts
@@ -369,7 +369,7 @@ export class UmbContentTypeDesignEditorElement extends UmbLitElement implements 
 		return html`
 			<umb-body-layout header-fit-height>
 				<div id="header" slot="header">
-					<div id="container-list" class="flex">${this.renderTabsNavigation()} ${this.renderAddButton()}</div>
+					<div id="container-list">${this.renderTabsNavigation()} ${this.renderAddButton()}</div>
 					${this.renderActions()}
 				</div>
 				<umb-router-slot
@@ -388,10 +388,12 @@ export class UmbContentTypeDesignEditorElement extends UmbLitElement implements 
 	renderAddButton() {
 		// TODO: Localize this:
 		if (this._sortModeActive) return;
-		return html`<uui-button id="add-tab" @click="${this.#addTab}" label="Add tab">
-			<uui-icon name="icon-add"></uui-icon>
-			Add tab
-		</uui-button>`;
+		return html`
+			<uui-button id="add-tab" @click="${this.#addTab}" label="Add tab">
+				<uui-icon name="icon-add"></uui-icon>
+				Add tab
+			</uui-button>
+		`;
 	}
 
 	renderActions() {
@@ -399,37 +401,41 @@ export class UmbContentTypeDesignEditorElement extends UmbLitElement implements 
 			? this.localize.term('general_reorderDone')
 			: this.localize.term('general_reorder');
 
-		return html`<div>
-			${this._compositionRepositoryAlias
-				? html`<uui-button
-						look="outline"
-						label=${this.localize.term('contentTypeEditor_compositions')}
-						compact
-						@click=${this.#openCompositionModal}>
-						<uui-icon name="icon-merge"></uui-icon>
-						${this.localize.term('contentTypeEditor_compositions')}
-					</uui-button>`
-				: ''}
-			<uui-button look="outline" label=${sortButtonText} compact @click=${this.#toggleSortMode}>
-				<uui-icon name="icon-navigation"></uui-icon>
-				${sortButtonText}
-			</uui-button>
-		</div>`;
+		return html`
+			<div id="actions">
+				${this._compositionRepositoryAlias
+					? html` <uui-button
+							look="outline"
+							label=${this.localize.term('contentTypeEditor_compositions')}
+							compact
+							@click=${this.#openCompositionModal}>
+							<uui-icon name="icon-merge"></uui-icon>
+							${this.localize.term('contentTypeEditor_compositions')}
+						</uui-button>`
+					: ''}
+				<uui-button look="outline" label=${sortButtonText} compact @click=${this.#toggleSortMode}>
+					<uui-icon name="icon-navigation"></uui-icon>
+					${sortButtonText}
+				</uui-button>
+			</div>
+		`;
 	}
 
 	renderTabsNavigation() {
 		if (!this._tabs || this._tabs.length === 0) return;
 
-		return html`<div id="tabs-group" class="flex">
-			<uui-tab-group>
-				${this.renderRootTab()}
-				${repeat(
-					this._tabs,
-					(tab) => tab.id,
-					(tab) => this.renderTab(tab),
-				)}
-			</uui-tab-group>
-		</div>`;
+		return html`
+			<div id="tabs-group">
+				<uui-tab-group>
+					${this.renderRootTab()}
+					${repeat(
+						this._tabs,
+						(tab) => tab.id,
+						(tab) => this.renderTab(tab),
+					)}
+				</uui-tab-group>
+			</div>
+		`;
 	}
 
 	renderRootTab() {
@@ -439,14 +445,16 @@ export class UmbContentTypeDesignEditorElement extends UmbLitElement implements 
 			// If we don't have any root groups and we are not in sort mode, then we don't want to render the root tab.
 			return nothing;
 		}
-		return html`<uui-tab
-			id="root-tab"
-			class=${this._hasRootGroups || rootTabActive ? '' : 'content-tab-is-empty'}
-			label=${this.localize.term('general_generic')}
-			.active=${rootTabActive}
-			href=${rootTabPath}>
-			${this.localize.term('general_generic')}
-		</uui-tab>`;
+		return html`
+			<uui-tab
+				id="root-tab"
+				class=${this._hasRootGroups || rootTabActive ? '' : 'content-tab-is-empty'}
+				label=${this.localize.term('general_generic')}
+				.active=${rootTabActive}
+				href=${rootTabPath}>
+				${this.localize.term('general_generic')}
+			</uui-tab>
+		`;
 	}
 
 	renderTab(tab: UmbPropertyTypeContainerModel) {
@@ -563,8 +571,17 @@ export class UmbContentTypeDesignEditorElement extends UmbLitElement implements 
 				flex-wrap: nowrap;
 			}
 
-			.flex {
+			#container-list {
 				display: flex;
+			}
+
+			#tabs-group {
+				display: flex;
+			}
+
+			#actions {
+				display: flex;
+				gap: var(--uui-size-space-2);
 			}
 
 			uui-tab-group {

--- a/src/packages/documents/document-types/workspace/document-type-workspace-editor.element.ts
+++ b/src/packages/documents/document-types/workspace/document-type-workspace-editor.element.ts
@@ -78,7 +78,7 @@ export class UmbDocumentTypeWorkspaceEditorElement extends UmbLitElement {
 		return html`
 			<umb-workspace-editor alias="Umb.Workspace.DocumentType">
 				<div id="header" slot="header">
-					<uui-button id="icon" @click=${this._handleIconClick} label="icon" compact>
+					<uui-button id="icon" compact label="icon" look="outline" @click=${this._handleIconClick}>
 						<umb-icon name=${ifDefined(this._icon)}></umb-icon>
 					</uui-button>
 
@@ -116,6 +116,7 @@ export class UmbDocumentTypeWorkspaceEditorElement extends UmbLitElement {
 			#header {
 				display: flex;
 				flex: 1 1 auto;
+				gap: var(--uui-size-space-2);
 			}
 
 			#editors {
@@ -140,9 +141,9 @@ export class UmbDocumentTypeWorkspaceEditorElement extends UmbLitElement {
 			}
 
 			#icon {
-				font-size: calc(var(--uui-size-layout-3) / 2);
-				margin-right: var(--uui-size-space-2);
-				margin-left: calc(var(--uui-size-space-4) * -1);
+				font-size: var(--uui-size-8);
+				height: 60px;
+				width: 60px;
 			}
 		`,
 	];

--- a/src/packages/media/media-types/workspace/media-type-workspace-editor.element.ts
+++ b/src/packages/media/media-types/workspace/media-type-workspace-editor.element.ts
@@ -80,32 +80,34 @@ export class UmbMediaTypeWorkspaceEditorElement extends UmbLitElement {
 	}
 
 	render() {
-		return html`<umb-workspace-editor alias="Umb.Workspace.MediaType">
-			<div id="header" slot="header">
-				<uui-button id="icon" @click=${this._handleIconClick} label="icon" compact>
-					<umb-icon name=${ifDefined(this._icon)}></umb-icon>
-				</uui-button>
+		return html`
+			<umb-workspace-editor alias="Umb.Workspace.MediaType">
+				<div id="header" slot="header">
+					<uui-button id="icon" compact label="icon" look="outline" @click=${this._handleIconClick}>
+						<umb-icon name=${ifDefined(this._icon)}></umb-icon>
+					</uui-button>
 
-				<div id="editors">
-					<umb-input-with-alias
-						id="name"
-						label=${this.localize.term('placeholders_entername')}
-						value=${this._name}
-						alias=${this._alias}
-						?auto-generate-alias=${this._isNew}
-						@change="${this.#onNameAndAliasChange}"
-						${umbFocus()}>
-					</umb-input-with-alias>
+					<div id="editors">
+						<umb-input-with-alias
+							id="name"
+							label=${this.localize.term('placeholders_entername')}
+							value=${this._name}
+							alias=${this._alias}
+							?auto-generate-alias=${this._isNew}
+							@change="${this.#onNameAndAliasChange}"
+							${umbFocus()}>
+						</umb-input-with-alias>
 
-					<uui-input
-						id="description"
-						.label=${this.localize.term('placeholders_enterDescription')}
-						.value=${this._description}
-						.placeholder=${this.localize.term('placeholders_enterDescription')}
-						@input=${this.#onDescriptionChange}></uui-input>
+						<uui-input
+							id="description"
+							.label=${this.localize.term('placeholders_enterDescription')}
+							.value=${this._description}
+							.placeholder=${this.localize.term('placeholders_enterDescription')}
+							@input=${this.#onDescriptionChange}></uui-input>
+					</div>
 				</div>
-			</div>
-		</umb-workspace-editor>`;
+			</umb-workspace-editor>
+		`;
 	}
 
 	static styles = [
@@ -119,6 +121,7 @@ export class UmbMediaTypeWorkspaceEditorElement extends UmbLitElement {
 			#header {
 				display: flex;
 				flex: 1 1 auto;
+				gap: var(--uui-size-space-2);
 			}
 
 			#editors {
@@ -143,9 +146,9 @@ export class UmbMediaTypeWorkspaceEditorElement extends UmbLitElement {
 			}
 
 			#icon {
-				font-size: calc(var(--uui-size-layout-3) / 2);
-				margin-right: var(--uui-size-space-2);
-				margin-left: calc(var(--uui-size-space-4) * -1);
+				font-size: var(--uui-size-8);
+				height: 60px;
+				width: 60px;
 			}
 		`,
 	];

--- a/src/packages/members/member-type/workspace/member-type-workspace-editor.element.ts
+++ b/src/packages/members/member-type/workspace/member-type-workspace-editor.element.ts
@@ -22,10 +22,6 @@ export class UmbMemberTypeWorkspaceEditorElement extends UmbLitElement {
 	@state()
 	private _isNew?: boolean;
 
-	@state()
-	private _iconColorAlias?: string;
-	// TODO: Color should be using an alias, and look up in some dictionary/key/value) of project-colors.
-
 	#workspaceContext?: typeof UMB_MEMBER_TYPE_WORKSPACE_CONTEXT.TYPE;
 
 	constructor() {
@@ -82,8 +78,8 @@ export class UmbMemberTypeWorkspaceEditorElement extends UmbLitElement {
 		return html`
 			<umb-workspace-editor alias="Umb.Workspace.MemberType">
 				<div id="header" slot="header">
-					<uui-button id="icon" @click=${this._handleIconClick} label="icon" compact>
-						<uui-icon name="${ifDefined(this._icon)}" style="color: ${this._iconColorAlias}"></uui-icon>
+					<uui-button id="icon" compact label="icon" look="outline" @click=${this._handleIconClick}>
+						<umb-icon name=${ifDefined(this._icon)}></umb-icon>
 					</uui-button>
 
 					<div id="editors">
@@ -120,6 +116,7 @@ export class UmbMemberTypeWorkspaceEditorElement extends UmbLitElement {
 			#header {
 				display: flex;
 				flex: 1 1 auto;
+				gap: var(--uui-size-space-2);
 			}
 
 			#editors {
@@ -156,9 +153,9 @@ export class UmbMemberTypeWorkspaceEditorElement extends UmbLitElement {
 			}
 
 			#icon {
-				font-size: calc(var(--uui-size-layout-3) / 2);
-				margin-right: var(--uui-size-space-2);
-				margin-left: calc(var(--uui-size-space-4) * -1);
+				font-size: var(--uui-size-8);
+				height: 60px;
+				width: 60px;
 			}
 		`,
 	];

--- a/src/packages/user/user-group/workspace/user-group-workspace-editor.element.ts
+++ b/src/packages/user/user-group/workspace/user-group-workspace-editor.element.ts
@@ -210,7 +210,7 @@ export class UmbUserGroupWorkspaceEditorElement extends UmbLitElement {
 	#renderHeader() {
 		return html`
 			<div id="header" slot="header">
-				<uui-button id="icon" @click=${this.#onIconClick} label="icon" compact>
+				<uui-button id="icon" compact label="icon" look="outline" @click=${this.#onIconClick}>
 					<umb-icon name=${this._icon || ''}></umb-icon>
 				</uui-button>
 
@@ -339,9 +339,12 @@ export class UmbUserGroupWorkspaceEditorElement extends UmbLitElement {
 	}
 
 	#renderRightColumn() {
-		return html` <uui-box headline="Actions">
-			<umb-entity-action-list .entityType=${UMB_USER_GROUP_ENTITY_TYPE} .unique=${this._unique}></umb-entity-action-list
-		></uui-box>`;
+		return html`
+			<uui-box headline="Actions">
+				<umb-entity-action-list .entityType=${UMB_USER_GROUP_ENTITY_TYPE} .unique=${this._unique}>
+				</umb-entity-action-list>
+			</uui-box>
+		`;
 	}
 
 	static styles = [
@@ -355,11 +358,14 @@ export class UmbUserGroupWorkspaceEditorElement extends UmbLitElement {
 			#header {
 				display: flex;
 				flex: 1 1 auto;
-				gap: var(--uui-size-space-3);
+				gap: var(--uui-size-space-2);
+				align-items: center;
 			}
 
 			#icon {
-				font-size: calc(var(--uui-size-layout-3) / 2);
+				font-size: var(--uui-size-5);
+				height: 30px;
+				width: 30px;
 			}
 
 			#name {


### PR DESCRIPTION
## Description

Cosmetics to Content Type workspace header UIs, to help towards tightening up the layout and aligning a little more with v13 UI.

I've applied the following...

- Icon picker, added border and positioning, to align with the property group panels
- Fixed the height of the tabs bar, as it changed when a tab was added
- Used flexbox for the tab bar actions, e.g. Composition/resize buttons, for spacing consistency
- Extra height on the "add property" and "add group" buttons, for prominence and alignment with v13 UI
- Property group's name input, made full width and transparent border, (border shows on hover), to align with v13 UI
- Added `auto-width` to the alias input-lock, so that the full alias can be displayed

**Before**
![before](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/209066/a06470c1-3787-4159-be4f-155a3d2afbd2)

**After**
![after](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/209066/39d58361-4a4f-40ee-83e6-554487c3e3a7)

I have applied these amends to the **Document Type**, **Media Type**, **Member Type** and **User Group** workspaces.


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
