### PR TITLE
Bugfix: Show dialog when property not supported

### DIFF
--- a/src/packages/core/content-type/components/property-type-based-property/property-type-based-property.element.ts
+++ b/src/packages/core/content-type/components/property-type-based-property/property-type-based-property.element.ts
@@ -23,6 +23,12 @@ export class UmbPropertyTypeBasedPropertyElement extends UmbLitElement {
 	}
 	private _property?: UmbPropertyTypeModel;
 
+	@property({ type: Boolean })
+	public notSupported = false;
+
+	@property({ type: String })
+	public notSupportedMessage?: string;
+
 	@property({ type: String, attribute: 'data-path' })
 	public dataPath?: string;
 
@@ -75,6 +81,8 @@ export class UmbPropertyTypeBasedPropertyElement extends UmbLitElement {
 	override render() {
 		return this._propertyEditorUiAlias && this._property?.alias
 			? html`<umb-property
+					?notSupported=${this.notSupported}
+					.notSupportedMessage=${this.notSupportedMessage}
 					.dataPath=${this.dataPath}
 					.alias=${this._property.alias}
 					.label=${this._property.name}

--- a/src/packages/core/property/property/property.element.ts
+++ b/src/packages/core/property/property/property.element.ts
@@ -2,7 +2,7 @@ import { UmbPropertyContext } from './property.context.js';
 import type { ManifestPropertyEditorUi } from '@umbraco-cms/backoffice/extension-registry';
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
-import { css, html, customElement, property, state, nothing } from '@umbraco-cms/backoffice/external/lit';
+import { css, html, customElement, property, state, nothing, ifDefined } from '@umbraco-cms/backoffice/external/lit';
 import { createExtensionElement } from '@umbraco-cms/backoffice/extension-api';
 import type { UmbObserverController } from '@umbraco-cms/backoffice/observable-api';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
@@ -26,6 +26,12 @@ import type { UmbPropertyTypeAppearanceModel } from '@umbraco-cms/backoffice/con
 
 @customElement('umb-property')
 export class UmbPropertyElement extends UmbLitElement {
+	@property({ type: Boolean })
+	public notSupported = false;
+
+	@property({ type: String })
+	public notSupportedMessage?: string;
+
 	/**
 	 * Label. Name of the property
 	 * @type {string}
@@ -297,16 +303,20 @@ export class UmbPropertyElement extends UmbLitElement {
 		return html`
 			<umb-property-layout
 				id="layout"
-				.alias=${this._alias}
-				.label=${this._label}
-				.description=${this._description}
+				alias=${ifDefined(this._alias)}
+				label=${ifDefined(this._label)}
+				description=${ifDefined(this._description)}
 				.orientation=${this._orientation ?? 'horizontal'}
 				?invalid=${this._invalid}>
 				${this.#renderPropertyActionMenu()}
 				${this._variantDifference
 					? html`<uui-tag look="secondary" slot="description">${this._variantDifference}</uui-tag>`
 					: ''}
-				<div slot="editor">${this._element}</div>
+				${this.notSupported
+					? html`<div slot="editor" class="not-supported">
+							${this.notSupportedMessage ?? 'This property is not supported.'}
+						</div>`
+					: html`<div slot="editor">${this._element}</div>`}
 			</umb-property-layout>
 		`;
 	}
@@ -327,6 +337,13 @@ export class UmbPropertyElement extends UmbLitElement {
 		css`
 			:host {
 				display: block;
+			}
+
+			.not-supported {
+				background-color: var(--uui-color-danger);
+				color: var(--uui-color-surface);
+				padding: var(--uui-size-space-4);
+				border-radius: var(--uui-border-radius);
 			}
 
 			p {


### PR DESCRIPTION
## Description

Shows a dialog when a picked property is not supported in current workspace, such as ImageCropper in blocks.
When do we know something is not supported?

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

