### PR TITLE
ESLint linebreak on windows

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -47,6 +47,7 @@ export default [
 		},
 		rules: {
 			semi: ['warn', 'always'],
+			"prettier/prettier": ["warn", {"endOfLine": "auto" }],
 			'no-unused-vars': 'off', //Let '@typescript-eslint/no-unused-vars' catch the errors to allow unused function parameters (ex: in interfaces)
 			'no-var': 'error',
 			'import/no-unresolved': 'off',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Eslint is complaining a lot on windows now.
Changing to warn and allowing linebreaks.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)


Example on windows without the changes:

![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/108085781/59d5e97f-9408-4574-8012-1a3b6c4e4bf6)

after
![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/108085781/a4942ca9-a7fa-4339-a694-f10f3e191653)

