### PR TITLE
Bugfix: Dropzones should be clickable

### DIFF
--- a/src/packages/media/media/components/input-image-cropper/input-image-cropper.element.ts
+++ b/src/packages/media/media/components/input-image-cropper/input-image-cropper.element.ts
@@ -1,6 +1,6 @@
 import type { UmbImageCropperPropertyEditorValue } from './types.js';
 import type { UmbInputImageCropperFieldElement } from './image-cropper-field.element.js';
-import { html, customElement, property, query, state } from '@umbraco-cms/backoffice/external/lit';
+import { html, customElement, property, query, state, css } from '@umbraco-cms/backoffice/external/lit';
 import type { UUIFileDropzoneElement, UUIFileDropzoneEvent } from '@umbraco-cms/backoffice/external/uui';
 import { UmbId } from '@umbraco-cms/backoffice/id';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
@@ -61,8 +61,9 @@ export class UmbInputImageCropperElement extends UmbLitElement {
 		this.dispatchEvent(new UmbChangeEvent());
 	}
 
-	#onBrowse() {
+	#onBrowse(e: Event) {
 		if (!this._dropzone) return;
+		e.stopImmediatePropagation();
 		this._dropzone.browse();
 	}
 
@@ -105,7 +106,7 @@ export class UmbInputImageCropperElement extends UmbLitElement {
 
 	#renderDropzone() {
 		return html`
-			<uui-file-dropzone id="dropzone" label="dropzone" @change="${this.#onUpload}">
+			<uui-file-dropzone id="dropzone" label="dropzone" @change="${this.#onUpload}" @click=${this.#onBrowse}>
 				<uui-button label=${this.localize.term('media_clickToUpload')} @click="${this.#onBrowse}"></uui-button>
 			</uui-file-dropzone>
 		`;
@@ -131,6 +132,22 @@ export class UmbInputImageCropperElement extends UmbLitElement {
 			</uui-button>
 		</umb-image-cropper-field> `;
 	}
+
+	static override styles = [
+		css`
+			uui-file-dropzone {
+				position: relative;
+				display: block;
+			}
+			uui-file-dropzone::after {
+				content: '';
+				position: absolute;
+				inset: 0;
+				cursor: pointer;
+				border: 1px dashed var(--uui-color-divider-emphasis);
+			}
+		`,
+	];
 }
 
 declare global {

--- a/src/packages/media/media/components/input-upload-field/input-upload-field.element.ts
+++ b/src/packages/media/media/components/input-upload-field/input-upload-field.element.ts
@@ -86,8 +86,9 @@ export class UmbInputUploadFieldElement extends UmbLitElement {
 		}
 	}
 
-	#handleBrowse() {
+	#handleBrowse(e: Event) {
 		if (!this._dropzone) return;
+		e.stopImmediatePropagation();
 		this._dropzone.browse();
 	}
 
@@ -98,6 +99,7 @@ export class UmbInputUploadFieldElement extends UmbLitElement {
 	#renderDropzone() {
 		return html`
 			<uui-file-dropzone
+				@click=${this.#handleBrowse}
 				id="dropzone"
 				label="dropzone"
 				@change="${this.#onUpload}"
@@ -195,7 +197,16 @@ export class UmbInputUploadFieldElement extends UmbLitElement {
 			}
 
 			uui-file-dropzone {
+				position: relative;
+				display: block;
 				padding: 3px; /** Dropzone background is blurry and covers slightly into other elements. Hack to avoid this */
+			}
+			uui-file-dropzone::after {
+				content: '';
+				position: absolute;
+				inset: 0;
+				cursor: pointer;
+				border: 1px dashed var(--uui-color-divider-emphasis);
 			}
 		`,
 	];


### PR DESCRIPTION
## Description

The dropzones for media picker and upload field are now clickable.
Fixes https://github.com/umbraco/Umbraco-CMS/issues/16450

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
