### PR TITLE
Bugfix: Package Builder import errors

### DIFF
--- a/src/packages/data-type/components/data-type-flow-input/data-type-flow-input.element.ts
+++ b/src/packages/data-type/components/data-type-flow-input/data-type-flow-input.element.ts
@@ -1,10 +1,10 @@
-import { UMB_DATATYPE_WORKSPACE_MODAL } from '../../index.js';
-import { UMB_DATA_TYPE_PICKER_FLOW_MODAL } from '../../modals/index.js';
 import { css, html, customElement, property, state } from '@umbraco-cms/backoffice/external/lit';
 import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbModalRouteRegistrationController } from '@umbraco-cms/backoffice/router';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
+import { UMB_DATA_TYPE_PICKER_FLOW_MODAL } from '../../modals/index.js';
+import { UMB_DATATYPE_WORKSPACE_MODAL } from '../../workspace/index.js';
 
 // Note: Does only support picking a single data type. But this could be developed later into this same component. To follow other picker input components.
 /**

--- a/src/packages/data-type/components/data-type-input/index.ts
+++ b/src/packages/data-type/components/data-type-input/index.ts
@@ -1,0 +1,2 @@
+export * from './data-type-input.element.js';
+export * from './data-type-input.context.js';

--- a/src/packages/data-type/components/index.ts
+++ b/src/packages/data-type/components/index.ts
@@ -2,3 +2,5 @@ import './data-type-input/data-type-input.element.js';
 import './data-type-flow-input/data-type-flow-input.element.js';
 import './ref-data-type/ref-data-type.element.js';
 import './property-editor-config/property-editor-config.element.js';
+
+export * from './data-type-input/index.js';

--- a/src/packages/dictionary/components/index.ts
+++ b/src/packages/dictionary/components/index.ts
@@ -1,0 +1,1 @@
+export * from './input-dictionary/index.js';

--- a/src/packages/dictionary/components/input-dictionary/index.ts
+++ b/src/packages/dictionary/components/input-dictionary/index.ts
@@ -1,0 +1,1 @@
+export * from './input-dictionary.context.js';

--- a/src/packages/dictionary/index.ts
+++ b/src/packages/dictionary/index.ts
@@ -2,3 +2,4 @@ export * from './repository/index.js';
 export * from './tree/index.js';
 export * from './modals/dictionary-picker-modal.token.js';
 export * from './entity.js';
+export * from './components/index.js';

--- a/src/packages/packages/package-builder/workspace/workspace-package-builder.element.ts
+++ b/src/packages/packages/package-builder/workspace/workspace-package-builder.element.ts
@@ -1,12 +1,12 @@
-import { UmbDictionaryPickerContext } from '../../../dictionary/components/input-dictionary/input-dictionary.context.js';
 import { UmbPackageRepository } from '../../package/repository/index.js';
-import { UmbPartialViewPickerContext } from '../../../templating/partial-views/components/input-partial-view/input-partial-view.context.js';
-import { UmbScriptPickerContext } from '../../../templating/scripts/components/input-script/input-script.context.js';
-import { UmbStylesheetPickerContext } from '../../../templating/stylesheets/components/stylesheet-input/stylesheet-input.context.js';
-import { UmbTemplatePickerContext } from '../../../templating/templates/components/input-template/input-template.context.js';
 import type { UmbCreatedPackageDefinition } from '../../types.js';
-import type { UmbDataTypeInputElement } from '../../../data-type/components/data-type-input/data-type-input.element.js';
-import type { UmbInputLanguageElement } from '../../../language/components/input-language/input-language.element.js';
+import { UmbDictionaryPickerContext } from '@umbraco-cms/backoffice/dictionary';
+import { UmbPartialViewPickerContext } from '@umbraco-cms/backoffice/partial-view';
+import { UmbScriptPickerContext } from '@umbraco-cms/backoffice/script';
+import { UmbStylesheetPickerContext } from '@umbraco-cms/backoffice/stylesheet';
+import { UmbTemplatePickerContext } from '@umbraco-cms/backoffice/template';
+import type { UmbDataTypeInputElement } from '@umbraco-cms/backoffice/data-type';
+import type { UmbInputLanguageElement } from '@umbraco-cms/backoffice/language';
 import {
 	css,
 	html,

--- a/src/packages/templating/partial-views/components/index.ts
+++ b/src/packages/templating/partial-views/components/index.ts
@@ -1,0 +1,1 @@
+export * from './input-partial-view/index.js';

--- a/src/packages/templating/partial-views/components/input-partial-view/index.ts
+++ b/src/packages/templating/partial-views/components/input-partial-view/index.ts
@@ -1,0 +1,1 @@
+export * from './input-partial-view.context.js';

--- a/src/packages/templating/partial-views/index.ts
+++ b/src/packages/templating/partial-views/index.ts
@@ -1,4 +1,5 @@
-export * from './repository/index.js';
+export * from './components/index.js';
 export * from './entity.js';
+export * from './repository/index.js';
 
 export { UMB_PARTIAL_VIEW_PICKER_MODAL } from './partial-view-picker/index.js';

--- a/src/packages/templating/scripts/components/index.ts
+++ b/src/packages/templating/scripts/components/index.ts
@@ -1,0 +1,1 @@
+export * from './input-script/index.js';

--- a/src/packages/templating/scripts/components/input-script/index.ts
+++ b/src/packages/templating/scripts/components/input-script/index.ts
@@ -1,0 +1,1 @@
+export * from './input-script.context.js';

--- a/src/packages/templating/scripts/index.ts
+++ b/src/packages/templating/scripts/index.ts
@@ -1,7 +1,8 @@
+export * from './components/index.js';
+export * from './entity.js';
 export * from './repository/index.js';
-export * from './workspace/script-workspace.context-token.js';
 export * from './tree/index.js';
 export * from './types.js';
-export * from './entity.js';
+export * from './workspace/script-workspace.context-token.js';
 
 export { UMB_SCRIPT_PICKER_MODAL } from './modals/script-picker-modal.token.js';

--- a/src/packages/templating/stylesheets/components/index.ts
+++ b/src/packages/templating/stylesheets/components/index.ts
@@ -2,8 +2,6 @@ import './stylesheet-input/stylesheet-input.element.js';
 import './stylesheet-rule-input/stylesheet-rule-input.element.js';
 import './stylesheet-rule-ref/stylesheet-rule-ref.element.js';
 
-export * from './stylesheet-input/stylesheet-input.element.js';
+export * from './stylesheet-input/index.js';
 export * from './stylesheet-rule-input/stylesheet-rule-input.element.js';
 export * from './stylesheet-rule-ref/stylesheet-rule-ref.element.js';
-
-export { UMB_STYLESHEET_PICKER_MODAL } from './stylesheet-input/index.js';

--- a/src/packages/templating/stylesheets/components/stylesheet-input/index.ts
+++ b/src/packages/templating/stylesheets/components/stylesheet-input/index.ts
@@ -1,1 +1,3 @@
+export * from './stylesheet-input.context.js';
+export * from './stylesheet-input.element.js';
 export { UMB_STYLESHEET_PICKER_MODAL } from './stylesheet-picker-modal.token.js';

--- a/src/packages/templating/stylesheets/index.ts
+++ b/src/packages/templating/stylesheets/index.ts
@@ -2,13 +2,9 @@ import './components/index.js';
 
 export * from './repository/index.js';
 export * from './entity.js';
+export * from './components/index.js';
 
 export { UmbStylesheetTreeRepository } from './tree/index.js';
-
-// Components
-export { UmbStylesheetRuleInputElement } from './components/index.js';
-export { UmbStylesheetInputElement } from './components/index.js';
-export { UMB_STYLESHEET_PICKER_MODAL } from './components/index.js';
 
 // Utils
 export { UmbStylesheetRuleManager } from './utils/index.js';

--- a/src/packages/templating/templates/components/index.ts
+++ b/src/packages/templating/templates/components/index.ts
@@ -1,2 +1,2 @@
 export * from './template-card/template-card.element.js';
-export * from './input-template/input-template.element.js';
+export * from './input-template/index.js';

--- a/src/packages/templating/templates/components/input-template/index.ts
+++ b/src/packages/templating/templates/components/input-template/index.ts
@@ -1,0 +1,2 @@
+export * from './input-template.context.js';
+export * from './input-template.element.js';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The Package builder was using relative imports across different packages. That doesn't work anymore because files are bundled. The correct way to import from another package is through the exposed importmap.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

