### PR TITLE
Chore: Remove the `user-defined.css` as it is not needed

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,6 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>Umbraco</title>
 		<script src="node_modules/msw/lib/iife/index.js"></script>
-		<link rel="stylesheet" href="src/css/user-defined.css" />
 		<link rel="stylesheet" href="node_modules/@umbraco-ui/uui-css/dist/uui-css.css" />
 		<link rel="stylesheet" href="src/css/umb-css.css" />
 		<script type="module" src="index.ts"></script>

--- a/src/css/user-defined.css
+++ b/src/css/user-defined.css
@@ -1,1 +1,0 @@
-/* This file can be overridden by placing a file with the same name in the /wwwroot/umbraco/backoffice/css folder of the website */

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -62,7 +62,6 @@ export default {
 					window.__UMBRACO_TEST_RUN_A11Y_TEST = ${(!devMode).toString()};
 				</script>
 				<script src="/node_modules/msw/lib/iife/index.js"></script>
-				<link rel="stylesheet" href="src/css/user-defined.css">
 				<link rel="stylesheet" href="node_modules/@umbraco-ui/uui-css/dist/uui-css.css">
 				<link rel="stylesheet" href="src/css/umb-css.css">
 				<script type="module">


### PR DESCRIPTION
> [!CAUTION]
> Merge after https://github.com/umbraco/Umbraco-CMS/pull/16792

There is not a need to have this empty file `user-defined.css` in the Backoffice client anymore.