### PR TITLE
Bugfix: TinyMCE does not show its box-shadow

### DIFF
--- a/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
+++ b/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
@@ -367,14 +367,6 @@ export class UmbInputTinyMceElement extends UUIFormControlMixin(UmbLitElement, '
 				border: var(--uui-input-border-width, 1px) solid var(--uui-input-border-color, var(--uui-color-border, #d8d7d9));
 			}
 
-			.tox-tinymce-aux {
-				z-index: 9000;
-			}
-
-			.tox-tinymce-inline {
-				z-index: 900;
-			}
-
 			.tox-tinymce-fullscreen {
 				position: absolute;
 			}
@@ -382,11 +374,6 @@ export class UmbInputTinyMceElement extends UUIFormControlMixin(UmbLitElement, '
 			/* FIXME: Remove this workaround when https://github.com/tinymce/tinymce/issues/6431 has been fixed */
 			.tox .tox-collection__item-label {
 				line-height: 1 !important;
-			}
-
-			/* Solves issue 1019 by lowering un-needed z-index on header.*/
-			.tox.tox-tinymce .tox-editor-header {
-				z-index: 0;
 			}
 		`,
 	];


### PR DESCRIPTION
## Description

Removes older CSS additions that should no longer be relevant to TinyMCE v6 such as z-index, which messes with the box-shadow.

Fixes https://github.com/umbraco/Umbraco-CMS/issues/16518

## Screenshots

There is now a box-shadow under the toolbar:

![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/752371/97a1c958-70bc-4c26-bb43-274140a12a87)
