### PR TITLE
Bugfix: Collection View menu close on selection

### DIFF
--- a/src/packages/core/collection/components/collection-view-bundle.element.ts
+++ b/src/packages/core/collection/components/collection-view-bundle.element.ts
@@ -110,6 +110,13 @@ export class UmbCollectionViewBundleElement extends UmbLitElement {
 
 	#onClick(view: UmbCollectionViewLayout) {
 		this.#collectionContext?.setLastSelectedView(this._entityUnique, view.alias);
+
+		setTimeout(() => {
+			// TODO: This ignorer is just neede for JSON SCHEMA TO WORK, As its not updated with latest TS jet.
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore
+			this._popover?.hidePopover();
+		}, 100);
 	}
 
 	override render() {
@@ -151,14 +158,11 @@ export class UmbCollectionViewBundleElement extends UmbLitElement {
 		css`
 			:host {
 				--uui-button-content-align: left;
+				--uui-menu-item-flat-structure: 1;
 			}
 
 			.filter-dropdown {
 				padding: var(--uui-size-space-3);
-			}
-
-			umb-icon {
-				display: inline-block;
 			}
 		`,
 	];


### PR DESCRIPTION
## Description

Hides the Collection View menu popover when an option is selected.

A timeout of 100ms is in place, as the Collection View is routable, so gives a small delay on the interaction.

Fixes https://github.com/umbraco/Umbraco-CMS/issues/16273

Also fixed a couple of minor cosmetic issues with the Collection View menu.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)