### PR TITLE
Remove all filter option from User Status

### DIFF
--- a/src/packages/user/user/collection/utils/index.ts
+++ b/src/packages/user/user/collection/utils/index.ts
@@ -13,6 +13,5 @@ export const UmbUserStateFilter = Object.freeze({
 	DISABLED: 'Disabled',
 	LOCKED_OUT: 'LockedOut',
 	INVITED: 'Invited',
-	INACTIVE: 'Inactive',
-	ALL: 'All',
+	INACTIVE: 'Inactive'
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes https://github.com/umbraco/Umbraco-CMS/issues/16252

Remove the "All" filter option from User Status