### PR TITLE
Bugfix: Localizes collection create action labels

### DIFF
--- a/src/packages/core/collection/action/collection-action-button.element.ts
+++ b/src/packages/core/collection/action/collection-action-button.element.ts
@@ -65,17 +65,16 @@ export class UmbCollectionActionButtonElement extends UmbLitElement {
 	}
 
 	override render() {
+		const label = this.manifest?.meta.label ? this.localize.string(this.manifest.meta.label) : this.manifest?.name;
 		return html`
 			<uui-button
 				id="action-button"
-				@click=${this._onClick}
-				look="outline"
 				color="default"
-				label=${ifDefined(
-					this.manifest?.meta.label ? this.localize.string(this.manifest.meta.label) : this.manifest?.name,
-				)}
-				href="${ifDefined(this.manifest?.meta.href)}"
-				.state=${this._buttonState}></uui-button>
+				look="outline"
+				label=${ifDefined(label)}
+				href=${ifDefined(this.manifest?.meta.href)}
+				.state=${this._buttonState}
+				@click=${this._onClick}></uui-button>
 		`;
 	}
 }

--- a/src/packages/core/collection/types.ts
+++ b/src/packages/core/collection/types.ts
@@ -1,5 +1,5 @@
-import type { ManifestCollection } from '@umbraco-cms/backoffice/extension-registry';
 import type { Observable } from '@umbraco-cms/backoffice/external/rxjs';
+import type { ManifestCollection } from '@umbraco-cms/backoffice/extension-registry';
 import type { UmbPaginationManager } from '@umbraco-cms/backoffice/utils';
 
 export interface UmbCollectionBulkActionPermissions {

--- a/src/packages/dictionary/collection/action/manifests.ts
+++ b/src/packages/dictionary/collection/action/manifests.ts
@@ -9,7 +9,7 @@ export const createManifest: ManifestCollectionAction = {
 	alias: 'Umb.CollectionAction.Dictionary.Create',
 	weight: 200,
 	meta: {
-		label: 'Create',
+		label: '#general_create',
 		href: `section/dictionary/workspace/dictionary/create/parent/${UMB_DICTIONARY_ROOT_ENTITY_TYPE}/null`,
 	},
 	conditions: [

--- a/src/packages/documents/documents/collection/action/create-document-collection-action.element.ts
+++ b/src/packages/documents/documents/collection/action/create-document-collection-action.element.ts
@@ -112,7 +112,12 @@ export class UmbCreateDocumentCollectionActionElement extends UmbLitElement {
 		if (this._allowedDocumentTypes.length !== 1) return;
 
 		const item = this._allowedDocumentTypes[0];
-		const label = (this.manifest?.meta.label ?? this.localize.term('general_create')) + ' ' + item.name;
+		const label =
+			(this.manifest?.meta.label
+				? this.localize.string(this.manifest?.meta.label)
+				: this.localize.term('general_create')) +
+			' ' +
+			item.name;
 
 		return html`
 			<uui-button color="default" href=${this.#getCreateUrl(item)} label=${label} look="outline"></uui-button>
@@ -122,7 +127,9 @@ export class UmbCreateDocumentCollectionActionElement extends UmbLitElement {
 	#renderDropdown() {
 		if (!this._allowedDocumentTypes.length) return;
 
-		const label = this.manifest?.meta.label ?? this.localize.term('general_create');
+		const label = this.manifest?.meta.label
+			? this.localize.string(this.manifest?.meta.label)
+			: this.localize.term('general_create');
 
 		return html`
 			<uui-button popovertarget="collection-action-menu-popover" label=${label} color="default" look="outline">

--- a/src/packages/documents/documents/collection/action/manifests.ts
+++ b/src/packages/documents/documents/collection/action/manifests.ts
@@ -9,7 +9,7 @@ export const createManifest: ManifestCollectionAction = {
 	element: () => import('./create-document-collection-action.element.js'),
 	weight: 100,
 	meta: {
-		label: 'Create',
+		label: '#general_create',
 	},
 	conditions: [
 		{

--- a/src/packages/language/collection/action/manifests.ts
+++ b/src/packages/language/collection/action/manifests.ts
@@ -8,7 +8,7 @@ export const createManifest: ManifestCollectionAction = {
 	alias: 'Umb.CollectionAction.Language.Create',
 	weight: 200,
 	meta: {
-		label: 'Create',
+		label: '#general_create',
 		href: 'section/settings/workspace/language/create',
 	},
 	conditions: [

--- a/src/packages/media/media/collection/action/create-media-collection-action.element.ts
+++ b/src/packages/media/media/collection/action/create-media-collection-action.element.ts
@@ -106,7 +106,12 @@ export class UmbCreateMediaCollectionActionElement extends UmbLitElement {
 		if (this._allowedMediaTypes.length !== 1) return;
 
 		const item = this._allowedMediaTypes[0];
-		const label = (this.manifest?.meta.label ?? this.localize.term('general_create')) + ' ' + item.name;
+		const label =
+			(this.manifest?.meta.label
+				? this.localize.string(this.manifest?.meta.label)
+				: this.localize.term('general_create')) +
+			' ' +
+			item.name;
 
 		return html`<uui-button
 			color="default"
@@ -119,8 +124,8 @@ export class UmbCreateMediaCollectionActionElement extends UmbLitElement {
 		if (!this._allowedMediaTypes.length) return;
 
 		const label = this.manifest?.meta.label
-			? this.localize.string(this.manifest.meta.label)
-			: this.manifest?.name ?? '';
+			? this.localize.string(this.manifest?.meta.label)
+			: this.localize.term('general_create');
 
 		return html`
 			<uui-button popovertarget="collection-action-menu-popover" label=${label} color="default" look="outline">

--- a/src/packages/webhook/collection/action/manifests.ts
+++ b/src/packages/webhook/collection/action/manifests.ts
@@ -8,7 +8,7 @@ export const createManifest: ManifestCollectionAction = {
 	alias: 'Umb.CollectionAction.Webhook.Create',
 	weight: 200,
 	meta: {
-		label: 'Create',
+		label: '#general_create',
 		href: 'section/settings/workspace/webhook/create',
 	},
 	conditions: [


### PR DESCRIPTION
## Description

Localizes the 'collectionAction' labels.

The Document and Media create actions use their own elements, so the localization had to be added within their own components.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
