### PR TITLE
Bugfix: Only render folders for move Document Type

### DIFF
--- a/src/packages/documents/document-types/entity-actions/move-to/manifests.ts
+++ b/src/packages/documents/document-types/entity-actions/move-to/manifests.ts
@@ -15,6 +15,7 @@ const entityActions: Array<ManifestTypes> = [
 			treeRepositoryAlias: UMB_DOCUMENT_TYPE_TREE_REPOSITORY_ALIAS,
 			moveRepositoryAlias: UMB_MOVE_DOCUMENT_TYPE_REPOSITORY_ALIAS,
 			treeAlias: UMB_DOCUMENT_TYPE_TREE_ALIAS,
+			foldersOnly: true,
 		},
 	},
 ];

--- a/src/packages/documents/document-types/tree/document-type.tree.server.data-source.ts
+++ b/src/packages/documents/document-types/tree/document-type.tree.server.data-source.ts
@@ -41,15 +41,24 @@ export class UmbDocumentTypeTreeServerDataSource extends UmbTreeServerDataSource
 
 const getRootItems = (args: UmbTreeRootItemsRequestArgs) =>
 	// eslint-disable-next-line local-rules/no-direct-api-import
-	DocumentTypeService.getTreeDocumentTypeRoot({ skip: args.skip, take: args.take });
+	DocumentTypeService.getTreeDocumentTypeRoot({
+		foldersOnly: args.foldersOnly,
+		skip: args.skip,
+		take: args.take,
+	});
 
 const getChildrenOf = (args: UmbTreeChildrenOfRequestArgs) => {
 	if (args.parent.unique === null) {
-		return getRootItems({ skip: args.skip, take: args.take });
+		return getRootItems({
+			foldersOnly: args.foldersOnly,
+			skip: args.skip,
+			take: args.take,
+		});
 	} else {
 		// eslint-disable-next-line local-rules/no-direct-api-import
 		return DocumentTypeService.getTreeDocumentTypeChildren({
 			parentId: args.parent.unique,
+			foldersOnly: args.foldersOnly,
 			skip: args.skip,
 			take: args.take,
 		});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Only render folders when moving a document type

## How to test
* Make sure that you can only see folders in the tree when selecting a destination for the document type

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)