### PR TITLE
Bugfix: Custom menu item label ellipsis

### DIFF
--- a/src/packages/documents/documents/tree/tree-item/document-tree-item.element.ts
+++ b/src/packages/documents/documents/tree/tree-item/document-tree-item.element.ts
@@ -130,6 +130,12 @@ export class UmbDocumentTreeItemElement extends UmbTreeItemElementBase<UmbDocume
 				line-height: 14px;
 			}
 
+			#label {
+				white-space: nowrap;
+				overflow: hidden;
+				text-overflow: ellipsis;
+			}
+
 			:hover #icon-lock {
 				background: var(--uui-color-surface-emphasis);
 			}

--- a/src/packages/media/media/tree/tree-item/media-tree-item.element.ts
+++ b/src/packages/media/media/tree/tree-item/media-tree-item.element.ts
@@ -30,6 +30,12 @@ export class UmbMediaTreeItemElement extends UmbTreeItemElementBase<UmbMediaTree
 			#icon {
 				vertical-align: middle;
 			}
+
+			#label {
+				white-space: nowrap;
+				overflow: hidden;
+				text-overflow: ellipsis;
+			}
 		`,
 	];
 }


### PR DESCRIPTION
Fixes our custom menu item labels in documents and media so that it correctly shows ellipsis

Before:
<img width="273" alt="image" src="https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/26099018/5dc3276f-839d-42d2-923d-197a4b638387">

After:
<img width="253" alt="image" src="https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/26099018/87ed061a-8866-4cf2-9430-4f9e6fabe5a8">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
