### PR TITLE
Block Grid: fallback to layout columns if no proper options

### DIFF
--- a/src/packages/block/block-grid/context/block-grid-entry.context.ts
+++ b/src/packages/block/block-grid/context/block-grid-entry.context.ts
@@ -217,7 +217,6 @@ export class UmbBlockGridEntryContext
 				if (newColumnSpan !== columnSpan) {
 					const layoutValue = this._layout.getValue();
 					if (!layoutValue) return;
-					console.log("newColumnSpan", newColumnSpan)
 					this._layout.setValue({
 						...layoutValue,
 						columnSpan: newColumnSpan,

--- a/src/packages/block/block/context/block-entries.context.ts
+++ b/src/packages/block/block/context/block-entries.context.ts
@@ -62,7 +62,6 @@ export abstract class UmbBlockEntriesContext<
 		return this._layoutEntries.setValue(layouts);
 	}
 	setOneLayout(layoutData: BlockLayoutType) {
-		console.log('setOneLayout', layoutData);
 		return this._layoutEntries.appendOne(layoutData);
 	}
 

--- a/src/packages/block/block/context/block-entry.context.ts
+++ b/src/packages/block/block/context/block-entry.context.ts
@@ -334,7 +334,6 @@ export abstract class UmbBlockEntryContext<
 				this.settings,
 				(settings) => {
 					if (settings) {
-						console.log('settings to be set', this.#contentUdi, settings);
 						this._manager?.setOneSettings(settings);
 					}
 				},

--- a/src/packages/block/block/context/block-entry.context.ts
+++ b/src/packages/block/block/context/block-entry.context.ts
@@ -307,6 +307,9 @@ export abstract class UmbBlockEntryContext<
 			},
 			'observeContent',
 		);
+		/*
+
+			This two way binding does not work well, might need to further investigate what the exact problem is.
 		this.observe(
 			this.content,
 			(content) => {
@@ -316,6 +319,7 @@ export abstract class UmbBlockEntryContext<
 			},
 			'observeInternalContent',
 		);
+		*/
 
 		// observe settings:
 		const settingsUdi = this._layout.value?.settingsUdi;

--- a/src/packages/block/block/context/block-entry.context.ts
+++ b/src/packages/block/block/context/block-entry.context.ts
@@ -355,8 +355,6 @@ export abstract class UmbBlockEntryContext<
 		this.observe(
 			this._manager.contentTypeOf(contentTypeKey),
 			(contentType) => {
-				//this.#contentElementTypeAlias.setValue(contentType?.alias);
-				//this.#contentElementTypeName.setValue(contentType?.name);
 				this.#contentElementType.setValue(contentType);
 				this._gotContentType(contentType);
 			},

--- a/src/packages/block/block/context/block-entry.context.ts
+++ b/src/packages/block/block/context/block-entry.context.ts
@@ -309,7 +309,7 @@ export abstract class UmbBlockEntryContext<
 		);
 		/*
 
-			This two way binding does not work well, might need to further investigate what the exact problem is.
+		This two way binding does not work well, might need to further investigate what the exact problem is.
 		this.observe(
 			this.content,
 			(content) => {


### PR DESCRIPTION
Makes a Block with no Column Span options, get corrected to the local layout columns(if in area, then that is the columns of the area).

Before this did no happen and a Block would not get any column span, it would look 1 column wide, aka. spanning only one column.

## Description

<!--- Describe the changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
