### PR TITLE
Bugfix: Workspace breadcrumbs, error when new at root

### DIFF
--- a/src/packages/core/menu/menu-tree-structure-workspace-context-base.ts
+++ b/src/packages/core/menu/menu-tree-structure-workspace-context-base.ts
@@ -58,28 +58,31 @@ export abstract class UmbMenuTreeStructureWorkspaceContextBase extends UmbContex
 		}
 
 		const isNew = this.#workspaceContext?.getIsNew();
-		const uniqueObservable = isNew ? this.#workspaceContext?.parentUnique : this.#workspaceContext?.unique;
+
 		const entityTypeObservable = isNew ? this.#workspaceContext?.parentEntityType : this.#workspaceContext?.entityType;
-
-		const unique = (await this.observe(uniqueObservable, () => {})?.asPromise()) as string;
-		if (!unique) throw new Error('Unique is not available');
-
 		const entityType = (await this.observe(entityTypeObservable, () => {})?.asPromise()) as string;
 		if (!entityType) throw new Error('Entity type is not available');
 
-		const { data } = await treeRepository.requestTreeItemAncestors({ treeItem: { unique, entityType } });
+		// If the entity type is different from the root entity type, then we can request the ancestors.
+		if (entityType !== root?.entityType) {
+			const uniqueObservable = isNew ? this.#workspaceContext?.parentUnique : this.#workspaceContext?.unique;
+			const unique = (await this.observe(uniqueObservable, () => {})?.asPromise()) as string;
+			if (!unique) throw new Error('Unique is not available');
 
-		if (data) {
-			const ancestorItems = data.map((treeItem) => {
-				return {
-					unique: treeItem.unique,
-					entityType: treeItem.entityType,
-					name: treeItem.name,
-					isFolder: treeItem.isFolder,
-				};
-			});
+			const { data } = await treeRepository.requestTreeItemAncestors({ treeItem: { unique, entityType } });
 
-			structureItems.push(...ancestorItems);
+			if (data) {
+				const ancestorItems = data.map((treeItem) => {
+					return {
+						unique: treeItem.unique,
+						entityType: treeItem.entityType,
+						name: treeItem.name,
+						isFolder: treeItem.isFolder,
+					};
+				});
+
+				structureItems.push(...ancestorItems);
+			}
 		}
 
 		const parent = structureItems[structureItems.length - 2];


### PR DESCRIPTION
## Description

When creating a new entity at the root, the workspace breadcrumbs (menu-tree-structure) code will throw an error in the console...

```
menu-tree-structure-workspace-context-base.ts:65 Uncaught (in promise) Error: Unique is not available
    at #requestStructure (menu-tree-structure-workspace-context-base.ts:65:22)
```

![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/752371/f9825451-3f71-4785-bbb7-4c5cfef28214)

This is because the entity root's unique value is typically set to `null`.

This fix moves the `entityType` observer before the `unique` observer, then checks if the entity-type is the same as the root's entity-type, if so, then there is no need to request the ancestor tree items.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
