### PR TITLE
Makes the styles optional in stylesheets

### DIFF
--- a/src/packages/templating/stylesheets/components/stylesheet-rule-input/stylesheet-rule-settings-modal.element.ts
+++ b/src/packages/templating/stylesheets/components/stylesheet-rule-input/stylesheet-rule-settings-modal.element.ts
@@ -75,7 +75,7 @@ export default class UmbStylesheetRuleSettingsModalElement extends UmbModalBaseE
 									</uui-input>
 								</uui-form-layout-item>
 								<uui-form-layout-item>
-									<uui-label for="styles" slot="label" required="">Styles</uui-label>
+									<uui-label for="styles" slot="label">Styles</uui-label>
 									<span slot="description"
 										>The CSS that should be applied in the rich text editor, e.g. "color:red;"</span
 									>
@@ -88,7 +88,7 @@ export default class UmbStylesheetRuleSettingsModalElement extends UmbModalBaseE
 									</uui-textarea>
 								</uui-form-layout-item>
 								<uui-form-layout-item>
-									<uui-label for="styles" slot="label" required="">Preview</uui-label>
+									<uui-label for="styles" slot="label">Preview</uui-label>
 									<span slot="description">How the text will look like in the rich text editor.</span>
 									<div style="${ifDefined(this.value.rule?.styles)}">
 										a b c d e f g h i j k l m n o p q r s t u v w x t z

--- a/src/packages/templating/stylesheets/utils/stylesheet-rule-manager.ts
+++ b/src/packages/templating/stylesheets/utils/stylesheet-rule-manager.ts
@@ -43,7 +43,7 @@ export class UmbStylesheetRuleManager {
 					(rule) => `
 /**umb_name:${rule.name}*/
 ${rule.selector} {
-	${rule.styles}
+	${rule.styles ?? ''}
 }
 `,
 				)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- In stylesheets, the "styles" and "preview" is no longer showing as required.
- Leaving the styles empty in a stylesheet no longer results in "undefined" being printed in the css stylesheet.

Fixes https://github.com/umbraco/Umbraco-CMS/issues/16500

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

