### PR TITLE
Feature: Document entity bulk action "trash"

### DIFF
--- a/src/packages/documents/documents/entity-bulk-actions/delete/delete.action.ts
+++ b/src/packages/documents/documents/entity-bulk-actions/delete/delete.action.ts
@@ -1,7 +1,0 @@
-import { UmbEntityBulkActionBase } from '@umbraco-cms/backoffice/entity-bulk-action';
-
-export class UmbDocumentDeleteEntityBulkAction extends UmbEntityBulkActionBase<object> {
-	async execute() {
-		console.log('execute bulk delete');
-	}
-}

--- a/src/packages/documents/documents/entity-bulk-actions/manifests.ts
+++ b/src/packages/documents/documents/entity-bulk-actions/manifests.ts
@@ -2,6 +2,7 @@ import { UMB_DOCUMENT_COLLECTION_ALIAS } from '../collection/index.js';
 import { UMB_DOCUMENT_ENTITY_TYPE } from '../entity.js';
 import { manifests as duplicateToManifests } from './duplicate-to/manifests.js';
 import { manifests as moveToManifests } from './move-to/manifests.js';
+import { manifests as trashManifests } from './trash/manifests.js';
 import type { UmbCollectionBulkActionPermissions } from '@umbraco-cms/backoffice/collection';
 import type { ManifestEntityBulkAction, ManifestTypes } from '@umbraco-cms/backoffice/extension-registry';
 import {
@@ -56,30 +57,11 @@ export const entityBulkActions: Array<ManifestEntityBulkAction> = [
 			},
 		],
 	},
-	/* TODO: implement bulk trash action
-	{
-		type: 'entityBulkAction',
-		kind: 'default',
-		alias: 'Umb.EntityBulkAction.Document.Delete',
-		name: 'Delete Document Entity Bulk Action',
-		weight: 10,
-		api: UmbDocumentDeleteEntityBulkAction,
-		meta: {
-			label: 'Delete',
-		},
-		forEntityTypes: [UMB_DOCUMENT_ENTITY_TYPE],
-		conditions: [
-			{
-				alias: UMB_COLLECTION_ALIAS_CONDITION,
-				match: UMB_DOCUMENT_COLLECTION_ALIAS,
-			},
-			{
-				alias: UMB_COLLECTION_BULK_ACTION_PERMISSION_CONDITION,
-				match: (permissions: UmbCollectionBulkActionPermissions) => permissions.allowBulkDelete,
-			},
-		],
-	},
-	*/
 ];
 
-export const manifests: Array<ManifestTypes> = [...entityBulkActions, ...duplicateToManifests, ...moveToManifests];
+export const manifests: Array<ManifestTypes> = [
+	...entityBulkActions,
+	...duplicateToManifests,
+	...moveToManifests,
+	...trashManifests,
+];

--- a/src/packages/documents/documents/entity-bulk-actions/trash/index.ts
+++ b/src/packages/documents/documents/entity-bulk-actions/trash/index.ts
@@ -1,0 +1,1 @@
+export { UmbBulkTrashDocumentRepository, UMB_BULK_TRASH_DOCUMENT_REPOSITORY_ALIAS } from './repository/index.js';

--- a/src/packages/documents/documents/entity-bulk-actions/trash/manifests.ts
+++ b/src/packages/documents/documents/entity-bulk-actions/trash/manifests.ts
@@ -1,0 +1,34 @@
+import { UMB_DOCUMENT_COLLECTION_ALIAS } from '../../collection/index.js';
+import { UMB_DOCUMENT_ENTITY_TYPE } from '../../entity.js';
+import { UMB_BULK_TRASH_DOCUMENT_REPOSITORY_ALIAS } from './repository/constants.js';
+import { manifests as repositoryManifests } from './repository/manifests.js';
+import {
+	UMB_COLLECTION_ALIAS_CONDITION,
+	UMB_COLLECTION_BULK_ACTION_PERMISSION_CONDITION,
+} from '@umbraco-cms/backoffice/collection';
+import type { ManifestTypes } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbCollectionBulkActionPermissions } from '@umbraco-cms/backoffice/collection';
+
+const bulkTrashAction: ManifestTypes = {
+	type: 'entityBulkAction',
+	kind: 'trash',
+	alias: 'Umb.EntityBulkAction.Document.Trash',
+	name: 'Trash Document Entity Bulk Action',
+	weight: 10,
+	forEntityTypes: [UMB_DOCUMENT_ENTITY_TYPE],
+	meta: {
+		bulkTrashRepositoryAlias: UMB_BULK_TRASH_DOCUMENT_REPOSITORY_ALIAS,
+	},
+	conditions: [
+		{
+			alias: UMB_COLLECTION_ALIAS_CONDITION,
+			match: UMB_DOCUMENT_COLLECTION_ALIAS,
+		},
+		{
+			alias: UMB_COLLECTION_BULK_ACTION_PERMISSION_CONDITION,
+			match: (permissions: UmbCollectionBulkActionPermissions) => permissions.allowBulkDelete,
+		},
+	],
+};
+
+export const manifests: Array<ManifestTypes> = [bulkTrashAction, ...repositoryManifests];

--- a/src/packages/documents/documents/entity-bulk-actions/trash/repository/constants.ts
+++ b/src/packages/documents/documents/entity-bulk-actions/trash/repository/constants.ts
@@ -1,0 +1,1 @@
+export const UMB_BULK_TRASH_DOCUMENT_REPOSITORY_ALIAS = 'Umb.Repository.Document.BulkTrash';

--- a/src/packages/documents/documents/entity-bulk-actions/trash/repository/index.ts
+++ b/src/packages/documents/documents/entity-bulk-actions/trash/repository/index.ts
@@ -1,0 +1,2 @@
+export { UmbBulkTrashDocumentRepository } from './trash.repository.js';
+export { UMB_BULK_TRASH_DOCUMENT_REPOSITORY_ALIAS } from './constants.js';

--- a/src/packages/documents/documents/entity-bulk-actions/trash/repository/manifests.ts
+++ b/src/packages/documents/documents/entity-bulk-actions/trash/repository/manifests.ts
@@ -1,0 +1,11 @@
+import { UMB_BULK_TRASH_DOCUMENT_REPOSITORY_ALIAS } from './constants.js';
+import type { ManifestRepository, ManifestTypes } from '@umbraco-cms/backoffice/extension-registry';
+
+const bulkTrashRepository: ManifestRepository = {
+	type: 'repository',
+	alias: UMB_BULK_TRASH_DOCUMENT_REPOSITORY_ALIAS,
+	name: 'Bulk Trash Document Repository',
+	api: () => import('./trash.repository.js'),
+};
+
+export const manifests: Array<ManifestTypes> = [bulkTrashRepository];

--- a/src/packages/documents/documents/entity-bulk-actions/trash/repository/trash.repository.ts
+++ b/src/packages/documents/documents/entity-bulk-actions/trash/repository/trash.repository.ts
@@ -1,0 +1,43 @@
+import { UmbDocumentRecycleBinServerDataSource } from '../../../recycle-bin/repository/document-recycle-bin.server.data-source.js';
+import { UmbRepositoryBase } from '@umbraco-cms/backoffice/repository';
+import { UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
+import type { UmbBulkTrashRepository, UmbBulkTrashRequestArgs } from '@umbraco-cms/backoffice/entity-bulk-action';
+import type { UmbRepositoryErrorResponse } from '@umbraco-cms/backoffice/repository';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+
+export class UmbBulkTrashDocumentRepository extends UmbRepositoryBase implements UmbBulkTrashRepository {
+	#notificationContext?: typeof UMB_NOTIFICATION_CONTEXT.TYPE;
+	#recycleBinSource = new UmbDocumentRecycleBinServerDataSource(this);
+
+	constructor(host: UmbControllerHost) {
+		super(host);
+
+		this.consumeContext(UMB_NOTIFICATION_CONTEXT, (notificationContext) => {
+			this.#notificationContext = notificationContext;
+		});
+	}
+
+	async requestBulkTrash(args: UmbBulkTrashRequestArgs): Promise<UmbRepositoryErrorResponse> {
+		let count = 0;
+
+		for (const unique of args.uniques) {
+			const { error } = await this.#recycleBinSource.trash({ unique });
+
+			if (error) {
+				const notification = { data: { message: error.message } };
+				this.#notificationContext?.peek('danger', notification);
+			} else {
+				count++;
+			}
+		}
+
+		if (count > 0) {
+			const notification = { data: { message: `Trashed ${count} ${count === 1 ? 'document' : 'documents'}` } };
+			this.#notificationContext?.peek('positive', notification);
+		}
+
+		return {};
+	}
+}
+
+export { UmbBulkTrashDocumentRepository as api };


### PR DESCRIPTION
## Description

> [!CAUTION]
> This PR is marked as draft until the following PR has been merged in...
> - #2127

Implements the Document collection bulk trash feature, (as a Entity Bulk Action `trash` kind).

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## How to test?

- Ensure that "Allow bulk trash" is enabled in the Collection (data-type) configuration.
- In a document that has a Collection enabled, select 1 or more document items.
- In the Collections actions toolbar (at the bottom), select the "Trash" action button.
- The items will be moved to the Recycle Bin, a success notification should be displayed and the Document Collection UI should be automatically refreshed.
- Expand the Recycle Bin to check that the trashed document items are there.
