### PR TITLE
hotfix: block grid live editing race condition

### DIFF
--- a/src/packages/block/block/workspace/block-workspace.context.ts
+++ b/src/packages/block/block/workspace/block-workspace.context.ts
@@ -130,9 +130,74 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 			'observeLayoutInitially',
 		);
 
+		this.#observeBlockData(unique);
+
+		if (this.#liveEditingMode) {
+			this.#establishLiveSync();
+		}
+	}
+
+	async create(contentElementTypeId: string) {
+		await this.#retrieveBlockEntries;
+		await this.#retrieveModalContext;
+		if (!this.#blockEntries) {
+			throw new Error('Block Entries not found');
+			return;
+		}
+		if (!this.#modalContext) {
+			throw new Error('Modal Context not found');
+			return;
+		}
+
+		// TODO: Missing some way to append more layout data... this could be part of modal data, (or context api?)
+
+		this.setIsNew(true);
+
+		const blockCreated = await this.#blockEntries.create(
+			contentElementTypeId,
+			{},
+			this.#modalContext.data as UmbBlockWorkspaceData,
+		);
+		if (!blockCreated) {
+			throw new Error('Block Entries could not create block');
+		}
+
+		// TODO: We should investigate if it makes sense to gather
+
+		if (!this.#liveEditingMode) {
+			this.#layout.setValue(blockCreated.layout as LayoutDataType);
+			this.content.setData(blockCreated.content);
+			if (blockCreated.settings) {
+				this.settings.setData(blockCreated.settings);
+			}
+		} else {
+			// Insert already, cause we are in live editing mode:
+			const blockInserted = await this.#blockEntries.insert(
+				blockCreated.layout,
+				blockCreated.content,
+				blockCreated.settings,
+				this.#modalContext.data as UmbBlockWorkspaceData,
+			);
+			if (!blockInserted) {
+				throw new Error('Block Entries could not insert block');
+			}
+
+			const unique = blockCreated.layout.contentUdi;
+
+			this.#observeBlockData(unique);
+			this.#establishLiveSync();
+		}
+	}
+
+	#observeBlockData(unique: string) {
+		if (!this.#blockEntries) {
+			throw new Error('Block Entries not found');
+			return;
+		}
 		this.observe(
 			this.#blockEntries.layoutOf(unique),
 			(layoutData) => {
+				console.log('layout data', layoutData);
 				this.#layout.setValue(layoutData as LayoutDataType);
 
 				// Content:
@@ -183,56 +248,6 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 			},
 			'observeLayout',
 		);
-
-		if (this.#liveEditingMode) {
-			this.#establishLiveSync();
-		}
-	}
-
-	async create(contentElementTypeId: string) {
-		await this.#retrieveBlockEntries;
-		await this.#retrieveModalContext;
-		if (!this.#blockEntries) {
-			throw new Error('Block Entries not found');
-			return;
-		}
-		if (!this.#modalContext) {
-			throw new Error('Modal Context not found');
-			return;
-		}
-
-		// TODO: Missing some way to append more layout data... this could be part of modal data, (or context api?)
-
-		this.setIsNew(true);
-
-		const blockCreated = await this.#blockEntries.create(
-			contentElementTypeId,
-			{},
-			this.#modalContext.data as UmbBlockWorkspaceData,
-		);
-		if (!blockCreated) {
-			throw new Error('Block Entries could not create block');
-		}
-
-		this.#layout.setValue(blockCreated.layout as LayoutDataType);
-		this.content.setData(blockCreated.content);
-		if (blockCreated.settings) {
-			this.settings.setData(blockCreated.settings);
-		}
-
-		if (this.#liveEditingMode) {
-			// Insert already, cause we are in live editing mode:
-			const blockInserted = await this.#blockEntries.insert(
-				blockCreated.layout,
-				blockCreated.content,
-				blockCreated.settings,
-				this.#modalContext.data as UmbBlockWorkspaceData,
-			);
-			if (!blockInserted) {
-				throw new Error('Block Entries could not insert block');
-			}
-			this.#establishLiveSync();
-		}
 	}
 
 	#establishLiveSync() {

--- a/src/packages/block/block/workspace/block-workspace.context.ts
+++ b/src/packages/block/block/workspace/block-workspace.context.ts
@@ -197,7 +197,6 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 		this.observe(
 			this.#blockEntries.layoutOf(unique),
 			(layoutData) => {
-				console.log('layout data', layoutData);
 				this.#layout.setValue(layoutData as LayoutDataType);
 
 				// Content:


### PR DESCRIPTION
Makes Block Grid Editor only set its data if its not in Live Editing Mode. Cause otherwise they end up competing with each other and eventually out rule the corrections made by the Property Editor.

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/16227

## Types of changes

This makes sure the Block Workspace observes data of the Property Editor while in create-state, in this way the corrections made of the Property Editor, like rowSpan setting, gets set and the Block Workspace receives that correction.

Only sets the Blocks data if its not in live editing mode. Cause setting these will eventually overwrite the corrections from the Property Editor.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
