### PR TITLE
Chore: Remove arg passed to oneEvent method

### DIFF
--- a/src/libs/context-api/consume/context-consumer.test.ts
+++ b/src/libs/context-api/consume/context-consumer.test.ts
@@ -2,7 +2,7 @@ import { expect, oneEvent } from '@open-wc/testing';
 import { UmbContextProvider } from '../provide/context-provider.js';
 import { UmbContextToken } from '../token/context-token.js';
 import { UmbContextConsumer } from './context-consumer.js';
-import type { UmbContextRequestEventImplementation} from './context-request.event.js';
+import type { UmbContextRequestEventImplementation } from './context-request.event.js';
 import { UMB_CONTENT_REQUEST_EVENT_TYPE } from './context-request.event.js';
 
 const testContextAlias = 'my-test-context';
@@ -39,7 +39,7 @@ describe('UmbContextConsumer', () => {
 
 		describe('events', () => {
 			it('dispatches context request event when constructed', async () => {
-				const listener = oneEvent(window, UMB_CONTENT_REQUEST_EVENT_TYPE, false);
+				const listener = oneEvent(window, UMB_CONTENT_REQUEST_EVENT_TYPE);
 
 				consumer.hostConnected();
 

--- a/src/packages/core/property/property-dataset/property-dataset.element.test.ts
+++ b/src/packages/core/property/property-dataset/property-dataset.element.test.ts
@@ -133,7 +133,7 @@ describe('UmbBasicVariantElement', () => {
 		});
 
 		it('fires change event', async () => {
-			const listener = oneEvent(datasetElement, UmbChangeEvent.TYPE, false);
+			const listener = oneEvent(datasetElement, UmbChangeEvent.TYPE);
 
 			expect(propertyEditor.alias).to.eq('testAlias');
 			propertyEditor.setValue('testValue3');
@@ -153,7 +153,7 @@ describe('UmbBasicVariantElement', () => {
 			adapterPropertyEditor.alias = 'testAdapterAlias';
 			datasetElement.appendChild(adapterPropertyEditor);
 
-			const listener = oneEvent(datasetElement, UmbChangeEvent.TYPE, false);
+			const listener = oneEvent(datasetElement, UmbChangeEvent.TYPE);
 
 			// The alias of the original property editor must be 'testAlias' for the adapter to set the value of it.
 			expect(propertyEditor.alias).to.eq('testAlias');

--- a/src/packages/core/utils/pagination-manager/pagination.manager.test.ts
+++ b/src/packages/core/utils/pagination-manager/pagination.manager.test.ts
@@ -141,7 +141,7 @@ describe('UmbPaginationManager', () => {
 		});
 
 		it('dispatches a change event', async () => {
-			const listener = oneEvent(manager, UmbChangeEvent.TYPE, false);
+			const listener = oneEvent(manager, UmbChangeEvent.TYPE);
 			manager.setCurrentPageNumber(2);
 			const event = (await listener) as unknown as UmbChangeEvent;
 			const target = event.target as UmbPaginationManager;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The method only takes 2 arguments, but we pass 3. I don't know why this hasn't shown up before.

<!--- Describe the changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
