### PR TITLE
V14/bugfix/missing css vars

### DIFF
--- a/src/packages/user/current-user/modals/current-user/current-user-modal.element.ts
+++ b/src/packages/user/current-user/modals/current-user/current-user-modal.element.ts
@@ -84,6 +84,9 @@ export class UmbCurrentUserModalElement extends UmbLitElement {
 	static override styles: CSSResultGroup = [
 		UmbTextStyles,
 		css`
+			:host {
+				color: var(--uui-color-text);
+			}
 			#main {
 				display: flex;
 				flex-direction: column;

--- a/src/packages/user/current-user/theme/current-user-theme-user-profile-app.element.ts
+++ b/src/packages/user/current-user/theme/current-user-theme-user-profile-app.element.ts
@@ -1,4 +1,4 @@
-import { css, html, customElement, state, nothing } from '@umbraco-cms/backoffice/external/lit';
+import { css, html, customElement, state, nothing, repeat } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { UMB_THEME_CONTEXT } from '@umbraco-cms/backoffice/themes';
@@ -50,15 +50,28 @@ export class UmbCurrentUserThemeUserProfileAppElement extends UmbLitElement {
 		return html`
 			<uui-box headline="Theme">
 				<uui-tag slot="headline" look="placeholder">Experimental</uui-tag>
-				<uui-select label="Select theme" .options=${this._themes} @change=${this.#onThemeChange}></uui-select>
+				<select label="Select theme" @change=${this.#onThemeChange}>
+					${repeat(
+						this._themes,
+						(theme) => theme.value,
+						(theme) => html`<option value=${theme.value} ?selected=${theme.selected}>${theme.name}</option>`,
+					)}
+				</select>
 			</uui-box>
 		`;
 	}
 
 	static override styles = [
 		css`
-			uui-select {
+			select {
 				width: 100%;
+				font: inherit;
+				color: var(--uui-color-text);
+				background-color: var(--uui-color-surface);
+				padding: var(--uui-size-1) var(--uui-size-space-3);
+				border: 1px solid var(--uui-color-border);
+				height: var(--uui-size-11);
+				box-sizing: border-box;
 			}
 		`,
 	];


### PR DESCRIPTION
Adds missing css vars to the current user modal.

Before
<img width="488" alt="image" src="https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/26099018/24f761ce-06eb-4540-b6b6-92b74babe416">

After
<img width="449" alt="image" src="https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/26099018/8a09b21c-3a76-42e2-aac4-8d4b27cf7563">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
