### PR TITLE
Bugfix: Block types do not show their descriptions

### DIFF
--- a/src/packages/block/block-type/components/block-type-card/block-type-card.element.ts
+++ b/src/packages/block/block-type/components/block-type-card/block-type-card.element.ts
@@ -47,6 +47,9 @@ export class UmbBlockTypeCardElement extends UmbLitElement {
 	_name?: string;
 
 	@state()
+	_description?: string;
+
+	@state()
 	_fallbackIcon?: string | null;
 
 	constructor() {
@@ -57,6 +60,7 @@ export class UmbBlockTypeCardElement extends UmbLitElement {
 			if (item) {
 				this._fallbackIcon = item.icon;
 				this._name = item.name;
+				this._description = item.description ?? undefined;
 			}
 		});
 	}
@@ -67,6 +71,7 @@ export class UmbBlockTypeCardElement extends UmbLitElement {
 			<uui-card-block-type
 				href=${ifDefined(this.href)}
 				.name=${this._name ?? 'Unknown'}
+				.description=${this._description}
 				.background=${this.backgroundColor}>
 				${this.iconFile
 					? html`<img src=${this.iconFile} alt="" />`

--- a/src/packages/documents/document-types/repository/item/document-type-item.server.data-source.ts
+++ b/src/packages/documents/document-types/repository/item/document-type-item.server.data-source.ts
@@ -35,5 +35,6 @@ const mapper = (item: DocumentTypeItemResponseModel): UmbDocumentTypeItemModel =
 		icon: item.icon,
 		unique: item.id,
 		name: item.name,
+		description: item.description,
 	};
 };

--- a/src/packages/documents/document-types/repository/item/types.ts
+++ b/src/packages/documents/document-types/repository/item/types.ts
@@ -6,4 +6,5 @@ export type UmbDocumentTypeItemModel = {
 	name: string;
 	isElement: boolean;
 	icon?: string | null;
+	description?: string | null;
 };


### PR DESCRIPTION
## Description

This maps the `description` property to the doc type model and displays it for block types.

Since the `description` field was added in https://github.com/umbraco/Umbraco-CMS/pull/16503 it is now possible to fix this issue.

Fixes https://github.com/umbraco/Umbraco-CMS/issues/16642

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## How to test?

1. Add a description to an element type and add that type to a block property editor
2. Add at least an addition block type (otherwise the block catalogue will not be shown)
3. Verify that the description is shown underneath the name

## Screenshots (if appropriate)

**Before**
![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/752371/450fb9af-2f9a-4c9b-8fb3-60df3e71dcd8)

**After**
![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/752371/61809daf-5b83-4518-bb1b-6dbaf1a49ec8)
