### PR TITLE
Bugfix: Remove image card when trashed outside a property editor

### DIFF
--- a/src/packages/media/media/components/input-media/input-media.element.ts
+++ b/src/packages/media/media/components/input-media/input-media.element.ts
@@ -141,7 +141,7 @@ export class UmbInputMediaElement extends UUIFormControlMixin(UmbLitElement, '')
 
 		this.observe(this.#pickerContext.selectedItems, async (selectedItems) => {
 			const missingCards = selectedItems.filter((item) => !this._cards.find((card) => card.unique === item.unique));
-			if (!missingCards.length) return;
+			if (selectedItems?.length && !missingCards.length) return;
 
 			if (!selectedItems?.length) {
 				this._cards = [];


### PR DESCRIPTION
## Description

The last image card would not be removed (when trashing it) from `umb-input-media` when outside a property editor.
Fixes https://github.com/umbraco/Umbraco.CMS.Backoffice/issues/2032

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
