### PR TITLE
Feature: Document entity bulk action "duplicate to"

### DIFF
--- a/src/packages/core/entity-bulk-action/common/duplicate-to/duplicate-to-repository.interface.ts
+++ b/src/packages/core/entity-bulk-action/common/duplicate-to/duplicate-to-repository.interface.ts
@@ -1,0 +1,7 @@
+import type { UmbRepositoryErrorResponse } from '../../../repository/types.js';
+import type { UmbBulkDuplicateToRequestArgs } from './types.js';
+import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
+
+export interface UmbBulkDuplicateToRepository extends UmbApi {
+	requestBulkDuplicateTo(args: UmbBulkDuplicateToRequestArgs): Promise<UmbRepositoryErrorResponse>;
+}

--- a/src/packages/core/entity-bulk-action/common/duplicate-to/duplicate-to.action.kind.ts
+++ b/src/packages/core/entity-bulk-action/common/duplicate-to/duplicate-to.action.kind.ts
@@ -1,0 +1,23 @@
+import { UMB_ENTITY_BULK_ACTION_DEFAULT_KIND_MANIFEST } from '../../default/default.action.kind.js';
+import type { UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+
+export const manifest: UmbBackofficeManifestKind = {
+	type: 'kind',
+	alias: 'Umb.Kind.EntityBulkAction.DuplicateTo',
+	matchKind: 'duplicateTo',
+	matchType: 'entityBulkAction',
+	manifest: {
+		...UMB_ENTITY_BULK_ACTION_DEFAULT_KIND_MANIFEST.manifest,
+		type: 'entityBulkAction',
+		kind: 'duplicateTo',
+		api: () => import('./duplicate-to.action.js'),
+		weight: 700,
+		forEntityTypes: [],
+		meta: {
+			icon: 'icon-enter',
+			label: '#actions_copyTo',
+			bulkDuplicateRepositoryAlias: '',
+			treeAlias: '',
+		},
+	},
+};

--- a/src/packages/core/entity-bulk-action/common/duplicate-to/duplicate-to.action.ts
+++ b/src/packages/core/entity-bulk-action/common/duplicate-to/duplicate-to.action.ts
@@ -1,0 +1,66 @@
+import type { UmbBulkDuplicateToRepository } from './duplicate-to-repository.interface.js';
+import { createExtensionApiByAlias } from '@umbraco-cms/backoffice/extension-registry';
+import { UmbEntityBulkActionBase } from '@umbraco-cms/backoffice/entity-bulk-action';
+import {
+	UmbRequestReloadChildrenOfEntityEvent,
+	UmbRequestReloadStructureForEntityEvent,
+} from '@umbraco-cms/backoffice/entity-action';
+import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
+import { UMB_ENTITY_CONTEXT } from '@umbraco-cms/backoffice/entity';
+import { UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
+import { UMB_TREE_PICKER_MODAL } from '@umbraco-cms/backoffice/tree';
+import type { MetaEntityBulkActionDuplicateToKind } from '@umbraco-cms/backoffice/extension-registry';
+
+export class UmbMediaDuplicateEntityBulkAction extends UmbEntityBulkActionBase<MetaEntityBulkActionDuplicateToKind> {
+	async execute() {
+		if (this.selection?.length === 0) return;
+
+		const modalManager = await this.getContext(UMB_MODAL_MANAGER_CONTEXT);
+
+		const modalContext = modalManager.open(this, UMB_TREE_PICKER_MODAL, {
+			data: {
+				foldersOnly: this.args.meta.foldersOnly,
+				hideTreeRoot: this.args.meta.hideTreeRoot,
+				treeAlias: this.args.meta.treeAlias,
+			},
+		});
+
+		const value = await modalContext.onSubmit().catch(() => undefined);
+		if (!value?.selection?.length) return;
+
+		const destinationUnique = value.selection[0];
+		if (destinationUnique === undefined) throw new Error('Destination Unique is not available');
+
+		const bulkMoveRepository = await createExtensionApiByAlias<UmbBulkDuplicateToRepository>(
+			this,
+			this.args.meta.bulkDuplicateRepositoryAlias,
+		);
+		if (!bulkMoveRepository) throw new Error('Bulk Duplicate Repository is not available');
+
+		await bulkMoveRepository.requestBulkDuplicateTo({
+			uniques: this.selection,
+			destination: { unique: destinationUnique },
+		});
+
+		const entityContext = await this.getContext(UMB_ENTITY_CONTEXT);
+		if (!entityContext) throw new Error('Entity Context is not available');
+
+		const entityType = entityContext.getEntityType();
+		const unique = entityContext.getUnique();
+
+		if (entityType && unique !== undefined) {
+			const eventContext = await this.getContext(UMB_ACTION_EVENT_CONTEXT);
+			if (!eventContext) throw new Error('Event Context is not available');
+
+			const args = { entityType, unique };
+
+			const reloadChildren = new UmbRequestReloadChildrenOfEntityEvent(args);
+			eventContext.dispatchEvent(reloadChildren);
+
+			const reloadStructure = new UmbRequestReloadStructureForEntityEvent(args);
+			eventContext.dispatchEvent(reloadStructure);
+		}
+	}
+}
+
+export { UmbMediaDuplicateEntityBulkAction as api };

--- a/src/packages/core/entity-bulk-action/common/duplicate-to/duplicate-to.action.ts
+++ b/src/packages/core/entity-bulk-action/common/duplicate-to/duplicate-to.action.ts
@@ -31,13 +31,13 @@ export class UmbMediaDuplicateEntityBulkAction extends UmbEntityBulkActionBase<M
 		const destinationUnique = value.selection[0];
 		if (destinationUnique === undefined) throw new Error('Destination Unique is not available');
 
-		const bulkMoveRepository = await createExtensionApiByAlias<UmbBulkDuplicateToRepository>(
+		const bulkDuplicateRepository = await createExtensionApiByAlias<UmbBulkDuplicateToRepository>(
 			this,
 			this.args.meta.bulkDuplicateRepositoryAlias,
 		);
-		if (!bulkMoveRepository) throw new Error('Bulk Duplicate Repository is not available');
+		if (!bulkDuplicateRepository) throw new Error('Bulk Duplicate Repository is not available');
 
-		await bulkMoveRepository.requestBulkDuplicateTo({
+		await bulkDuplicateRepository.requestBulkDuplicateTo({
 			uniques: this.selection,
 			destination: { unique: destinationUnique },
 		});

--- a/src/packages/core/entity-bulk-action/common/duplicate-to/index.ts
+++ b/src/packages/core/entity-bulk-action/common/duplicate-to/index.ts
@@ -1,0 +1,2 @@
+export type { UmbBulkDuplicateToRepository } from './duplicate-to-repository.interface.js';
+export type { UmbBulkDuplicateToRequestArgs } from './types.js';

--- a/src/packages/core/entity-bulk-action/common/duplicate-to/manifests.ts
+++ b/src/packages/core/entity-bulk-action/common/duplicate-to/manifests.ts
@@ -1,0 +1,4 @@
+import { manifest as duplicateToKindManifest } from './duplicate-to.action.kind.js';
+import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+
+export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [duplicateToKindManifest];

--- a/src/packages/core/entity-bulk-action/common/duplicate-to/types.ts
+++ b/src/packages/core/entity-bulk-action/common/duplicate-to/types.ts
@@ -1,0 +1,6 @@
+export interface UmbBulkDuplicateToRequestArgs {
+	uniques: Array<string>;
+	destination: {
+		unique: string | null;
+	};
+}

--- a/src/packages/core/entity-bulk-action/common/index.ts
+++ b/src/packages/core/entity-bulk-action/common/index.ts
@@ -1,1 +1,2 @@
+export * from './duplicate-to/index.js';
 export * from './move-to/index.js';

--- a/src/packages/core/entity-bulk-action/manifests.ts
+++ b/src/packages/core/entity-bulk-action/manifests.ts
@@ -1,8 +1,10 @@
 import { manifests as defaultEntityBulkActionManifests } from './default/manifests.js';
+import { manifests as duplicateEntityBulkActionManifests } from './common/duplicate-to/manifests.js';
 import { manifests as moveToEntityBulkActionManifests } from './common/move-to/manifests.js';
 import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
 export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
 	...defaultEntityBulkActionManifests,
+	...duplicateEntityBulkActionManifests,
 	...moveToEntityBulkActionManifests,
 ];

--- a/src/packages/core/extension-registry/models/entity-bulk-action.model.ts
+++ b/src/packages/core/extension-registry/models/entity-bulk-action.model.ts
@@ -34,6 +34,20 @@ export interface MetaEntityBulkActionDefaultKind extends MetaEntityBulkAction {
 	label?: string;
 }
 
+// DUPLICATE TO
+export interface ManifestEntityBulkActionDuplicateToKind
+	extends ManifestEntityBulkAction<MetaEntityBulkActionDuplicateToKind> {
+	type: 'entityBulkAction';
+	kind: 'duplicateTo';
+}
+
+export interface MetaEntityBulkActionDuplicateToKind extends ManifestEntityBulkAction {
+	bulkDuplicateRepositoryAlias: string;
+	hideTreeRoot?: boolean;
+	foldersOnly?: boolean;
+	treeAlias: string;
+}
+
 // MOVE TO
 export interface ManifestEntityBulkActionMoveToKind extends ManifestEntityBulkAction<MetaEntityBulkActionMoveToKind> {
 	type: 'entityBulkAction';

--- a/src/packages/documents/documents/entity-bulk-actions/duplicate-to/index.ts
+++ b/src/packages/documents/documents/entity-bulk-actions/duplicate-to/index.ts
@@ -1,0 +1,4 @@
+export {
+	UmbBulkDuplicateToDocumentRepository,
+	UMB_BULK_DUPLICATE_DOCUMENT_REPOSITORY_ALIAS,
+} from './repository/index.js';

--- a/src/packages/documents/documents/entity-bulk-actions/duplicate-to/manifests.ts
+++ b/src/packages/documents/documents/entity-bulk-actions/duplicate-to/manifests.ts
@@ -1,0 +1,36 @@
+import { UMB_DOCUMENT_COLLECTION_ALIAS } from '../../collection/index.js';
+import { UMB_DOCUMENT_ENTITY_TYPE } from '../../entity.js';
+import { UMB_DOCUMENT_TREE_ALIAS } from '../../tree/manifests.js';
+import { UMB_BULK_DUPLICATE_DOCUMENT_REPOSITORY_ALIAS } from './repository/constants.js';
+import { manifests as repositoryManifests } from './repository/manifests.js';
+import {
+	UMB_COLLECTION_ALIAS_CONDITION,
+	UMB_COLLECTION_BULK_ACTION_PERMISSION_CONDITION,
+} from '@umbraco-cms/backoffice/collection';
+import type { UmbCollectionBulkActionPermissions } from '@umbraco-cms/backoffice/collection';
+import type { ManifestTypes } from '@umbraco-cms/backoffice/extension-registry';
+
+const bulkDuplicateAction: ManifestTypes = {
+	type: 'entityBulkAction',
+	kind: 'duplicateTo',
+	alias: 'Umb.EntityBulkAction.Document.DuplicateTo',
+	name: 'Duplicate Document Entity Bulk Action',
+	weight: 30,
+	forEntityTypes: [UMB_DOCUMENT_ENTITY_TYPE],
+	meta: {
+		bulkDuplicateRepositoryAlias: UMB_BULK_DUPLICATE_DOCUMENT_REPOSITORY_ALIAS,
+		treeAlias: UMB_DOCUMENT_TREE_ALIAS,
+	},
+	conditions: [
+		{
+			alias: UMB_COLLECTION_ALIAS_CONDITION,
+			match: UMB_DOCUMENT_COLLECTION_ALIAS,
+		},
+		{
+			alias: UMB_COLLECTION_BULK_ACTION_PERMISSION_CONDITION,
+			match: (permissions: UmbCollectionBulkActionPermissions) => permissions.allowBulkCopy,
+		},
+	],
+};
+
+export const manifests: Array<ManifestTypes> = [bulkDuplicateAction, ...repositoryManifests];

--- a/src/packages/documents/documents/entity-bulk-actions/duplicate-to/repository/constants.ts
+++ b/src/packages/documents/documents/entity-bulk-actions/duplicate-to/repository/constants.ts
@@ -1,0 +1,1 @@
+export const UMB_BULK_DUPLICATE_DOCUMENT_REPOSITORY_ALIAS = 'Umb.Repository.Document.BulkDuplicate';

--- a/src/packages/documents/documents/entity-bulk-actions/duplicate-to/repository/duplicate-to.repository.ts
+++ b/src/packages/documents/documents/entity-bulk-actions/duplicate-to/repository/duplicate-to.repository.ts
@@ -1,0 +1,49 @@
+import { UmbDuplicateDocumentServerDataSource } from '../../../entity-actions/duplicate/repository/document-duplicate.server.data-source.js';
+import type { UmbBulkDuplicateToDocumentRequestArgs } from './types.js';
+import { UmbRepositoryBase } from '@umbraco-cms/backoffice/repository';
+import { UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
+import type { UmbBulkDuplicateToRepository } from '@umbraco-cms/backoffice/entity-bulk-action';
+import type { UmbRepositoryErrorResponse } from '@umbraco-cms/backoffice/repository';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+
+export class UmbBulkDuplicateToDocumentRepository extends UmbRepositoryBase implements UmbBulkDuplicateToRepository {
+	#duplicateSource = new UmbDuplicateDocumentServerDataSource(this);
+	#notificationContext?: typeof UMB_NOTIFICATION_CONTEXT.TYPE;
+
+	constructor(host: UmbControllerHost) {
+		super(host);
+
+		this.consumeContext(UMB_NOTIFICATION_CONTEXT, (notificationContext) => {
+			this.#notificationContext = notificationContext;
+		});
+	}
+
+	async requestBulkDuplicateTo(args: UmbBulkDuplicateToDocumentRequestArgs): Promise<UmbRepositoryErrorResponse> {
+		let count = 0;
+
+		for (const unique of args.uniques) {
+			const { error } = await this.#duplicateSource.duplicate({
+				unique,
+				destination: args.destination,
+				relateToOriginal: args.relateToOriginal,
+				includeDescendants: args.includeDescendants,
+			});
+
+			if (error) {
+				const notification = { data: { message: error.message } };
+				this.#notificationContext?.peek('danger', notification);
+			} else {
+				count++;
+			}
+		}
+
+		if (count > 0) {
+			const notification = { data: { message: `Duplicated ${count} ${count === 1 ? 'document' : 'documents'}` } };
+			this.#notificationContext?.peek('positive', notification);
+		}
+
+		return {};
+	}
+}
+
+export { UmbBulkDuplicateToDocumentRepository as api };

--- a/src/packages/documents/documents/entity-bulk-actions/duplicate-to/repository/index.ts
+++ b/src/packages/documents/documents/entity-bulk-actions/duplicate-to/repository/index.ts
@@ -1,0 +1,2 @@
+export { UmbBulkDuplicateToDocumentRepository } from './duplicate-to.repository.js';
+export { UMB_BULK_DUPLICATE_DOCUMENT_REPOSITORY_ALIAS } from './constants.js';

--- a/src/packages/documents/documents/entity-bulk-actions/duplicate-to/repository/manifests.ts
+++ b/src/packages/documents/documents/entity-bulk-actions/duplicate-to/repository/manifests.ts
@@ -1,0 +1,11 @@
+import { UMB_BULK_DUPLICATE_DOCUMENT_REPOSITORY_ALIAS } from './constants.js';
+import type { ManifestRepository, ManifestTypes } from '@umbraco-cms/backoffice/extension-registry';
+
+const bulkDuplicateRepository: ManifestRepository = {
+	type: 'repository',
+	alias: UMB_BULK_DUPLICATE_DOCUMENT_REPOSITORY_ALIAS,
+	name: 'Bulk Duplicate Media Repository',
+	api: () => import('./duplicate-to.repository.js'),
+};
+
+export const manifests: Array<ManifestTypes> = [bulkDuplicateRepository];

--- a/src/packages/documents/documents/entity-bulk-actions/duplicate-to/repository/types.ts
+++ b/src/packages/documents/documents/entity-bulk-actions/duplicate-to/repository/types.ts
@@ -1,0 +1,6 @@
+import type { UmbBulkDuplicateToRequestArgs } from '@umbraco-cms/backoffice/entity-bulk-action';
+
+export interface UmbBulkDuplicateToDocumentRequestArgs extends UmbBulkDuplicateToRequestArgs {
+	relateToOriginal: boolean;
+	includeDescendants: boolean;
+}

--- a/src/packages/documents/documents/entity-bulk-actions/duplicate/duplicate.action.ts
+++ b/src/packages/documents/documents/entity-bulk-actions/duplicate/duplicate.action.ts
@@ -1,7 +1,0 @@
-import { UmbEntityBulkActionBase } from '@umbraco-cms/backoffice/entity-bulk-action';
-
-export class UmbDocumentDuplicateEntityBulkAction extends UmbEntityBulkActionBase<object> {
-	async execute() {
-		console.log('execute bulk duplicate');
-	}
-}

--- a/src/packages/documents/documents/entity-bulk-actions/manifests.ts
+++ b/src/packages/documents/documents/entity-bulk-actions/manifests.ts
@@ -1,6 +1,6 @@
 import { UMB_DOCUMENT_COLLECTION_ALIAS } from '../collection/index.js';
 import { UMB_DOCUMENT_ENTITY_TYPE } from '../entity.js';
-//import { UMB_DOCUMENT_TREE_ALIAS } from '../tree/manifests.js';
+import { manifests as duplicateToManifests } from './duplicate-to/manifests.js';
 import { manifests as moveToManifests } from './move-to/manifests.js';
 import type { UmbCollectionBulkActionPermissions } from '@umbraco-cms/backoffice/collection';
 import type { ManifestEntityBulkAction, ManifestTypes } from '@umbraco-cms/backoffice/extension-registry';
@@ -54,30 +54,6 @@ export const entityBulkActions: Array<ManifestEntityBulkAction> = [
 			},
 		],
 	},
-	/* TODO: implement bulk duplicate action
-	{
-		type: 'entityBulkAction',
-		kind: 'default',
-		alias: 'Umb.EntityBulkAction.Document.Duplicate',
-		name: 'Duplicate Document Entity Bulk Action',
-		weight: 30,
-		api: UmbDocumentDuplicateEntityBulkAction,
-		meta: {
-			label: 'Duplicate...',
-		},
-		forEntityTypes: [UMB_DOCUMENT_ENTITY_TYPE],
-		conditions: [
-			{
-				alias: UMB_COLLECTION_ALIAS_CONDITION,
-				match: UMB_DOCUMENT_COLLECTION_ALIAS,
-			},
-			{
-				alias: UMB_COLLECTION_BULK_ACTION_PERMISSION_CONDITION,
-				match: (permissions: UmbCollectionBulkActionPermissions) => permissions.allowBulkCopy,
-			},
-		],
-	},
-	*/
 	/* TODO: implement bulk trash action
 	{
 		type: 'entityBulkAction',
@@ -104,4 +80,4 @@ export const entityBulkActions: Array<ManifestEntityBulkAction> = [
 	*/
 ];
 
-export const manifests: Array<ManifestTypes> = [...entityBulkActions, ...moveToManifests];
+export const manifests: Array<ManifestTypes> = [...entityBulkActions, ...duplicateToManifests, ...moveToManifests];

--- a/src/packages/documents/documents/entity-bulk-actions/move/move.action.ts
+++ b/src/packages/documents/documents/entity-bulk-actions/move/move.action.ts
@@ -1,7 +1,0 @@
-import { UmbEntityBulkActionBase } from '@umbraco-cms/backoffice/entity-bulk-action';
-
-export class UmbMoveDocumentEntityBulkAction extends UmbEntityBulkActionBase<object> {
-	async execute() {
-		console.log(`execute bulk move`);
-	}
-}

--- a/src/packages/property-editors/collection/config/bulk-action-permissions/permissions.element.ts
+++ b/src/packages/property-editors/collection/config/bulk-action-permissions/permissions.element.ts
@@ -76,7 +76,7 @@ export class UmbPropertyEditorUICollectionPermissionsElement
 			<uui-toggle
 				?checked=${this.value.allowBulkCopy}
 				@change=${(e: UUIBooleanInputEvent) => this.#onChange(e, 'allowBulkCopy')}
-				label="Allow bulk copy (content only)"></uui-toggle>
+				label="Allow bulk duplicate (content only)"></uui-toggle>
 			<uui-toggle
 				?checked=${this.value.allowBulkMove}
 				@change=${(e: UUIBooleanInputEvent) => this.#onChange(e, 'allowBulkMove')}


### PR DESCRIPTION
## Description

Implements the Document collection bulk duplicate (copy) feature, (as a Entity Bulk Action `duplicateTo` kind).

To note, I haven't implemented the Media equivalent feature, as the "copy" endpoint (for media) doesn't exist in the Management API. 

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## How to test?

- Ensure that "Allow bulk duplicate" is enabled in the Collection (data-type) configuration.
- In a document that has a Collection enabled, select 1 or more document items.
- In the Collections actions toolbar (at the bottom), select the "Duplicate to" action button.
- A document picker modal should appear to select the destination/target of the items, select an item.
  - If an item is selected where child document items are not allowed, an error will be displayed.
  - If an item is selected where child document items are allowed, then the items will be copied/duplicated, a success notification should be displayed and the Document Collection UI should be automatically refreshed.
- Go to the destination/target folder and check that the duplicated document items are there.
