### PR TITLE
Only render folders for move document blueprint

### DIFF
--- a/src/packages/documents/document-blueprints/entity-actions/move-to/manifests.ts
+++ b/src/packages/documents/document-blueprints/entity-actions/move-to/manifests.ts
@@ -15,6 +15,7 @@ const entityActions: Array<ManifestTypes> = [
 			treeRepositoryAlias: UMB_DOCUMENT_BLUEPRINT_TREE_REPOSITORY_ALIAS,
 			moveRepositoryAlias: UMB_MOVE_DOCUMENT_BLUEPRINT_REPOSITORY_ALIAS,
 			treeAlias: UMB_DOCUMENT_BLUEPRINT_TREE_ALIAS,
+			foldersOnly: true,
 		},
 	},
 ];

--- a/src/packages/documents/document-blueprints/tree/document-blueprint-tree.server.data-source.ts
+++ b/src/packages/documents/document-blueprints/tree/document-blueprint-tree.server.data-source.ts
@@ -41,7 +41,11 @@ export class UmbDocumentBlueprintTreeServerDataSource extends UmbTreeServerDataS
 
 const getRootItems = (args: UmbTreeRootItemsRequestArgs) =>
 	// eslint-disable-next-line local-rules/no-direct-api-import
-	DocumentBlueprintService.getTreeDocumentBlueprintRoot({ skip: args.skip, take: args.take });
+	DocumentBlueprintService.getTreeDocumentBlueprintRoot({
+		foldersOnly: args.foldersOnly,
+		skip: args.skip,
+		take: args.take,
+	});
 
 const getChildrenOf = (args: UmbTreeChildrenOfRequestArgs) => {
 	if (args.parent.unique === null) {
@@ -50,6 +54,7 @@ const getChildrenOf = (args: UmbTreeChildrenOfRequestArgs) => {
 		// eslint-disable-next-line local-rules/no-direct-api-import
 		return DocumentBlueprintService.getTreeDocumentBlueprintChildren({
 			parentId: args.parent.unique,
+			foldersOnly: args.foldersOnly,
 		});
 	}
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Only render folders when moving a media type

## How to test
* Make sure that you can only see folders in the tree when selecting a destination for the media type

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
