### PR TITLE
Chore: Bundling dictionary module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21166,6 +21166,8 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
-		"src/packages/dictionary": {}
+		"src/packages/dictionary": {
+			"name": "@umbraco-backoffice/dictionary"
+		}
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
 			"name": "@umbraco-cms/backoffice",
 			"version": "14.1.0",
 			"license": "MIT",
+			"workspaces": [
+				"./src/packages/dictionary"
+			],
 			"dependencies": {
 				"@types/diff": "^5.2.1",
 				"@types/dompurify": "^3.0.5",
@@ -6800,6 +6803,10 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			}
+		},
+		"node_modules/@umbraco-backoffice/dictionary": {
+			"resolved": "src/packages/dictionary",
+			"link": true
 		},
 		"node_modules/@umbraco-ui/uui": {
 			"version": "1.8.1",
@@ -21158,6 +21165,7 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
 			}
-		}
+		},
+		"src/packages/dictionary": {}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -130,12 +130,12 @@
 	"scripts": {
 		"backoffice:test:e2e": "npx playwright test",
 		"build-storybook": "npm run wc-analyze && storybook build",
-		"build:for:cms": "npm run build && npm run build:workspaces && node ./devops/build/copy-to-cms.js",
-		"build:for:npm": "npm run build",
+		"build:for:cms": "npm run build && npm run build:workspaces && npm run generate:manifest && npm run package:validate && node ./devops/build/copy-to-cms.js",
+		"build:for:npm": "npm run build && npm run generate:manifest && npm run package:validate",
 		"build:for:static": "vite build",
 		"build:vite": "tsc && vite build --mode staging",
 		"build:workspaces": "npm run build -ws --if-present",
-		"build": "tsc --project ./src/tsconfig.build.json && rollup -c ./src/rollup.config.js && npm run package:validate && npm run generate:manifest && npm run check:paths",
+		"build": "tsc --project ./src/tsconfig.build.json && rollup -c ./src/rollup.config.js",
 		"check": "npm run lint:errors && npm run compile && npm run build-storybook && npm run generate:jsonschema:dist",
 		"check:paths": "node ./devops/build/check-path-length.js src 140",
 		"compile": "tsc",
@@ -168,7 +168,7 @@
 		"wc-analyze": "wca **/*.element.ts --outFile dist-cms/custom-elements.json",
 		"generate:tsconfig": "node ./devops/tsconfig/index.js",
 		"generate:manifest": "node ./devops/build/create-umbraco-package.js",
-		"package:validate": "node ./devops/package/validate-exports.js",
+		"package:validate": "node ./devops/package/validate-exports.js && npm run check:paths",
 		"generate:ui-api-docs": "typedoc --options typedoc.config.js"
 	},
 	"engines": {

--- a/package.json
+++ b/package.json
@@ -124,12 +124,17 @@
 		"email": "backoffice@umbraco.com",
 		"url": "https://umbraco.com"
 	},
+	"workspaces": [
+		"./src/packages/language"
+	],
 	"scripts": {
 		"backoffice:test:e2e": "npx playwright test",
 		"build-storybook": "npm run wc-analyze && storybook build",
-		"build:for:cms": "npm run build && node ./devops/build/copy-to-cms.js",
+		"build:for:cms": "npm run build && npm run build:workspaces && node ./devops/build/copy-to-cms.js",
+		"build:for:npm": "npm run build",
 		"build:for:static": "vite build",
 		"build:vite": "tsc && vite build --mode staging",
+		"build:workspaces": "npm run build -ws --if-present",
 		"build": "tsc --project ./src/tsconfig.build.json && rollup -c ./src/rollup.config.js && npm run package:validate && npm run generate:manifest && npm run check:paths",
 		"check": "npm run lint:errors && npm run compile && npm run build-storybook && npm run generate:jsonschema:dist",
 		"check:paths": "node ./devops/build/check-path-length.js src 140",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
 		"url": "https://umbraco.com"
 	},
 	"workspaces": [
-		"./src/packages/language"
+		"./src/packages/dictionary"
 	],
 	"scripts": {
 		"backoffice:test:e2e": "npx playwright test",

--- a/src/packages/dictionary/package.json
+++ b/src/packages/dictionary/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "@umbraco-backoffice/dictionary",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"build": "vite build"
+	}
+}

--- a/src/packages/dictionary/vite.config.ts
+++ b/src/packages/dictionary/vite.config.ts
@@ -8,6 +8,7 @@ rmSync(dist, { recursive: true, force: true });
 
 export default defineConfig({
 	build: {
+		target: 'es2022',
 		lib: {
 			entry: ['index.ts', 'manifests.ts', 'umbraco-package.ts'],
 			formats: ['es'],

--- a/src/packages/dictionary/vite.config.ts
+++ b/src/packages/dictionary/vite.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vite';
+import { rmSync } from 'fs';
+
+const dist = '../../../dist-cms/packages/dictionary';
+
+// delete the unbundled dist folder
+rmSync(dist, { recursive: true, force: true });
+
+export default defineConfig({
+	build: {
+		lib: {
+			entry: ['index.ts', 'manifests.ts', 'umbraco-package.ts'],
+			formats: ['es'],
+		},
+		outDir: dist,
+		//sourcemap: true,
+		rollupOptions: {
+			external: [/^@umbraco/],
+		},
+	},
+});

--- a/src/packages/dictionary/vite.config.ts
+++ b/src/packages/dictionary/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
 			formats: ['es'],
 		},
 		outDir: dist,
-		//sourcemap: true,
+		sourcemap: true,
 		rollupOptions: {
 			external: [/^@umbraco/],
 		},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This is the beginning of bundling our modules. Unfortunately, bundling all the modules before v15 might not be possible because some files are located incorrectly. These files can't be moved without a breaking change. Therefore, We will go through the modules one by one, and bundle the possible ones.

This PR sets up the basic build script for bundling. The build is made with npm workspaces which makes it possible to run a "local" build script in each package. The bundling is done by Vite.

We now have one for the npm package, which is not bundled, and one for the CMS which will be partly bundled. 

The idea is to build the same way as before but swap out the "old" module files for the bundled ones when a module is ready. 

## How to test

1. Run the `npm run build:for:cms` script in the CMS project. 
2. Check that you see the bundled javascript output in the `src/packages/dictionary` folder.
3. Clear your browser cache
4. Test the dictionary section/workspaces etc. All works as before


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
