### PR TITLE
Chore: Fix test runner log filter

### DIFF
--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -12,6 +12,8 @@ if (!['dev', 'prod'].includes(mode)) {
 	throw new Error(`MODE must be "dev" or "prod", was "${mode}"`);
 }
 
+const silencedLogs = ['Lit is in dev mode.', 'Multiple versions of Lit loaded.'];
+
 /** @type {import('@web/dev-server').DevServerConfig} */
 export default {
 	rootDir: '.',
@@ -38,6 +40,14 @@ export default {
 		}),
 		esbuildPlugin({ ts: true, tsconfig: './tsconfig.json', target: 'auto', json: true }),
 	],
+	filterBrowserLogs(log) {
+		for (const arg of log.args) {
+			if (typeof arg === 'string' && silencedLogs.some((l) => arg.includes(l))) {
+				return false;
+			}
+		}
+		return true;
+	},
 	testRunnerHtml: (testFramework, devMode) =>
 		`<html lang="en-us">
 			<head>
@@ -59,19 +69,6 @@ export default {
 			</head>
       <body>
         <script type="module" src="${testFramework}"></script>
-				<script type="module">
-					/* Hack to disable Lit dev mode warnings */
-					const systemWarn = window.console.warn;
-					window.console.warn = (...args) => {
-						if (args[0].indexOf('Lit is in dev mode.') === 0) {
-							return;
-						}
-						if (args[0].indexOf('Multiple versions of Lit loaded.') === 0) {
-							return;
-						}
-						systemWarn(...args);
-					};
-				</script>
         <script type="module">
 					import 'element-internals-polyfill';
 					import '@umbraco-ui/uui';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The current Log filter, to filter out 'Lit is in dev mode', didn't seem to do the job. I have added an alternative implementation to filter out unwanted logs.

## How to test:
* The test logs should no longer include a warning about Lit being in dev mode.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
