### PR TITLE
Bugfix: Collections description, removes tree child items reference

### DIFF
--- a/src/assets/lang/da-dk.ts
+++ b/src/assets/lang/da-dk.ts
@@ -1587,7 +1587,7 @@ export default {
 		requiredLabel: 'Påkrævet label',
 		enableListViewHeading: 'Aktivér listevisning',
 		enableListViewDescription:
-			'Konfigurér indholdet til at blive vist i en sortérbar og søgbar liste;\n      undersider vil ikke blive vist i træet\n    ',
+			'Konfigurér indholdet til at blive vist i en sortérbar og søgbar liste.',
 		allowedTemplatesHeading: 'Tilladte skabeloner',
 		allowedTemplatesDescription: 'Vælg hvilke skabeloner, der er tilladt at bruge på dette indhold.',
 		allowAtRootHeading: 'Tillad på rodniveau',
@@ -1682,7 +1682,7 @@ export default {
 			'Changing a data type with stored values is disabled. To allow this you can change the Umbraco:CMS:DataTypes:CanBeChanged setting in appsettings.json.',
 		collections: 'Samlinger',
 		collectionsDescription:
-			'Konfigurerer indholdselementet til at vise listen over dets underordnede elementer, underordnede elementer vil ikke blive vist i træet.',
+			'Konfigurerer indholdselementet til at vise listen over dets underordnede elementer.',
 		structure: 'Struktur',
 		presentation: 'Præsentation',
 	},

--- a/src/assets/lang/en-us.ts
+++ b/src/assets/lang/en-us.ts
@@ -1601,7 +1601,7 @@ export default {
 		requiredLabel: 'Required label',
 		enableListViewHeading: 'Enable list view',
 		enableListViewDescription:
-			'Configures the content item to show a sortable and searchable list of its\n      children, the children will not be shown in the tree\n    ',
+			'Configures the content item to show a sortable and searchable list of its children.',
 		allowedTemplatesHeading: 'Allowed Templates',
 		allowedTemplatesDescription: 'Choose which templates editors are allowed to use on content of this type',
 		allowAtRootHeading: 'Allow at root',
@@ -1694,7 +1694,7 @@ export default {
 			'Changing a data type with stored values is disabled. To allow this you can change the Umbraco:CMS:DataTypes:CanBeChanged setting in appsettings.json.',
 		collections: 'Collections',
 		collectionsDescription:
-			'Configures the content item to show list of its children, the children will not be shown in the tree.',
+			'Configures the content item to show list of its children.',
 		structure: 'Structure',
 		presentation: 'Presentation',
 	},

--- a/src/assets/lang/en.ts
+++ b/src/assets/lang/en.ts
@@ -1624,7 +1624,7 @@ export default {
 		requiredLabel: 'Required label',
 		enableListViewHeading: 'Enable list view',
 		enableListViewDescription:
-			'Configures the content item to show a sortable and searchable list of its\n      children, the children will not be shown in the tree\n    ',
+			'Configures the content item to show a sortable and searchable list of its children.',
 		allowedTemplatesHeading: 'Allowed Templates',
 		allowedTemplatesDescription: 'Choose which templates editors are allowed to use on content of this type',
 		allowAtRootHeading: 'Allow at root',
@@ -1718,7 +1718,7 @@ export default {
 			'Changing a data type with stored values is disabled. To allow this you can change the Umbraco:CMS:DataTypes:CanBeChanged setting in appsettings.json.',
 		collections: 'Collections',
 		collectionsDescription:
-			'Configures the content item to show list of its children, the children will not be shown in the tree.',
+			'Configures the content item to show list of its children.',
 		structure: 'Structure',
 		presentation: 'Presentation',
 	},


### PR DESCRIPTION
## Description

Updates Collections description to remove reference about the child items not displaying in the tree.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
