### PR TITLE
Bugfix: Document Public Access cancelled server requests

### DIFF
--- a/src/assets/lang/en-us.ts
+++ b/src/assets/lang/en-us.ts
@@ -46,7 +46,7 @@ export default {
 		logout: 'Exit',
 		move: 'Move to',
 		notify: 'Notifications',
-		protect: 'Restrict Public Access',
+		protect: 'Public Access',
 		publish: 'Publish',
 		refreshNode: 'Reload',
 		remove: 'Remove',

--- a/src/assets/lang/en.ts
+++ b/src/assets/lang/en.ts
@@ -45,7 +45,7 @@ export default {
 		logout: 'Exit',
 		move: 'Move to',
 		notify: 'Notifications',
-		protect: 'Restrict Public Access',
+		protect: 'Public Access',
 		publish: 'Publish',
 		refreshNode: 'Reload',
 		remove: 'Remove',

--- a/src/packages/documents/documents/entity-actions/public-access/manifests.ts
+++ b/src/packages/documents/documents/entity-actions/public-access/manifests.ts
@@ -25,6 +25,10 @@ const entityActions: Array<ManifestTypes> = [
 			{
 				alias: UMB_ENTITY_IS_NOT_TRASHED_CONDITION_ALIAS,
 			},
+			{
+				alias: 'Umb.Condition.SectionUserPermission',
+				match: 'Umb.Section.Members',
+			},
 		],
 	},
 ];

--- a/src/packages/documents/documents/entity-actions/public-access/modal/public-access-modal.element.ts
+++ b/src/packages/documents/documents/entity-actions/public-access/modal/public-access-modal.element.ts
@@ -112,9 +112,9 @@ export class UmbPublicAccessModalElement extends UmbModalBaseElement<
 		this.modalContext?.submit();
 	}
 
-	#handleDelete() {
+	async #handleDelete() {
 		if (!this.#unique) return;
-		this.#publicAccessRepository.delete(this.#unique);
+		await this.#publicAccessRepository.delete(this.#unique);
 		this.modalContext?.submit();
 	}
 

--- a/src/packages/documents/documents/entity-actions/public-access/modal/public-access-modal.element.ts
+++ b/src/packages/documents/documents/entity-actions/public-access/modal/public-access-modal.element.ts
@@ -5,7 +5,7 @@ import type { UmbPublicAccessModalData, UmbPublicAccessModalValue } from './publ
 import { css, customElement, html, nothing, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
-import { UmbMemberItemRepository, type UmbInputMemberElement } from '@umbraco-cms/backoffice/member';
+import { UmbMemberDetailRepository, type UmbInputMemberElement } from '@umbraco-cms/backoffice/member';
 import { UmbMemberGroupItemRepository, type UmbInputMemberGroupElement } from '@umbraco-cms/backoffice/member-group';
 import type { PublicAccessRequestModel } from '@umbraco-cms/backoffice/external/backend-api';
 import type { UUIRadioEvent } from '@umbraco-cms/backoffice/external/uui';
@@ -191,7 +191,10 @@ export class UmbPublicAccessModalElement extends UmbModalBaseElement<
 				<small>
 					<umb-localize key="publicAccess_paLoginPageHelp"> Choose the page that contains the login form </umb-localize>
 				</small>
-				<umb-input-document max="1" @change=${this.#onChangeLoginPage}></umb-input-document>
+				<umb-input-document
+					.value=${this._loginDocumentId ? this._loginDocumentId : ''}
+					max="1"
+					@change=${this.#onChangeLoginPage}></umb-input-document>
 			</div>
 			<br />
 			<div class="select-item">
@@ -201,7 +204,10 @@ export class UmbPublicAccessModalElement extends UmbModalBaseElement<
 						Used when people are logged on, but do not have access
 					</umb-localize>
 				</small>
-				<umb-input-document max="1" @change=${this.#onChangeErrorPage}></umb-input-document>
+				<umb-input-document
+					.value=${this._errorDocumentId ? this._errorDocumentId : ''}
+					max="1"
+					@change=${this.#onChangeErrorPage}></umb-input-document>
 			</div>`;
 	}
 

--- a/src/packages/documents/documents/entity-actions/public-access/modal/public-access-modal.element.ts
+++ b/src/packages/documents/documents/entity-actions/public-access/modal/public-access-modal.element.ts
@@ -57,7 +57,6 @@ export class UmbPublicAccessModalElement extends UmbModalBaseElement<
 	async #getPublicAccessModel() {
 		if (!this.#unique) return;
 		const { data } = await this.#publicAccessRepository.read(this.#unique);
-		debugger;
 
 		if (!data) return;
 		this.#isNew = false;

--- a/src/packages/documents/documents/entity-actions/public-access/modal/public-access-modal.element.ts
+++ b/src/packages/documents/documents/entity-actions/public-access/modal/public-access-modal.element.ts
@@ -68,9 +68,9 @@ export class UmbPublicAccessModalElement extends UmbModalBaseElement<
 
 		//selection
 		if (data.members.length > 0) {
-			this._selection = data.members.map((m: any) => m.id);
+			this._selection = data.members.map((m) => m.id);
 		} else if (data.groups.length > 0) {
-			this._selection = data.groups.map((g: any) => g.id);
+			this._selection = data.groups.map((g) => g.id);
 		}
 
 		this._loginDocumentId = data.loginDocument.id;

--- a/src/packages/documents/documents/entity-actions/public-access/modal/public-access-modal.element.ts
+++ b/src/packages/documents/documents/entity-actions/public-access/modal/public-access-modal.element.ts
@@ -42,7 +42,6 @@ export class UmbPublicAccessModalElement extends UmbModalBaseElement<
 	firstUpdated() {
 		this.#unique = this.data?.unique;
 		this.#getDocumentName();
-		this.#getPublicAccessModel();
 	}
 
 	async #getDocumentName() {
@@ -50,8 +49,13 @@ export class UmbPublicAccessModalElement extends UmbModalBaseElement<
 		// Should this be done here or in the action file?
 		const { data } = await new UmbDocumentItemRepository(this).requestItems([this.#unique]);
 		if (!data) return;
+		const item = data[0];
 		//TODO How do we ensure we get the correct variant?
-		this._documentName = data[0].variants[0]?.name;
+		this._documentName = item.variants[0]?.name;
+
+		if (item.isProtected) {
+			this.#getPublicAccessModel();
+		}
 	}
 
 	async #getPublicAccessModel() {

--- a/src/packages/documents/documents/entity-actions/public-access/modal/public-access-modal.element.ts
+++ b/src/packages/documents/documents/entity-actions/public-access/modal/public-access-modal.element.ts
@@ -97,8 +97,16 @@ export class UmbPublicAccessModalElement extends UmbModalBaseElement<
 
 		if (this._specific) {
 			// Members
+			// user name is not part of the item model, so we need to look it up from the member detail repository
+			// be aware that the detail repository requires access to the member section.
+			const repo = new UmbMemberDetailRepository(this);
+			const promises = this._selection.map((memberId) => repo.requestByUnique(memberId));
+			const responses = await Promise.all(promises);
+			const memberUserNames = responses
+				.filter((response) => response.data)
+				.map((response) => response.data?.username) as string[];
 
-			console.log('Specific members');
+			requestBody.memberUserNames = memberUserNames;
 		} else {
 			// Groups
 			const repo = new UmbMemberGroupItemRepository(this);

--- a/src/packages/documents/documents/entity-actions/public-access/modal/public-access-modal.element.ts
+++ b/src/packages/documents/documents/entity-actions/public-access/modal/public-access-modal.element.ts
@@ -64,7 +64,7 @@ export class UmbPublicAccessModalElement extends UmbModalBaseElement<
 		this._startPage = false;
 
 		// Specific or Groups
-		this._specific = data.members.length > 0 ? true : false;
+		this._specific = data.members.length > 0;
 
 		//selection
 		if (data.members.length > 0) {

--- a/src/packages/documents/documents/entity-actions/public-access/modal/public-access-modal.element.ts
+++ b/src/packages/documents/documents/entity-actions/public-access/modal/public-access-modal.element.ts
@@ -1,5 +1,5 @@
 import { UmbDocumentPublicAccessRepository } from '../repository/public-access.repository.js';
-import { UmbDocumentDetailRepository } from '../../../repository/index.js';
+import { UmbDocumentItemRepository } from '../../../repository/index.js';
 import type { UmbInputDocumentElement } from '../../../components/index.js';
 import type { UmbPublicAccessModalData, UmbPublicAccessModalValue } from './public-access-modal.token.js';
 import { css, customElement, html, nothing, state } from '@umbraco-cms/backoffice/external/lit';
@@ -48,10 +48,10 @@ export class UmbPublicAccessModalElement extends UmbModalBaseElement<
 	async #getDocumentName() {
 		if (!this.#unique) return;
 		// Should this be done here or in the action file?
-		const { data } = await new UmbDocumentDetailRepository(this).requestByUnique(this.#unique);
+		const { data } = await new UmbDocumentItemRepository(this).requestItems([this.#unique]);
 		if (!data) return;
 		//TODO How do we ensure we get the correct variant?
-		this._documentName = data.variants[0]?.name;
+		this._documentName = data[0].variants[0]?.name;
 	}
 
 	async #getPublicAccessModel() {

--- a/src/packages/documents/documents/entity-actions/public-access/modal/public-access-modal.element.ts
+++ b/src/packages/documents/documents/entity-actions/public-access/modal/public-access-modal.element.ts
@@ -104,9 +104,9 @@ export class UmbPublicAccessModalElement extends UmbModalBaseElement<
 		};
 
 		if (this.#isNew) {
-			this.#publicAccessRepository.create(this.#unique, requestBody);
+			await this.#publicAccessRepository.create(this.#unique, requestBody);
 		} else {
-			this.#publicAccessRepository.update(this.#unique, requestBody);
+			await this.#publicAccessRepository.update(this.#unique, requestBody);
 		}
 
 		this.modalContext?.submit();

--- a/src/packages/documents/documents/entity-actions/public-access/public-access.action.ts
+++ b/src/packages/documents/documents/entity-actions/public-access/public-access.action.ts
@@ -1,8 +1,13 @@
 import { UMB_PUBLIC_ACCESS_MODAL } from './modal/public-access-modal.token.js';
 import type { UmbEntityActionArgs } from '@umbraco-cms/backoffice/entity-action';
-import { UmbEntityActionBase } from '@umbraco-cms/backoffice/entity-action';
+import {
+	UmbEntityActionBase,
+	UmbRequestReloadChildrenOfEntityEvent,
+	UmbRequestReloadStructureForEntityEvent,
+} from '@umbraco-cms/backoffice/entity-action';
 import { UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
 import type { UmbDocumentDetailRepository } from '@umbraco-cms/backoffice/document';
+import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
 
 export class UmbDocumentPublicAccessEntityAction extends UmbEntityActionBase<never> {
 	constructor(host: UmbDocumentDetailRepository, args: UmbEntityActionArgs<never>) {
@@ -14,5 +19,23 @@ export class UmbDocumentPublicAccessEntityAction extends UmbEntityActionBase<nev
 		const modalManager = await this.getContext(UMB_MODAL_MANAGER_CONTEXT);
 		const modal = modalManager.open(this, UMB_PUBLIC_ACCESS_MODAL, { data: { unique: this.args.unique } });
 		await modal.onSubmit();
+		this.#requestReloadEntity();
+	}
+
+	async #requestReloadEntity() {
+		const actionEventContext = await this.getContext(UMB_ACTION_EVENT_CONTEXT);
+
+		const entityStructureEvent = new UmbRequestReloadStructureForEntityEvent({
+			unique: this.args.unique,
+			entityType: this.args.entityType,
+		});
+
+		const entityChildrenEvent = new UmbRequestReloadChildrenOfEntityEvent({
+			unique: this.args.unique,
+			entityType: this.args.entityType,
+		});
+
+		actionEventContext.dispatchEvent(entityStructureEvent);
+		actionEventContext.dispatchEvent(entityChildrenEvent);
 	}
 }

--- a/src/packages/documents/documents/entity-actions/public-access/repository/public-access.repository.ts
+++ b/src/packages/documents/documents/entity-actions/public-access/repository/public-access.repository.ts
@@ -25,7 +25,7 @@ export class UmbDocumentPublicAccessRepository extends UmbControllerBase impleme
 		if (!unique) throw new Error('unique is missing');
 		if (!data) throw new Error('Data is missing');
 
-		const { error } = await this.#dataSource.update(unique, data);
+		const { error } = await this.#dataSource.create(unique, data);
 		if (!error) {
 			const notification = { data: { message: `Public acccess setting created` } };
 			this.#notificationContext?.peek('positive', notification);

--- a/src/packages/documents/documents/tree/tree-item/document-tree-item.element.ts
+++ b/src/packages/documents/documents/tree/tree-item/document-tree-item.element.ts
@@ -74,6 +74,7 @@ export class UmbDocumentTreeItemElement extends UmbTreeItemElementBase<UmbDocume
 				${this.item?.documentType.icon
 					? html`
 							<umb-icon id="icon" slot="icon" name="${this.item.documentType.icon}"></umb-icon>
+							${this.item.isProtected ? this.#renderIsProtectedIcon() : nothing}
 							<!--
 							// TODO: implement correct status symbol
 							<span id="status-symbol"></span>
@@ -88,6 +89,10 @@ export class UmbDocumentTreeItemElement extends UmbTreeItemElementBase<UmbDocume
 		return html`<span id="label" slot="label" class=${classMap({ draft: this.#isDraft() })}
 			>${this.#getLabel()}</span
 		> `;
+	}
+
+	#renderIsProtectedIcon() {
+		return html`<umb-icon id="icon-lock" slot="icon" name="icon-lock" title="Protected"></umb-icon>`;
 	}
 
 	static styles = [
@@ -111,6 +116,30 @@ export class UmbDocumentTreeItemElement extends UmbTreeItemElementBase<UmbDocume
 				bottom: 0;
 				right: 0;
 				border-radius: 100%;
+			}
+
+			#icon-lock {
+				position: absolute;
+				bottom: -5px;
+				right: -5px;
+				font-size: 10px;
+				background: var(--uui-color-surface);
+				width: 14px;
+				height: 14px;
+				border-radius: 100%;
+				line-height: 14px;
+			}
+
+			:hover #icon-lock {
+				background: var(--uui-color-surface-emphasis);
+			}
+
+			[active] #icon-lock {
+				background: var(--uui-color-current);
+			}
+
+			[active]:hover #icon-lock {
+				background: var(--uui-color-current-emphasis);
 			}
 
 			.draft {

--- a/src/packages/documents/documents/tree/tree-item/document-tree-item.element.ts
+++ b/src/packages/documents/documents/tree/tree-item/document-tree-item.element.ts
@@ -134,12 +134,27 @@ export class UmbDocumentTreeItemElement extends UmbTreeItemElementBase<UmbDocume
 				background: var(--uui-color-surface-emphasis);
 			}
 
+			/** Active */
 			[active] #icon-lock {
 				background: var(--uui-color-current);
 			}
 
 			[active]:hover #icon-lock {
 				background: var(--uui-color-current-emphasis);
+			}
+
+			/** Selected */
+			[selected] #icon-lock {
+				background-color: var(--uui-color-selected);
+			}
+
+			[selected]:hover #icon-lock {
+				background-color: var(--uui-color-selected-emphasis);
+			}
+
+			/** Disabled */
+			[disabled] #icon-lock {
+				background-color: var(--uui-color-disabled);
 			}
 
 			.draft {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/16548

This PR ensures that the "Public Access"-entity action is wired up. The PR also adds an icon to the document tree item to show when a document is protected.

The member endpoints require access to the member section to work. We have the same limitation in V13. I have decided to hide the "Public Access"-entity access if a user doesn't have access to the member section. Then we prevent the UI from exploding.

**What to test:**
* Set public access settings for a document
  * individual members
  * member groups
* Remove public settings for a document
* Check that the protected icon is shown in the tree

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)