### PR TITLE
Bugfix: Localizes the Collection view's "Clear" button label

### DIFF
--- a/src/packages/core/collection/components/collection-selection-actions.element.ts
+++ b/src/packages/core/collection/components/collection-selection-actions.element.ts
@@ -82,7 +82,7 @@ export class UmbCollectionSelectionActionsElement extends UmbLitElement {
 					<uui-button
 						@click=${this._handleClearSelection}
 						@keydown=${this._handleKeyDown}
-						label="Clear"
+						label=${this.localize.term('buttons_clearSelection')}
 						look="secondary"></uui-button>
 					${this._renderSelectionCount()}
 				</div>


### PR DESCRIPTION
## Description

Localizes the Collection view's "Clear" button label to be "Clear selection".

![Screenshot 2024-07-17 155659](https://github.com/user-attachments/assets/114b60ce-94d6-46e6-9d04-8424a1354ae5)


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
