### PR TITLE
[FIX] Scroll Bar / Panel Width Adjustment cursor

### DIFF
--- a/src/packages/core/components/split-panel/split-panel.element.ts
+++ b/src/packages/core/components/split-panel/split-panel.element.ts
@@ -294,7 +294,7 @@ export class UmbSplitPanelElement extends LitElement {
 		#divider-touch-area {
 			position: absolute;
 			top: 0;
-			left: 0;
+			left: 5px;
 			height: 100%;
 			width: var(--umb-split-panel-divider-touch-area-width);
 			transform: translateX(-50%);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

You can't scroll in the side panel, only make the panel wider.

<!--- Describe the changes in detail -->

Example of the issue.
![scrollBarNotWorking](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/9438758/f1c7fb83-b096-429f-9ce9-fceb85ad208f)

You can only make the panel wider. 

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and context

From a users point of view, you can't scroll down to select any other items that might be visible in the left hand side.
The issue is the div with the class id divider-touch-area is sitting over the top of the scroll bar. The fix was to move this div 5px to the left and this then allows the user to scroll and still make the panel wider. 

## How to test?

See screenshot above, and the fix demo : 

![scrollBarWorking](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/9438758/da9baebd-ac09-41d7-871d-65706381f631)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
