### PR TITLE
Feature: Collection: Sets label and icon of Workspace View

### DIFF
--- a/src/packages/core/workspace/components/workspace-editor/workspace-editor.context.ts
+++ b/src/packages/core/workspace/components/workspace-editor/workspace-editor.context.ts
@@ -1,0 +1,100 @@
+import type { ManifestWorkspaceView } from '../../types.js';
+import { createExtensionElement, UmbExtensionsManifestInitializer } from '@umbraco-cms/backoffice/extension-api';
+import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
+import { UmbArrayState } from '@umbraco-cms/backoffice/observable-api';
+import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
+import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import type { UmbRoute } from '@umbraco-cms/backoffice/router';
+
+export type UmbWorkspaceEditorView = {
+	alias: string;
+	label: string;
+	icon: string;
+	pathName: string;
+	weight: number;
+};
+
+export class UmbWorkspaceEditorContext extends UmbContextBase<UmbWorkspaceEditorContext> {
+	#routes = new UmbArrayState<UmbRoute>([], (x) => x.path);
+	public readonly routes = this.#routes.asObservable();
+
+	#views = new UmbArrayState<UmbWorkspaceEditorView>([], (x) => x.alias);
+	public readonly views = this.#views.asObservable();
+
+	constructor(host: UmbControllerHost) {
+		super(host, UMB_WORKSPACE_EDITOR_CONTEXT);
+
+		new UmbExtensionsManifestInitializer(this, umbExtensionsRegistry, 'workspaceView', null, (workspaceViews) => {
+			const manifests = workspaceViews.map((view) => view.manifest);
+			this.#createRoutes(manifests);
+			this.#createViews(manifests);
+		});
+	}
+
+	#createRoutes(manifests: Array<ManifestWorkspaceView> | null) {
+		let routes: UmbRoute[] = [];
+
+		if (manifests?.length) {
+			routes = manifests.map((manifest) => {
+				return {
+					path: `view/${manifest.meta.pathname}`,
+					component: () => createExtensionElement(manifest),
+					setup: (component) => {
+						if (component) {
+							(component as any).manifest = manifest;
+						}
+					},
+				} as UmbRoute;
+			});
+
+			// Duplicate first workspace and use it for the empty path scenario. [NL]
+			routes.push({ ...routes[0], path: '' });
+
+			routes.push({
+				path: `**`,
+				component: async () => (await import('@umbraco-cms/backoffice/router')).UmbRouteNotFoundElement,
+			});
+		}
+
+		this.#routes.setValue(routes);
+	}
+
+	#createViews(manifests: Array<ManifestWorkspaceView> | null) {
+		if (!manifests?.length) return;
+
+		const views = manifests
+			? manifests.map((manifest) => ({
+					alias: manifest.alias,
+					icon: manifest.meta.icon,
+					label: manifest.meta.label ?? manifest.name,
+					pathName: manifest.meta.pathname,
+					weight: manifest.weight ?? 100,
+				}))
+			: [];
+
+		this.#views.setValue(views);
+	}
+
+	setWorkspaceViewMeta(alias: string, icon: string | undefined, label: string | undefined, weight: number | undefined) {
+		if (!alias) return;
+
+		// NOTE: Edge-case, as the server sets "icon-badge" as the default icon, but that particular icon doesn't exist in the backoffice. [LK]
+		// https://github.com/umbraco/Umbraco-CMS/blob/release-14.0.0/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/MigrateDataTypeConfigurations.cs#L718
+		if (icon === 'icon-badge color-black') {
+			icon = 'icon-grid';
+		}
+
+		const views = [...this.#views.getValue()].map((view) =>
+			view.alias === alias
+				? { ...view, ...(icon && { icon }), ...(label && { label }), ...(weight && { weight }) }
+				: view,
+		);
+
+		this.#views.setValue(views);
+	}
+}
+
+export default UmbWorkspaceEditorContext;
+
+export const UMB_WORKSPACE_EDITOR_CONTEXT = new UmbContextToken<UmbWorkspaceEditorContext>('UmbWorkspaceEditorContext');


### PR DESCRIPTION
## Description

> Attempts to fix:
> - https://github.com/umbraco/Umbraco-CMS/issues/16633

When setting a custom label and icon for a Collection (data-type), the workspace view's label and icon were not being updated.

This PR adds a `UmbWorkspaceEditorContext`, which moves logic from the `UmbWorkspaceEditorElement` to collect the manifests and build the routes & views.

The context exposes a method `.setWorkspaceViewMeta()` to enable a workspace view's label and icon be configured, (based on the workspace view's extension alias).

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## How to test?

1. Configure a document-type to use a collection, (Structure > Presentation > Collections)
2. In the corresponding data-type for the Collection, set the "Content app icon" and "Content app name" fields
3. Go to the document (either create new or existing). Has the icon and label changed?

## Notes

1. There is an edge-case, where a server-side migration (for v14) sets the default icon for a Collection to be [`icon-badge color-black`](https://github.com/umbraco/Umbraco-CMS/blob/release-14.0.0/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/MigrateDataTypeConfigurations.cs#L718), but that particular icon doesn't exist in the backoffice for v14. So I have added a check for this, and set it to `icon-grid`.

2. There is an annoying UI glitch, where the default icon and label (from the Collection manifest) is displayed, before changing to the custom icon and label. (Sometimes it happens faster, other times slow, **try setting the video playback speed to 0.25x**).

https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/209066/6bbdaf22-4b3e-4430-962a-102f75cc6990

This is because the Workspace Editor loads in the Workspace View manifests first, then it can calculate the routes, then the Workspace View Collection is loaded in (from that route), which then has access to the data-type configuration and sets the custom icon and label.

3. I have commented out code to handle the `showContentFirst`, but I hit various issues that I'm not currently able to resolve. e.g. moving the "Content" workspace to the first position, but the route doesn't update, so it displays the "Collection" instead. There is also a similar UI glitch with the Workspace View tabs updating, (it shows "Collection" first, then suddenly swaps with "Content").

I'll mark this PR as a draft until we've addressed the above issues.
