### PR TITLE
Bugfix: Resized media urls result in the request path being too long

### DIFF
--- a/src/packages/media/imaging/constants.ts
+++ b/src/packages/media/imaging/constants.ts
@@ -1,1 +1,2 @@
 export const UMB_IMAGING_REPOSITORY_ALIAS = 'Umb.Repository.Imaging';
+export const UMB_IMAGING_STORE_ALIAS = 'Umb.Store.Imaging';

--- a/src/packages/media/imaging/imaging.repository.ts
+++ b/src/packages/media/imaging/imaging.repository.ts
@@ -36,7 +36,7 @@ export class UmbImagingRepository extends UmbRepositoryBase implements UmbApi {
 
 		for (const unique of uniques) {
 			const existingCrop = this.#dataStore.getCrop(unique, imagingModel);
-			if (existingCrop) {
+			if (existingCrop !== undefined) {
 				urls.set(unique, existingCrop);
 				continue;
 			}
@@ -48,9 +48,11 @@ export class UmbImagingRepository extends UmbRepositoryBase implements UmbApi {
 				continue;
 			}
 
-			if (urlModels?.[0].url) {
-				const url = urlModels[0].url;
-				this.#dataStore.addCrop(unique, url, imagingModel);
+			const url = urlModels?.[0].url;
+
+			this.#dataStore.addCrop(unique, url ?? '', imagingModel);
+
+			if (url) {
 				urls.set(unique, url);
 			}
 		}

--- a/src/packages/media/imaging/imaging.repository.ts
+++ b/src/packages/media/imaging/imaging.repository.ts
@@ -69,7 +69,7 @@ export class UmbImagingRepository extends UmbRepositoryBase implements UmbApi {
 	 * @memberof UmbImagingRepository
 	 */
 	async requestThumbnailUrls(uniques: Array<string>, height: number, width: number, mode = ImageCropModeModel.MIN) {
-		const imagingModel = { height: height, width: width, mode };
+		const imagingModel: UmbImagingModel = { height, width, mode };
 		return this.requestResizedItems(uniques, imagingModel);
 	}
 }

--- a/src/packages/media/imaging/imaging.repository.ts
+++ b/src/packages/media/imaging/imaging.repository.ts
@@ -1,30 +1,61 @@
 import type { UmbImagingModel } from './types.js';
 import { UmbImagingServerDataSource } from './imaging.server.data.js';
-import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
+import { UMB_IMAGING_STORE_CONTEXT } from './imaging.store.token.js';
 import { ImageCropModeModel } from '@umbraco-cms/backoffice/external/backend-api';
+import { UmbRepositoryBase } from '@umbraco-cms/backoffice/repository';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
+import type { UmbMediaUrlModel } from '@umbraco-cms/backoffice/media';
 
-export class UmbImagingRepository extends UmbControllerBase implements UmbApi {
+export class UmbImagingRepository extends UmbRepositoryBase implements UmbApi {
+	#dataStore?: typeof UMB_IMAGING_STORE_CONTEXT.TYPE;
 	#itemSource: UmbImagingServerDataSource;
 
 	constructor(host: UmbControllerHost) {
 		super(host);
 		this.#itemSource = new UmbImagingServerDataSource(host);
+
+		this.consumeContext(UMB_IMAGING_STORE_CONTEXT, (instance) => {
+			this.#dataStore = instance;
+		});
 	}
 
 	/**
 	 * Requests the items for the given uniques
 	 * @param {Array<string>} uniques
-	 * @return {*}
 	 * @memberof UmbImagingRepository
 	 */
-	async requestResizedItems(uniques: Array<string>, imagingModel?: UmbImagingModel) {
+	async requestResizedItems(
+		uniques: Array<string>,
+		imagingModel?: UmbImagingModel,
+	): Promise<{ data: UmbMediaUrlModel[] }> {
 		if (!uniques.length) throw new Error('Uniques are missing');
+		if (!this.#dataStore) throw new Error('Data store is missing');
 
-		const { data, error: _error } = await this.#itemSource.getItems(uniques, imagingModel);
-		const error: any = _error;
-		return { data, error };
+		const urls = new Map<string, string>();
+
+		for (const unique of uniques) {
+			const existingCrop = this.#dataStore.getCrop(unique, imagingModel);
+			if (existingCrop) {
+				urls.set(unique, existingCrop);
+				continue;
+			}
+
+			const { data: urlModels, error } = await this.#itemSource.getItems([unique], imagingModel);
+
+			if (error) {
+				console.error('[UmbImagingRepository] Error fetching items', error);
+				continue;
+			}
+
+			if (urlModels?.[0].url) {
+				const url = urlModels[0].url;
+				this.#dataStore.addCrop(unique, url, imagingModel);
+				urls.set(unique, url);
+			}
+		}
+
+		return { data: Array.from(urls).map(([unique, url]) => ({ unique, url })) };
 	}
 
 	/**
@@ -32,12 +63,12 @@ export class UmbImagingRepository extends UmbControllerBase implements UmbApi {
 	 * @param {Array<string>} uniques
 	 * @param {number} height
 	 * @param {number} width
-	 * @returns {*}
+	 * @param {ImageCropModeModel} mode - The crop mode
 	 * @memberof UmbImagingRepository
 	 */
-	async requestThumbnailUrls(uniques: Array<string>, height: number, width: number) {
-		const imagingModel = { height: height, width: width, mode: ImageCropModeModel.MIN };
-		return await this.requestResizedItems(uniques, imagingModel);
+	async requestThumbnailUrls(uniques: Array<string>, height: number, width: number, mode = ImageCropModeModel.MIN) {
+		const imagingModel = { height: height, width: width, mode };
+		return this.requestResizedItems(uniques, imagingModel);
 	}
 }
 

--- a/src/packages/media/imaging/imaging.store.token.ts
+++ b/src/packages/media/imaging/imaging.store.token.ts
@@ -1,0 +1,4 @@
+import type { UmbImagingStore } from './imaging.store.js';
+import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
+
+export const UMB_IMAGING_STORE_CONTEXT = new UmbContextToken<UmbImagingStore>('UmbImagingStore');

--- a/src/packages/media/imaging/imaging.store.ts
+++ b/src/packages/media/imaging/imaging.store.ts
@@ -1,0 +1,47 @@
+import { UMB_IMAGING_STORE_CONTEXT } from './imaging.store.token.js';
+import type { UmbImagingModel } from './types.js';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
+import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
+
+export class UmbImagingStore extends UmbContextBase<never> implements UmbApi {
+	#data;
+
+	constructor(host: UmbControllerHost) {
+		super(host, UMB_IMAGING_STORE_CONTEXT.toString());
+		this.#data = new Map<string, Map<string, string>>();
+	}
+
+	/**
+	 * Gets the data from the store.
+	 */
+	getData(unique: string) {
+		return this.#data.get(unique);
+	}
+
+	/**
+	 * Gets a specific crop if it exists.
+	 */
+	getCrop(unique: string, data?: UmbImagingModel) {
+		return this.#data.get(unique)?.get(this.#generateCropKey(data));
+	}
+
+	/**
+	 * Adds a new crop to the store.
+	 */
+	addCrop(unique: string, urlInfo: string, data?: UmbImagingModel) {
+		if (!this.#data.has(unique)) {
+			this.#data.set(unique, new Map());
+		}
+		this.#data.get(unique)?.set(this.#generateCropKey(data), urlInfo);
+	}
+
+	/**
+	 * Generates a unique key for the crop based on the width, height and mode.
+	 */
+	#generateCropKey(data?: UmbImagingModel) {
+		return data ? `${data.width}x${data.height};${data.mode}` : 'generic';
+	}
+}
+
+export default UmbImagingStore;

--- a/src/packages/media/imaging/manifests.ts
+++ b/src/packages/media/imaging/manifests.ts
@@ -1,5 +1,5 @@
-import { UMB_IMAGING_REPOSITORY_ALIAS } from './constants.js';
-import type { ManifestRepository, ManifestTypes } from '@umbraco-cms/backoffice/extension-registry';
+import { UMB_IMAGING_REPOSITORY_ALIAS, UMB_IMAGING_STORE_ALIAS } from './constants.js';
+import type { ManifestRepository, ManifestStore, ManifestTypes } from '@umbraco-cms/backoffice/extension-registry';
 
 const repository: ManifestRepository = {
 	type: 'repository',
@@ -8,4 +8,11 @@ const repository: ManifestRepository = {
 	api: () => import('./imaging.repository.js'),
 };
 
-export const manifests: Array<ManifestTypes> = [repository];
+const store: ManifestStore = {
+	type: 'store',
+	alias: UMB_IMAGING_STORE_ALIAS,
+	name: 'Imaging Store',
+	api: () => import('./imaging.store.js'),
+};
+
+export const manifests: Array<ManifestTypes> = [repository, store];

--- a/src/packages/media/media/collection/media-collection.context.ts
+++ b/src/packages/media/media/collection/media-collection.context.ts
@@ -4,7 +4,6 @@ import { UmbImagingRepository } from '@umbraco-cms/backoffice/imaging';
 import { UmbArrayState } from '@umbraco-cms/backoffice/observable-api';
 import { UmbDefaultCollectionContext } from '@umbraco-cms/backoffice/collection';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
-import { ImageCropModeModel } from '@umbraco-cms/backoffice/external/backend-api';
 
 export class UmbMediaCollectionContext extends UmbDefaultCollectionContext<
 	UmbMediaCollectionItemModel,
@@ -12,7 +11,7 @@ export class UmbMediaCollectionContext extends UmbDefaultCollectionContext<
 > {
 	#imagingRepository: UmbImagingRepository;
 
-	#thumbnailItems = new UmbArrayState<UmbMediaCollectionItemModel>([], (x) => x);
+	#thumbnailItems = new UmbArrayState<UmbMediaCollectionItemModel>([], (x) => x.unique);
 	public readonly thumbnailItems = this.#thumbnailItems.asObservable();
 
 	constructor(host: UmbControllerHost) {
@@ -22,9 +21,10 @@ export class UmbMediaCollectionContext extends UmbDefaultCollectionContext<
 		this.observe(this.items, async (items) => {
 			if (!items?.length) return;
 
-			const { data } = await this.#imagingRepository.requestResizedItems(
+			const { data } = await this.#imagingRepository.requestThumbnailUrls(
 				items.map((m) => m.unique),
-				{ height: 400, width: 400, mode: ImageCropModeModel.MIN },
+				400,
+				400,
 			);
 
 			this.#thumbnailItems.setValue(

--- a/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
+++ b/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
@@ -8,7 +8,6 @@ import type { UmbMediaPickerFolderPathElement } from './components/media-picker-
 import type { UmbMediaPickerModalData, UmbMediaPickerModalValue } from './media-picker-modal.token.js';
 import { css, html, customElement, state, repeat, ifDefined, query } from '@umbraco-cms/backoffice/external/lit';
 import { debounce } from '@umbraco-cms/backoffice/utils';
-import { ImageCropModeModel } from '@umbraco-cms/backoffice/external/backend-api';
 import { UmbImagingRepository } from '@umbraco-cms/backoffice/imaging';
 import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 import { UMB_CONTENT_PROPERTY_CONTEXT } from '@umbraco-cms/backoffice/content';

--- a/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
+++ b/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
@@ -95,9 +95,10 @@ export class UmbMediaPickerModalElement extends UmbModalBaseElement<
 	async #mapMediaUrls(items: Array<UmbMediaItemModel>): Promise<Array<UmbMediaCardItemModel>> {
 		if (!items.length) return [];
 
-		const { data } = await this.#imagingRepository.requestResizedItems(
+		const { data } = await this.#imagingRepository.requestThumbnailUrls(
 			items.map((item) => item.unique),
-			{ height: 400, width: 400, mode: ImageCropModeModel.MIN },
+			400,
+			400,
 		);
 
 		return items


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Some web servers carry a limit to the length of the request path. This harms the media thumbnail generator, which is a GET endpoint. We cannot change the backend as that would be a breaking change, nor do we wish to do it because of the purity of REST. So we are going to make a network request for each thumbnail instead. This is exactly what the old Backoffice did as well.

There are some advantages to doing this besides fixing the web servers: We can now space out the calls and wait until the elements are visible before initiating the request -- we will look into some of this in subsequential PRs.

The thumbnails are now also being cached in memory through a store in a nested map based on the media key (GUID) and thumbnail options (width, height, mode). This results in far fewer network calls when you have a lot of media showing up in the media library.

Fixes https://github.com/umbraco/Umbraco-CMS/issues/16716

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How to test?

1. Upload more than 50 media items in a single folder in the Media library
2. Check that no requests result in a 500 error (this error most likely won't happen on local Kestrel anyway)
3. Check that all medias have their thumbnail URLs generated in separate requests
