### PR TITLE
Make allowAtRoot preset for Block Grid Types

### DIFF
--- a/src/packages/block/block-grid/components/block-grid-area-config-entry/workspace/block-grid-area-type-workspace.context.ts
+++ b/src/packages/block/block-grid/components/block-grid-area-config-entry/workspace/block-grid-area-type-workspace.context.ts
@@ -1,11 +1,10 @@
 import type { UmbBlockGridTypeAreaType } from '../../../types.js';
 import type { UmbPropertyDatasetContext } from '@umbraco-cms/backoffice/property';
 import { UMB_PROPERTY_CONTEXT } from '@umbraco-cms/backoffice/property';
-import {
-	type UmbInvariantDatasetWorkspaceContext,
-	type UmbRoutableWorkspaceContext,
-	type UmbWorkspaceContext,
-	UmbWorkspaceRouteManager,
+import type {
+	UmbInvariantDatasetWorkspaceContext,
+	UmbRoutableWorkspaceContext,
+	UmbWorkspaceContext,
 } from '@umbraco-cms/backoffice/workspace';
 import {
 	UmbSubmittableWorkspaceContextBase,

--- a/src/packages/block/block-grid/property-editors/block-grid-type-configuration/property-editor-ui-block-grid-type-configuration.element.ts
+++ b/src/packages/block/block-grid/property-editors/block-grid-type-configuration/property-editor-ui-block-grid-type-configuration.element.ts
@@ -17,14 +17,13 @@ import {
 } from '@umbraco-cms/backoffice/property-editor';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import { UMB_BLOCK_GRID_TYPE, type UmbBlockGridTypeGroupType } from '@umbraco-cms/backoffice/block-grid';
+import { UMB_BLOCK_GRID_TYPE, UMB_BLOCK_GRID_TYPE_WORKSPACE_MODAL, type UmbBlockGridTypeGroupType } from '@umbraco-cms/backoffice/block-grid';
 import type { UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
 import {
 	UMB_PROPERTY_CONTEXT,
 	UMB_PROPERTY_DATASET_CONTEXT,
 	type UmbPropertyDatasetContext,
 } from '@umbraco-cms/backoffice/property';
-import { UMB_WORKSPACE_MODAL } from '@umbraco-cms/backoffice/modal';
 import { UmbModalRouteRegistrationController } from '@umbraco-cms/backoffice/router';
 import { UmbSorterController } from '@umbraco-cms/backoffice/sorter';
 
@@ -61,8 +60,8 @@ export class UmbPropertyEditorUIBlockGridTypeConfigurationElement
 
 	#datasetContext?: UmbPropertyDatasetContext;
 	#blockTypeWorkspaceModalRegistration?: UmbModalRouteRegistrationController<
-		typeof UMB_WORKSPACE_MODAL.DATA,
-		typeof UMB_WORKSPACE_MODAL.VALUE
+		typeof UMB_BLOCK_GRID_TYPE_WORKSPACE_MODAL.DATA,
+		typeof UMB_BLOCK_GRID_TYPE_WORKSPACE_MODAL.VALUE
 	>;
 
 	#value: Array<UmbBlockTypeWithGroupKey> = [];
@@ -105,11 +104,8 @@ export class UmbPropertyEditorUIBlockGridTypeConfigurationElement
 			this.#observeBlockGroups();
 		});
 
-		this.#blockTypeWorkspaceModalRegistration = new UmbModalRouteRegistrationController(this, UMB_WORKSPACE_MODAL)
+		this.#blockTypeWorkspaceModalRegistration = new UmbModalRouteRegistrationController(this, UMB_BLOCK_GRID_TYPE_WORKSPACE_MODAL)
 			.addAdditionalPath(UMB_BLOCK_GRID_TYPE)
-			.onSetup(() => {
-				return { data: { entityType: UMB_BLOCK_GRID_TYPE, preset: {} }, modal: { size: 'large' } };
-			})
 			.observeRouteBuilder((routeBuilder) => {
 				const newpath = routeBuilder({});
 				this._workspacePath = newpath;

--- a/src/packages/block/block-grid/workspace/block-grid-type-workspace.modal-token.ts
+++ b/src/packages/block/block-grid/workspace/block-grid-type-workspace.modal-token.ts
@@ -1,0 +1,17 @@
+import { UMB_BLOCK_GRID_TYPE, type UmbBlockGridTypeModel } from '../types.js';
+import type { UmbWorkspaceModalData, UmbWorkspaceModalValue } from '@umbraco-cms/backoffice/modal';
+import { UmbModalToken } from '@umbraco-cms/backoffice/modal';
+
+export type UmbBlockGridTypeWorkspaceData = UmbWorkspaceModalData<UmbBlockGridTypeModel>;
+
+export const UMB_BLOCK_GRID_TYPE_WORKSPACE_MODAL = new UmbModalToken<UmbBlockGridTypeWorkspaceData, UmbWorkspaceModalValue>(
+	'Umb.Modal.Workspace',
+	{
+		modal: {
+			type: 'sidebar',
+			size: 'large',
+		},
+		data: { entityType: UMB_BLOCK_GRID_TYPE, preset: {allowAtRoot: true} },
+	},
+	// Recast the type, so the entityType data prop is not required:
+) as UmbModalToken<Omit<UmbWorkspaceModalData, 'entityType' | 'preset'>, UmbWorkspaceModalValue>;

--- a/src/packages/block/block-grid/workspace/block-grid-workspace.modal-token.ts
+++ b/src/packages/block/block-grid/workspace/block-grid-workspace.modal-token.ts
@@ -18,6 +18,6 @@ export const UMB_BLOCK_GRID_WORKSPACE_MODAL = new UmbModalToken<UmbBlockGridWork
 			size: 'medium',
 		},
 		data: { entityType: 'block', preset: {}, originData: { index: -1, parentUnique: null } },
-		// Recast the type, so the entityType data prop is not required:
 	},
+	// Recast the type, so the entityType data prop is not required:
 ) as UmbModalToken<Omit<UmbWorkspaceModalData, 'entityType'>, UmbWorkspaceModalValue>;

--- a/src/packages/block/block-grid/workspace/index.ts
+++ b/src/packages/block/block-grid/workspace/index.ts
@@ -1,2 +1,3 @@
 export const UMB_BLOCK_GRID_TYPE_WORKSPACE_ALIAS = 'Umb.Workspace.BlockGridType';
 export * from './block-grid-workspace.modal-token.js';
+export * from './block-grid-type-workspace.modal-token.js';

--- a/src/packages/block/block-list/workspace/block-list-workspace.modal-token.ts
+++ b/src/packages/block/block-list/workspace/block-list-workspace.modal-token.ts
@@ -16,6 +16,6 @@ export const UMB_BLOCK_LIST_WORKSPACE_MODAL = new UmbModalToken<UmbBlockListWork
 			size: 'medium',
 		},
 		data: { entityType: 'block', preset: {}, originData: { index: -1 } },
-		// Recast the type, so the entityType data prop is not required:
 	},
+	// Recast the type, so the entityType data prop is not required:
 ) as UmbModalToken<Omit<UmbWorkspaceModalData, 'entityType'>, UmbWorkspaceModalValue>;

--- a/src/packages/block/block-rte/workspace/block-rte-workspace.modal-token.ts
+++ b/src/packages/block/block-rte/workspace/block-rte-workspace.modal-token.ts
@@ -12,6 +12,6 @@ export const UMB_BLOCK_RTE_WORKSPACE_MODAL = new UmbModalToken<UmbBlockRteWorksp
 			size: 'medium',
 		},
 		data: { entityType: 'block', preset: {}, originData: {} },
-		// Recast the type, so the entityType data prop is not required:
 	},
+	// Recast the type, so the entityType data prop is not required:
 ) as UmbModalToken<Omit<UmbWorkspaceModalData, 'entityType'>, UmbWorkspaceModalValue>;

--- a/src/packages/block/block-type/workspace/block-type-workspace.context.ts
+++ b/src/packages/block/block-type/workspace/block-type-workspace.context.ts
@@ -10,7 +10,6 @@ import {
 	UmbSubmittableWorkspaceContextBase,
 	UmbInvariantWorkspacePropertyDatasetContext,
 	UmbWorkspaceIsNewRedirectController,
-	UmbWorkspaceRouteManager,
 } from '@umbraco-cms/backoffice/workspace';
 import { UmbArrayState, UmbObjectState, appendToFrozenArray } from '@umbraco-cms/backoffice/observable-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
@@ -99,11 +98,21 @@ export class UmbBlockTypeWorkspaceContext<BlockTypeData extends UmbBlockTypeWith
 
 	async create(contentElementTypeId: string, groupKey?: string | null) {
 		this.resetState();
-		//Only set groupKey property if it exists
-		const data: BlockTypeData = {
-			contentElementTypeKey: contentElementTypeId,
-			...(groupKey && { groupKey: groupKey }),
+
+
+		let data: BlockTypeData = {
+			contentElementTypeKey: contentElementTypeId
 		} as BlockTypeData;
+
+		// If we have a modal context, we blend in the modal preset data: [NL]
+		if (this.modalContext) {
+			data = { ...data, ...this.modalContext.data.preset };
+		}
+
+		// Only set groupKey property if it has been parsed to this method
+		if (groupKey) {
+			data.groupKey = groupKey;
+		}
 
 		this.setIsNew(true);
 		this.#data.setValue(data);

--- a/src/packages/block/block/workspace/block-workspace.modal-token.ts
+++ b/src/packages/block/block/workspace/block-workspace.modal-token.ts
@@ -13,6 +13,6 @@ export const UMB_BLOCK_WORKSPACE_MODAL = new UmbModalToken<UmbBlockWorkspaceData
 			size: 'large',
 		},
 		data: { entityType: 'block', preset: {}, originData: {} },
-		// Recast the type, so the entityType data prop is not required:
 	},
+	// Recast the type, so the entityType data prop is not required:
 ) as UmbModalToken<Omit<UmbWorkspaceModalData, 'entityType'>, UmbWorkspaceModalValue>;

--- a/src/packages/core/modal/context/modal.context.ts
+++ b/src/packages/core/modal/context/modal.context.ts
@@ -26,7 +26,7 @@ export type UmbModalContextClassArgs<
 
 // TODO: consider splitting this into two separate handlers
 export class UmbModalContext<
-	ModalPreset extends { [key: string]: any } = { [key: string]: any },
+	ModalData extends { [key: string]: any } = { [key: string]: any },
 	ModalValue = any,
 > extends UmbControllerBase {
 	//
@@ -35,19 +35,19 @@ export class UmbModalContext<
 	#submitRejecter?: (reason?: UmbModalRejectReason) => void;
 
 	public readonly key: string;
-	public readonly data: ModalPreset;
+	public readonly data: ModalData;
 	public readonly type: UmbModalType = 'dialog';
 	public readonly size: UUIModalSidebarSize = 'small';
 	public readonly backdropBackground?: string;
 	public readonly router: IRouterSlot | null = null;
-	public readonly alias: string | UmbModalToken<ModalPreset, ModalValue>;
+	public readonly alias: string | UmbModalToken<ModalData, ModalValue>;
 
 	#value;
 	public readonly value;
 
 	constructor(
 		host: UmbControllerHost,
-		modalAlias: string | UmbModalToken<ModalPreset, ModalValue>,
+		modalAlias: string | UmbModalToken<ModalData, ModalValue>,
 		args: UmbModalContextClassArgs<UmbModalToken>,
 	) {
 		super(host);
@@ -69,9 +69,9 @@ export class UmbModalContext<
 		this.data = Object.freeze(
 			// If we have both data and defaultData perform a deep merge
 			args.data && defaultData
-				? (umbDeepMerge(args.data as UmbDeepPartialObject<ModalPreset>, defaultData) as ModalPreset)
+				? (umbDeepMerge(args.data as UmbDeepPartialObject<ModalData>, defaultData) as ModalData)
 				: // otherwise pick one of them:
-					(args.data as ModalPreset) ?? defaultData,
+					(args.data as ModalData) ?? defaultData,
 		);
 
 		const initValue =

--- a/src/packages/data-type/workspace/data-type-workspace.modal-token.ts
+++ b/src/packages/data-type/workspace/data-type-workspace.modal-token.ts
@@ -1,6 +1,6 @@
-import type { UmbDataTypeDetailModel } from '../types.js';
 import type { UmbWorkspaceModalData, UmbWorkspaceModalValue } from '@umbraco-cms/backoffice/modal';
 import { UmbModalToken } from '@umbraco-cms/backoffice/modal';
+import type { UmbDataTypeDetailModel } from '../types.js';
 
 export const UMB_DATATYPE_WORKSPACE_MODAL = new UmbModalToken<
 	UmbWorkspaceModalData<UmbDataTypeDetailModel>,

--- a/src/packages/documents/document-types/workspace/document-type-workspace.modal-token.ts
+++ b/src/packages/documents/document-types/workspace/document-type-workspace.modal-token.ts
@@ -1,7 +1,7 @@
-import { UMB_DOCUMENT_TYPE_ENTITY_TYPE } from '../entity.js';
 import { UMB_WORKSPACE_MODAL, UmbModalToken } from '@umbraco-cms/backoffice/modal';
 import type { UmbDeepPartialObject } from '@umbraco-cms/backoffice/utils';
 import type { UmbWorkspaceModalData, UmbWorkspaceModalValue } from '@umbraco-cms/backoffice/modal';
+import { UMB_DOCUMENT_TYPE_ENTITY_TYPE } from '../entity.js';
 
 export interface UmbDocumentTypeWorkspaceData extends UmbWorkspaceModalData {}
 

--- a/src/packages/language/workspace/language/language-workspace.modal-token.ts
+++ b/src/packages/language/workspace/language/language-workspace.modal-token.ts
@@ -1,6 +1,6 @@
-import type { UmbLanguageDetailModel } from '../../types.js';
 import type { UmbWorkspaceModalData, UmbWorkspaceModalValue } from '@umbraco-cms/backoffice/modal';
 import { UmbModalToken } from '@umbraco-cms/backoffice/modal';
+import type { UmbLanguageDetailModel } from '../../types.js';
 
 export const UMB_LANGUAGE_WORKSPACE_MODAL = new UmbModalToken<
 	UmbWorkspaceModalData<UmbLanguageDetailModel>,


### PR DESCRIPTION
Makes `Allow in root` checked when creating a new Block Type

![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/6791648/92e8988a-8f92-47c6-ab59-6f38d607c483)

Fixes https://github.com/umbraco/Umbraco-CMS/issues/16466


## Description

<!--- Describe the changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
