### PR TITLE
Feature: Readonly mode for Toggle Property Editor UI

### DIFF
--- a/src/packages/core/components/input-toggle/input-toggle.element.ts
+++ b/src/packages/core/components/input-toggle/input-toggle.element.ts
@@ -26,6 +26,15 @@ export class UmbInputToggleElement extends UUIFormControlMixin(UmbLitElement, ''
 	@property({ type: String })
 	labelOff?: string;
 
+	/**
+	 * Sets the input to readonly mode, meaning value cannot be changed but still able to read and select its content.
+	 * @type {boolean}
+	 * @attr
+	 * @default false
+	 */
+	@property({ type: Boolean, reflect: true })
+	readonly = false;
+
 	@state()
 	_currentLabel?: string;
 
@@ -52,7 +61,8 @@ export class UmbInputToggleElement extends UUIFormControlMixin(UmbLitElement, ''
 		return html`<uui-toggle
 			.checked=${this.#checked}
 			.label=${this._currentLabel}
-			@change=${this.#onChange}></uui-toggle>`;
+			@change=${this.#onChange}
+			?readonly=${this.readonly}></uui-toggle>`;
 	}
 
 	static styles = [

--- a/src/packages/property-editors/toggle/property-editor-ui-toggle.element.ts
+++ b/src/packages/property-editors/toggle/property-editor-ui-toggle.element.ts
@@ -13,6 +13,15 @@ export class UmbPropertyEditorUIToggleElement extends UmbLitElement implements U
 	@property({ type: Boolean })
 	value: undefined | boolean = undefined;
 
+	/**
+	 * Sets the input to readonly mode, meaning value cannot be changed but still able to read and select its content.
+	 * @type {boolean}
+	 * @attr
+	 * @default false
+	 */
+	@property({ type: Boolean, reflect: true })
+	readonly = false;
+
 	@state()
 	_labelOff?: string;
 
@@ -42,7 +51,8 @@ export class UmbPropertyEditorUIToggleElement extends UmbLitElement implements U
 				.labelOff=${this._labelOff}
 				?checked=${this.value}
 				?showLabels=${this._showLabels}
-				@change=${this.#onChange}>
+				@change=${this.#onChange}
+				?readonly=${this.readonly}>
 			</umb-input-toggle>
 		`;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds `readonly` mode to the Toggle Property Editor UI

## How to test

* Add the `readonly` attribute to the element through developer tools

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)