### PR TITLE
Bugfix: Tinymce allows potentially unsafe embeds

### DIFF
--- a/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
+++ b/src/packages/tiny-mce/components/input-tiny-mce/input-tiny-mce.element.ts
@@ -243,6 +243,7 @@ export class UmbInputTinyMceElement extends UUIFormControlMixin(UmbLitElement, '
 			paste_data_images: false,
 			language: this.#getLanguage(),
 			promotion: false,
+			convert_unsafe_embeds: true, // [JOV] Workaround for CVE-2024-29881
 
 			// Extend with configuration options
 			...configurationOptions,


### PR DESCRIPTION
This sets `convert_unsafe_embeds` to true to act as a workaround for CVE-2024-29881 seeing that we cannot upgrade to tinymce 7 at the moment. The only difference from TinyMCE 6 to 7 in this regard is that this option is set to true and is the official workaround.

Fixes https://github.com/umbraco/Umbraco.CMS.Backoffice/security/dependabot/44