### PR TITLE
Feature: TinyMce Custom Configuration

### DIFF
--- a/public-assets/App_Plugins/tinyMcePlugin.js
+++ b/public-assets/App_Plugins/tinyMcePlugin.js
@@ -2,7 +2,7 @@ export default class UmbTinyMceMockPlugin {
 	/**
 	 * @param {TinyMcePluginArguments} args
 	 */
-	constructor(host, args) {
+	constructor(args) {
 		// Add your plugin code here
 		console.log('editor initialized', args)
 	}

--- a/public-assets/App_Plugins/tinyMcePlugin.js
+++ b/public-assets/App_Plugins/tinyMcePlugin.js
@@ -1,0 +1,9 @@
+export default class UmbTinyMceMockPlugin {
+	/**
+	 * @param {TinyMcePluginArguments} args
+	 */
+	constructor(host, args) {
+		// Add your plugin code here
+		console.log('editor initialized', args)
+	}
+}

--- a/src/mocks/handlers/manifests.handlers.ts
+++ b/src/mocks/handlers/manifests.handlers.ts
@@ -52,7 +52,7 @@ const privateManifests: PackageManifestResponse = [
 				js: '/App_Plugins/tinyMcePlugin.js',
 				meta: {
 					config: {
-						plugins: 'wordcount',
+						plugins: ['wordcount'],
 						statusbar: true,
 					},
 				},

--- a/src/mocks/handlers/manifests.handlers.ts
+++ b/src/mocks/handlers/manifests.handlers.ts
@@ -45,6 +45,18 @@ const privateManifests: PackageManifestResponse = [
 					propertyEditorSchema: 'Umbraco.TextBox',
 				},
 			},
+			{
+				type: 'tinyMcePlugin',
+				alias: 'My.TinyMcePlugin.Custom',
+				name: 'My Custom TinyMce Plugin',
+				js: '/App_Plugins/tinyMcePlugin.js',
+				meta: {
+					config: {
+						plugins: 'wordcount',
+						statusbar: true,
+					},
+				},
+			},
 		],
 	},
 	{

--- a/src/packages/core/extension-registry/models/tinymce-plugin.model.ts
+++ b/src/packages/core/extension-registry/models/tinymce-plugin.model.ts
@@ -1,5 +1,6 @@
 import type { UmbTinyMcePluginBase } from '@umbraco-cms/backoffice/tiny-mce';
 import type { ManifestApi } from '@umbraco-cms/backoffice/extension-api';
+import type { RawEditorOptions } from '@umbraco-cms/backoffice/external/tinymce';
 
 export interface MetaTinyMcePlugin {
 	/**
@@ -26,6 +27,20 @@ export interface MetaTinyMcePlugin {
 		 */
 		icon?: string;
 	}>;
+
+	/**
+	 * Sets the default configuration for the TinyMCE editor. This configuration will be used when the editor is initialized.
+	 *
+	 * @see [TinyMCE Configuration](https://www.tiny.cloud/docs/configure/) for more information.
+	 * @optional
+	 * @examples [
+	 * {
+	 *   "plugins": "wordcount",
+	 *   "statusbar": true
+	 * }
+	 * ]
+	 */
+	config?: RawEditorOptions;
 }
 
 /**

--- a/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
+++ b/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
@@ -242,6 +242,7 @@ export class UmbInputTinyMceElement extends UUIFormControlMixin(UmbLitElement, '
 			target: this._editorElement,
 			paste_data_images: false,
 			language: this.#getLanguage(),
+			promotion: false,
 
 			// Extend with configuration options
 			...configurationOptions,

--- a/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
+++ b/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
@@ -330,13 +330,14 @@ export class UmbInputTinyMceElement extends UUIFormControlMixin(UmbLitElement, '
 				}
 			});
 		});
-		editor.on('init', () => editor.setContent(this.value?.toString() ?? ''));
+
 	}
 
 	#onInit(editor: Editor) {
 		//enable browser based spell checking
 		editor.getBody().setAttribute('spellcheck', 'true');
 		uriAttributeSanitizer(editor);
+		editor.setContent(this.value?.toString() ?? '');
 	}
 
 	#onChange(value: string) {

--- a/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
+++ b/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
@@ -5,7 +5,7 @@ import { uriAttributeSanitizer } from './input-tiny-mce.sanitizer.js';
 import type { UmbTinyMcePluginBase } from './tiny-mce-plugin.js';
 import { type ClassConstructor, loadManifestApi } from '@umbraco-cms/backoffice/extension-api';
 import { css, customElement, html, property, query } from '@umbraco-cms/backoffice/external/lit';
-import { getProcessedImageUrl } from '@umbraco-cms/backoffice/utils';
+import { getProcessedImageUrl, umbDeepMerge } from '@umbraco-cms/backoffice/utils';
 import { type ManifestTinyMcePlugin, umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
@@ -95,10 +95,10 @@ export class UmbInputTinyMceElement extends UUIFormControlMixin(UmbLitElement, '
 			let config: RawEditorOptions = {};
 			manifests.forEach((manifest) => {
 				if (manifest.meta?.config) {
-					// TODO: Deep merge config
-					config = { ...config, ...manifest.meta.config };
+					config = umbDeepMerge(manifest.meta.config, config);
 				}
 			});
+
 			this.#setTinyConfig(config);
 		});
 	}
@@ -227,7 +227,7 @@ export class UmbInputTinyMceElement extends UUIFormControlMixin(UmbLitElement, '
 		}
 
 		// set the default values that will not be modified via configuration
-		const config: RawEditorOptions = {
+		let config: RawEditorOptions = {
 			autoresize_bottom_margin: 10,
 			body_class: 'umb-rte',
 			contextMenu: false,
@@ -245,12 +245,12 @@ export class UmbInputTinyMceElement extends UUIFormControlMixin(UmbLitElement, '
 
 			// Extend with configuration options
 			...configurationOptions,
-
-			// Extend with additional configuration options
-			//...additionalConfig, // TODO: Deep merge
 		};
 
-		console.log('tried to set config', additionalConfig);
+		// Extend with additional configuration options
+		if (additionalConfig) {
+			config = umbDeepMerge(additionalConfig, config);
+		}
 
 		this.#editorRef?.destroy();
 

--- a/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
+++ b/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
@@ -53,10 +53,6 @@ export class UmbInputTinyMceElement extends UUIFormControlMixin(UmbLitElement, '
 	@property({ attribute: false })
 	configuration?: UmbPropertyEditorConfigCollection;
 
-	@state()
-	private _tinyConfig: RawEditorOptions = {};
-
-	#plugins: Array<new (args: TinyMcePluginArguments) => UmbTinyMcePluginBase> = [];
 	#editorRef?: Editor | null = null;
 	#stylesheetRepository = new UmbStylesheetDetailRepository(this);
 	#umbStylesheetRuleManager = new UmbStylesheetRuleManager();
@@ -230,7 +226,7 @@ export class UmbInputTinyMceElement extends UUIFormControlMixin(UmbLitElement, '
 		}
 
 		// set the default values that will not be modified via configuration
-		this._tinyConfig = {
+		const config: RawEditorOptions = {
 			autoresize_bottom_margin: 10,
 			body_class: 'umb-rte',
 			contextMenu: false,
@@ -249,13 +245,13 @@ export class UmbInputTinyMceElement extends UUIFormControlMixin(UmbLitElement, '
 			...configurationOptions,
 		};
 
-		this.#setLanguage();
+		config.language = this.#getLanguage();
 
 		if (this.#editorRef) {
 			this.#editorRef.destroy();
 		}
 
-		const editors = await renderEditor(this._tinyConfig).catch((error) => {
+		const editors = await renderEditor(config).catch((error) => {
 			console.error('Failed to render TinyMCE', error);
 			return [];
 		});
@@ -263,8 +259,9 @@ export class UmbInputTinyMceElement extends UUIFormControlMixin(UmbLitElement, '
 	}
 
 	/**
-	 * Sets the language to use for TinyMCE */
-	#setLanguage() {
+	 * Gets the language to use for TinyMCE
+	 **/
+	#getLanguage() {
 		const localeId = this.localize.lang();
 		//try matching the language using full locale format
 		let languageMatch = availableLanguages.find((x) => localeId?.localeCompare(x) === 0);
@@ -277,10 +274,7 @@ export class UmbInputTinyMceElement extends UUIFormControlMixin(UmbLitElement, '
 			}
 		}
 
-		// only set if language exists, will fall back to tiny default
-		if (languageMatch) {
-			this._tinyConfig.language = languageMatch;
-		}
+		return languageMatch;
 	}
 
 	#editorSetup(editor: Editor) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Some configurations such as `statusbar`, `menubar`, and other visuals are invalid to add after the editor has been rendered. To accommodate this, we are adding a `config` object to the manifest file which essentially supports the same options as the former `CustomConfig` in V13.

There is also a fix for async-loaded extensions, which were previously not considered after the editor was rendered. Now we have an observer on the extensions registry and in case a `tinyMcePlugin` is added or removed, we will re-render the editor and merge the new configuration.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How to test?

**Dev server**
1. Turn on the `VITE_UMBRACO_EXTENSION_MOCKS=on` environment variable
2. Notice that the RTE on the "All properties" page are shown with a statusbar and the wordcount plugin

You have to remove these lines from input-tiny-mce.defaults.ts to get the dev server to work:
![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/752371/fdbceffd-55ea-4c20-a860-9e64dbbd18a2)


**CMS**
1. Add a manifest for `tinyMcePlugin` and attempt to add configuration
2. Check that the API is also able to load and receive an arguments object with `host` and `editor`, which you can use to interact with the editor (this is already so before this fix, but make sure this hasn't been broken)

## Screenshots (if appropriate)

![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/752371/67f91e76-6cf5-443b-9012-cc333ef91684)
