### PR TITLE
Bugfix: Localizes 'sectionSidebarApp' headers

### DIFF
--- a/src/assets/lang/en.ts
+++ b/src/assets/lang/en.ts
@@ -1875,6 +1875,8 @@ export default {
 		settingsGroup: 'Settings',
 		templatingGroup: 'Templating',
 		thirdPartyGroup: 'Third Party',
+		structureGroup: 'Structure',
+		advancedGroup: 'Advanced',
 		webhooks: 'Webhooks',
 	},
 	update: {

--- a/src/packages/core/section/section-sidebar-menu-with-entity-actions/section-sidebar-menu-with-entity-actions.element.ts
+++ b/src/packages/core/section/section-sidebar-menu-with-entity-actions/section-sidebar-menu-with-entity-actions.element.ts
@@ -21,15 +21,17 @@ umbExtensionsRegistry.register(manifestWithEntityActions);
 @customElement('umb-section-sidebar-menu-with-entity-actions')
 export class UmbSectionSidebarMenuWithEntityActionsElement extends UmbSectionSidebarMenuElement<ManifestSectionSidebarAppMenuWithEntityActionsKind> {
 	override renderHeader() {
-		return html`<div id="header">
-			<h3>${this.manifest?.meta?.label}</h3>
-			<umb-entity-actions-bundle
-				slot="actions"
-				.unique=${null}
-				.entityType=${this.manifest?.meta.entityType}
-				.label=${this.manifest?.meta.label}>
-			</umb-entity-actions-bundle>
-		</div> `;
+		return html`
+			<div id="header">
+				<h3>${this.localize.string(this.manifest?.meta?.label ?? '')}</h3>
+				<umb-entity-actions-bundle
+					slot="actions"
+					.unique=${null}
+					.entityType=${this.manifest?.meta.entityType}
+					.label=${this.manifest?.meta.label}>
+				</umb-entity-actions-bundle>
+			</div>
+		`;
 	}
 
 	static override styles = [

--- a/src/packages/core/section/section-sidebar-menu/section-sidebar-menu.element.ts
+++ b/src/packages/core/section/section-sidebar-menu/section-sidebar-menu.element.ts
@@ -30,15 +30,17 @@ export class UmbSectionSidebarMenuElement<
 	manifest?: ManifestType;
 
 	renderHeader() {
-		return html`<h3>${this.manifest?.meta?.label}</h3>`;
+		return html`<h3>${this.localize.string(this.manifest?.meta?.label ?? '')}</h3>`;
 	}
 
 	override render() {
-		return html`${this.renderHeader()}
+		return html`
+			${this.renderHeader()}
 			<umb-extension-slot
 				type="menu"
 				.filter="${(menu: ManifestMenu) => menu.alias === this.manifest?.meta?.menu}"
-				default-element="umb-menu"></umb-extension-slot>`;
+				default-element="umb-menu"></umb-extension-slot>
+		`;
 	}
 
 	static override styles = [

--- a/src/packages/core/settings/manifests.ts
+++ b/src/packages/core/settings/manifests.ts
@@ -32,7 +32,7 @@ export const manifests: Array<ManifestTypes> = [
 		name: 'Structure Settings Sidebar Menu',
 		weight: 300,
 		meta: {
-			label: 'Structure',
+			label: '#treeHeaders_structureGroup',
 			menu: 'Umb.Menu.StructureSettings',
 		},
 		conditions: [
@@ -54,7 +54,7 @@ export const manifests: Array<ManifestTypes> = [
 		name: 'Advanced Settings Sidebar Menu',
 		weight: 100,
 		meta: {
-			label: 'Advanced',
+			label: '#treeHeaders_advancedGroup',
 			menu: 'Umb.Menu.AdvancedSettings',
 		},
 		conditions: [

--- a/src/packages/dictionary/section/manifests.ts
+++ b/src/packages/dictionary/section/manifests.ts
@@ -31,7 +31,7 @@ const menuSectionSidebarApp: ManifestSectionSidebarApp = {
 	name: 'Dictionary Sidebar Menu',
 	weight: 100,
 	meta: {
-		label: 'Dictionary',
+		label: '#sections_translation',
 		menu: UMB_DICTIONARY_MENU_ALIAS,
 		entityType: UMB_DICTIONARY_ROOT_ENTITY_TYPE,
 	},

--- a/src/packages/documents/section/manifests.ts
+++ b/src/packages/documents/section/manifests.ts
@@ -30,7 +30,7 @@ const menuSectionSidebarApp: ManifestSectionSidebarAppMenuWithEntityActionsKind 
 	name: 'Content Sidebar Menu',
 	weight: 100,
 	meta: {
-		label: 'Content',
+		label: '#sections_content',
 		menu: UMB_CONTENT_MENU_ALIAS,
 		entityType: UMB_DOCUMENT_ROOT_ENTITY_TYPE,
 	},

--- a/src/packages/media/media-section/manifests.ts
+++ b/src/packages/media/media-section/manifests.ts
@@ -31,7 +31,7 @@ const menuSectionSidebarApp: ManifestSectionSidebarApp = {
 	name: 'Media Section Sidebar Menu',
 	weight: 100,
 	meta: {
-		label: 'Media',
+		label: '#sections_media',
 		menu: UMB_MEDIA_MENU_ALIAS,
 		entityType: UMB_MEDIA_ROOT_ENTITY_TYPE,
 	},

--- a/src/packages/templating/menu/manifests.ts
+++ b/src/packages/templating/menu/manifests.ts
@@ -15,7 +15,7 @@ const menuSectionSidebarApp: ManifestTypes = {
 	name: 'Templating Section Sidebar Menu',
 	weight: 200,
 	meta: {
-		label: 'Templating',
+		label: '#treeHeaders_templatingGroup',
 		menu: 'Umb.Menu.Templating',
 	},
 	conditions: [


### PR DESCRIPTION
## Description

Localizes the 'sectionSidebarApp' headers. Updates the manifests to use the relevant localization keys, also added the missing ones for Setting's "Structure" and "Advanced".

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
