### PR TITLE
Bugfix: Date Picker with only "date" or "time" does not display correctly

### DIFF
--- a/src/packages/property-editors/date-picker/property-editor-ui-date-picker.test.ts
+++ b/src/packages/property-editors/date-picker/property-editor-ui-date-picker.test.ts
@@ -3,7 +3,6 @@ import { UmbPropertyEditorUIDatePickerElement } from './property-editor-ui-date-
 import { expect, fixture, html } from '@open-wc/testing';
 import { type UmbTestRunnerWindow, defaultA11yConfig } from '@umbraco-cms/internal/test-utils';
 import { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
-import type { UUIInputElement } from '@umbraco-cms/backoffice/external/uui';
 
 describe('UmbPropertyEditorUIDatePickerElement', () => {
 	let element: UmbPropertyEditorUIDatePickerElement;
@@ -48,53 +47,56 @@ describe('UmbPropertyEditorUIDatePickerElement', () => {
 	describe('input', () => {
 		it('should format the value to a datetime-local', async () => {
 			element.value = '2024-05-03 10:44:00';
+			element.config = new UmbPropertyEditorConfigCollection([{ alias: 'format', value: 'YYYY-MM-dd HH:mm:ss' }]);
 			await element.updateComplete;
-			expect(inputElement.value).to.equal('2024-05-03 10:44:00');
+			expect((element as any)._inputValue).to.equal('2024-05-03T10:44:00');
 		});
 
 		it('should format the value to a date', async () => {
 			element.value = '2024-05-03 10:44:00';
 			element.config = new UmbPropertyEditorConfigCollection([{ alias: 'format', value: 'YYYY-MM-dd' }]);
 			await element.updateComplete;
-			expect(inputElement.value).to.equal('2024-05-03');
+			expect((element as any)._inputValue).to.equal('2024-05-03');
 		});
 
 		it('should format the value to a time', async () => {
 			element.value = '2024-05-03 10:44:00';
 			element.config = new UmbPropertyEditorConfigCollection([{ alias: 'format', value: 'HH:mm' }]);
 			await element.updateComplete;
-			expect(inputElement.value).to.equal('10:44:00');
+			expect((element as any)._inputValue).to.equal('10:44:00');
+		});
+
+		it('should disregard a non-datetime value', async () => {
+			element.value = '03/05/2024 10:44:00';
+			await element.updateComplete;
+			expect((element as any)._inputValue).to.be.undefined;
 		});
 	});
 
 	describe('output', () => {
-		let innerInput: UUIInputElement;
-
-		beforeEach(async () => {
-			innerInput = inputElement.shadowRoot?.querySelector('uui-input') as UUIInputElement;
-		});
-
 		it('should format the value to a datetime-local', async () => {
-			innerInput.value = '2024-05-03T10:44:00';
-			innerInput.dispatchEvent(new CustomEvent('change'));
+			inputElement.value = '2024-05-03T10:44:00';
+			inputElement.dispatchEvent(new CustomEvent('change'));
 			await element.updateComplete;
 			expect(element.value).to.equal('2024-05-03 10:44:00');
 		});
 
 		it('should format the value to a date', async () => {
 			element.config = new UmbPropertyEditorConfigCollection([{ alias: 'format', value: 'YYYY-MM-dd' }]);
-			innerInput.value = '2024-05-03T10:44:00';
-			innerInput.dispatchEvent(new CustomEvent('change'));
 			await element.updateComplete;
-			expect(element.value).to.equal('2024-05-03');
+			inputElement.value = '2024-05-03';
+			inputElement.dispatchEvent(new CustomEvent('change'));
+			await element.updateComplete;
+			expect(element.value).to.equal('2024-05-03 00:00:00');
 		});
 
 		it('should format the value to a time', async () => {
 			element.config = new UmbPropertyEditorConfigCollection([{ alias: 'format', value: 'HH:mm' }]);
-			innerInput.value = '2024-05-03T10:44:00';
-			innerInput.dispatchEvent(new CustomEvent('change'));
 			await element.updateComplete;
-			expect(element.value).to.equal('10:44:00');
+			inputElement.value = '10:44:00';
+			inputElement.dispatchEvent(new CustomEvent('change'));
+			await element.updateComplete;
+			expect(element.value).to.equal('0001-01-01 10:44:00');
 		});
 	});
 });

--- a/src/packages/property-editors/date-picker/property-editor-ui-date-picker.test.ts
+++ b/src/packages/property-editors/date-picker/property-editor-ui-date-picker.test.ts
@@ -3,6 +3,7 @@ import { UmbPropertyEditorUIDatePickerElement } from './property-editor-ui-date-
 import { expect, fixture, html } from '@open-wc/testing';
 import { type UmbTestRunnerWindow, defaultA11yConfig } from '@umbraco-cms/internal/test-utils';
 import { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
+import type { UUIInputElement } from '@umbraco-cms/backoffice/external/uui';
 
 describe('UmbPropertyEditorUIDatePickerElement', () => {
 	let element: UmbPropertyEditorUIDatePickerElement;
@@ -43,4 +44,57 @@ describe('UmbPropertyEditorUIDatePickerElement', () => {
 			await expect(element).shadowDom.to.be.accessible(defaultA11yConfig);
 		});
 	}
+
+	describe('input', () => {
+		it('should format the value to a datetime-local', async () => {
+			element.value = '2024-05-03 10:44:00';
+			await element.updateComplete;
+			expect(inputElement.value).to.equal('2024-05-03 10:44:00');
+		});
+
+		it('should format the value to a date', async () => {
+			element.value = '2024-05-03 10:44:00';
+			element.config = new UmbPropertyEditorConfigCollection([{ alias: 'format', value: 'YYYY-MM-dd' }]);
+			await element.updateComplete;
+			expect(inputElement.value).to.equal('2024-05-03');
+		});
+
+		it('should format the value to a time', async () => {
+			element.value = '2024-05-03 10:44:00';
+			element.config = new UmbPropertyEditorConfigCollection([{ alias: 'format', value: 'HH:mm' }]);
+			await element.updateComplete;
+			expect(inputElement.value).to.equal('10:44:00');
+		});
+	});
+
+	describe('output', () => {
+		let innerInput: UUIInputElement;
+
+		beforeEach(async () => {
+			innerInput = inputElement.shadowRoot?.querySelector('uui-input') as UUIInputElement;
+		});
+
+		it('should format the value to a datetime-local', async () => {
+			innerInput.value = '2024-05-03T10:44:00';
+			innerInput.dispatchEvent(new CustomEvent('change'));
+			await element.updateComplete;
+			expect(element.value).to.equal('2024-05-03 10:44:00');
+		});
+
+		it('should format the value to a date', async () => {
+			element.config = new UmbPropertyEditorConfigCollection([{ alias: 'format', value: 'YYYY-MM-dd' }]);
+			innerInput.value = '2024-05-03T10:44:00';
+			innerInput.dispatchEvent(new CustomEvent('change'));
+			await element.updateComplete;
+			expect(element.value).to.equal('2024-05-03');
+		});
+
+		it('should format the value to a time', async () => {
+			element.config = new UmbPropertyEditorConfigCollection([{ alias: 'format', value: 'HH:mm' }]);
+			innerInput.value = '2024-05-03T10:44:00';
+			innerInput.dispatchEvent(new CustomEvent('change'));
+			await element.updateComplete;
+			expect(element.value).to.equal('10:44:00');
+		});
+	});
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The server always expects a regular DateTime string because the property value converter does not consider the config. The value will be unset if the string does not validate as a DateTime.

This PR aims to differentiate between input and output dates to communicate the expected value to the underlying date input component. The UI component expects the following:

| Format | Inner input | Output |
|--------|-------|--------|
| datetime-local | YYYY-mm-dd HH:ii(:ss) | YYYY-mm-dd HH:ii:ss |
| date | YYYY-mm-dd | YYYY-mm-dd HH:ii:ss |
| time | HH:ii(:ss) | YYYY-mm-dd HH:ii:ss |

Because of this, we have to patch the value coming out of the UI into a regular DateTime. Vice-versa we have to patch the value from the database into the expected _inner input_ value.

Fixes https://github.com/umbraco/Umbraco-CMS/issues/16779

## How to test

1. Configure a Date Picker with a format of `HH:mm:ss`
2. Test that it is possible to save a value
3. Test that the saved value is displayed correctly to the end-user
4. Verify that the updated unit tests make sense

## Screenshots

![image](https://github.com/user-attachments/assets/6c254204-7981-479b-a43e-4b0e096c79ec)
