### PR TITLE
Feature: Improve when `umb-code-editor` loads Monaco

### DIFF
--- a/src/external/monaco-editor/index.ts
+++ b/src/external/monaco-editor/index.ts
@@ -13,20 +13,6 @@ import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker.js?worker
 import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker.js?worker';
 /* eslint-enable */
 
-import { css, unsafeCSS } from '@umbraco-cms/backoffice/external/lit';
-
-export const monacoEditorStyles = css`
-	${unsafeCSS(styles)}
-`;
-
-export const monacoJumpingCursorHack = css`
-	/* a hacky workaround this issue: https://github.com/microsoft/monaco-editor/issues/3217
-	should probably be removed when the issue is fixed */
-	.view-lines {
-		font-feature-settings: revert !important;
-	}
-`;
-
 const initializeWorkers = () => {
 	self.MonacoEnvironment = {
 		getWorker(workerId: string, label: string): Promise<Worker> | Worker {
@@ -50,3 +36,4 @@ const initializeWorkers = () => {
 initializeWorkers();
 
 export * as monaco from 'monaco-editor';
+export { styles };

--- a/src/packages/core/modal/common/code-editor/code-editor-modal.element.ts
+++ b/src/packages/core/modal/common/code-editor/code-editor-modal.element.ts
@@ -1,21 +1,16 @@
 import { css, html, ifDefined, customElement, query } from '@umbraco-cms/backoffice/external/lit';
-import { loadCodeEditor, type UmbCodeEditorElement } from '@umbraco-cms/backoffice/code-editor';
-import type { UmbCodeEditorModalData, UmbCodeEditorModalValue } from '@umbraco-cms/backoffice/modal';
 import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
-import { UmbBooleanState } from '@umbraco-cms/backoffice/observable-api';
+import type { UmbCodeEditorElement } from '@umbraco-cms/backoffice/code-editor';
+import type { UmbCodeEditorModalData, UmbCodeEditorModalValue } from '@umbraco-cms/backoffice/modal';
 
-@customElement('umb-code-editor-modal')
+import '@umbraco-cms/backoffice/code-editor';
+
+const elementName = 'umb-code-editor-modal';
+
+@customElement(elementName)
 export class UmbCodeEditorModalElement extends UmbModalBaseElement<UmbCodeEditorModalData, UmbCodeEditorModalValue> {
-	#isCodeEditorReady = new UmbBooleanState(false);
-	isCodeEditorReady = this.#isCodeEditorReady.asObservable();
-
 	@query('umb-code-editor')
 	_codeEditor?: UmbCodeEditorElement;
-
-	constructor() {
-		super();
-		this.#loadCodeEditor();
-	}
 
 	#handleConfirm() {
 		this.value = { content: this._codeEditor?.editor?.monacoEditor?.getValue() ?? '' };
@@ -25,34 +20,15 @@ export class UmbCodeEditorModalElement extends UmbModalBaseElement<UmbCodeEditor
 	#handleCancel() {
 		this.modalContext?.reject();
 	}
-
-	async #loadCodeEditor() {
-		try {
-			await loadCodeEditor();
-			this.#isCodeEditorReady.setValue(true);
-		} catch (error) {
-			console.error(error);
-		}
-	}
-
-	#renderCodeEditor() {
-		return html`<umb-code-editor
-			language=${ifDefined(this.data?.language)}
-			.code=${this.data?.content ?? ''}></umb-code-editor>`;
-	}
-
-	#renderLoading() {
-		return html`<div id="loader-container">
-			<uui-loader></uui-loader>
-		</div>`;
-	}
-
 	override render() {
 		return html`
 			<umb-body-layout .headline=${this.data?.headline ?? 'Code Editor'}>
-				<div id="editor-box">${this.isCodeEditorReady ? this.#renderCodeEditor() : this.#renderLoading()}</div>
+				<div id="editor-box">${this.#renderCodeEditor()}</div>
 				<div slot="actions">
-					<uui-button id="cancel" label="Cancel" @click="${this.#handleCancel}">Cancel</uui-button>
+					<uui-button
+						id="cancel"
+						label=${this.localize.term('general_cancel')}
+						@click=${this.#handleCancel}></uui-button>
 					<uui-button
 						id="confirm"
 						color="${this.data?.color || 'positive'}"
@@ -61,6 +37,12 @@ export class UmbCodeEditorModalElement extends UmbModalBaseElement<UmbCodeEditor
 						@click=${this.#handleConfirm}></uui-button>
 				</div>
 			</umb-body-layout>
+		`;
+	}
+
+	#renderCodeEditor() {
+		return html`
+			<umb-code-editor language=${ifDefined(this.data?.language)} .code=${this.data?.content ?? ''}></umb-code-editor>
 		`;
 	}
 
@@ -83,6 +65,6 @@ export default UmbCodeEditorModalElement;
 
 declare global {
 	interface HTMLElementTagNameMap {
-		'umb-code-editor-modal': UmbCodeEditorModalElement;
+		[elementName]: UmbCodeEditorModalElement;
 	}
 }

--- a/src/packages/core/modal/common/code-editor/code-editor-modal.element.ts
+++ b/src/packages/core/modal/common/code-editor/code-editor-modal.element.ts
@@ -33,7 +33,7 @@ export class UmbCodeEditorModalElement extends UmbModalBaseElement<UmbCodeEditor
 						id="confirm"
 						color="${this.data?.color || 'positive'}"
 						look="primary"
-						label="${this.data?.confirmLabel || 'Submit'}"
+						label="${this.data?.confirmLabel || this.localize.term('general_submit')}"
 						@click=${this.#handleConfirm}></uui-button>
 				</div>
 			</umb-body-layout>

--- a/src/packages/core/workspace/components/workspace-editor/workspace-editor.element.ts
+++ b/src/packages/core/workspace/components/workspace-editor/workspace-editor.element.ts
@@ -14,7 +14,7 @@ import type { UmbRoute, UmbRouterSlotInitEvent, UmbRouterSlotChangeEvent } from 
  * @slot name - Slot for name
  * @slot footer - Slot for workspace footer
  * @slot actions - Slot for workspace footer actions
- * @slot default - slot for main content
+ * @slot - slot for main content
  * @export
  * @class UmbWorkspaceEditor
  * @extends {UmbLitElement}

--- a/src/packages/templating/code-editor/code-editor-loaded.event.ts
+++ b/src/packages/templating/code-editor/code-editor-loaded.event.ts
@@ -1,0 +1,7 @@
+export class UmbCodeEditorLoadedEvent extends Event {
+	public static readonly TYPE = 'loaded';
+
+	public constructor() {
+		super(UmbCodeEditorLoadedEvent.TYPE, { bubbles: true, composed: true, cancelable: false });
+	}
+}

--- a/src/packages/templating/code-editor/code-editor-loaded.event.ts
+++ b/src/packages/templating/code-editor/code-editor-loaded.event.ts
@@ -2,6 +2,6 @@ export class UmbCodeEditorLoadedEvent extends Event {
 	public static readonly TYPE = 'loaded';
 
 	public constructor() {
-		super(UmbCodeEditorLoadedEvent.TYPE, { bubbles: true, composed: true, cancelable: false });
+		super(UmbCodeEditorLoadedEvent.TYPE, { bubbles: true, cancelable: false });
 	}
 }

--- a/src/packages/templating/code-editor/code-editor.controller.ts
+++ b/src/packages/templating/code-editor/code-editor.controller.ts
@@ -144,6 +144,7 @@ export class UmbCodeEditorController {
 		this.#editor?.onDidChangeModel(() => {
 			this.#host.dispatchEvent(new UmbChangeEvent());
 		});
+
 		this.#editor?.onDidChangeCursorPosition((e) => {
 			this.#position = e.position;
 			this.#secondaryPositions = e.secondaryPositions;
@@ -192,6 +193,7 @@ export class UmbCodeEditorController {
 			readOnly: this.#host.readonly,
 			ariaLabel: this.#host.label,
 		});
+
 		this.#initiateEvents();
 	}
 	/**
@@ -376,3 +378,5 @@ export class UmbCodeEditorController {
 		});
 	}
 }
+
+export default UmbCodeEditorController;

--- a/src/packages/templating/code-editor/code-editor.element.ts
+++ b/src/packages/templating/code-editor/code-editor.element.ts
@@ -1,11 +1,23 @@
-import { UmbCodeEditorController } from './code-editor.controller.js';
+import type { UmbCodeEditorController } from './code-editor.controller.js';
 import type { CodeEditorLanguage, CodeEditorSearchOptions, UmbCodeEditorHost } from './code-editor.model.js';
 import { CodeEditorTheme } from './code-editor.model.js';
+import { UmbCodeEditorLoadedEvent } from './code-editor-loaded.event.js';
 import { UMB_THEME_CONTEXT } from '@umbraco-cms/backoffice/themes';
-import { monacoEditorStyles, monacoJumpingCursorHack } from '@umbraco-cms/backoffice/external/monaco-editor';
 import type { PropertyValues, Ref } from '@umbraco-cms/backoffice/external/lit';
-import { css, html, createRef, ref, customElement, property } from '@umbraco-cms/backoffice/external/lit';
+import {
+	createRef,
+	css,
+	customElement,
+	html,
+	property,
+	ref,
+	state,
+	unsafeCSS,
+	when,
+} from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+
+const elementName = 'umb-code-editor';
 
 /**
  * A custom element that renders a code editor. Code editor is based on the Monaco Editor library.
@@ -21,7 +33,7 @@ import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
  * @fires input - Fired when the value of the editor changes.
  * @fires change - Fired when the entire model of editor is replaced.
  */
-@customElement('umb-code-editor')
+@customElement(elementName)
 export class UmbCodeEditorElement extends UmbLitElement implements UmbCodeEditorHost {
 	private containerRef: Ref<HTMLElement> = createRef();
 
@@ -88,8 +100,15 @@ export class UmbCodeEditorElement extends UmbLitElement implements UmbCodeEditor
 	@property({ type: Boolean, attribute: 'readonly' })
 	readonly = false;
 
+	@state()
+	private _loading = true;
+
+	@state()
+	private _styles?: string;
+
 	constructor() {
 		super();
+
 		this.consumeContext(UMB_THEME_CONTEXT, (instance) => {
 			this.observe(
 				instance.theme,
@@ -101,8 +120,15 @@ export class UmbCodeEditorElement extends UmbLitElement implements UmbCodeEditor
 		});
 	}
 
-	override firstUpdated() {
-		this.#editor = new UmbCodeEditorController(this);
+	override async firstUpdated() {
+		const { styles } = await import('@umbraco-cms/backoffice/external/monaco-editor');
+		this._styles = styles;
+
+		const controller = (await import('./code-editor.controller.js')).default;
+		this.#editor = new controller(this);
+
+		this._loading = false;
+		this.dispatchEvent(new UmbCodeEditorLoadedEvent());
 	}
 
 	protected override updated(_changedProperties: PropertyValues<this>): void {
@@ -149,16 +175,34 @@ export class UmbCodeEditorElement extends UmbLitElement implements UmbCodeEditor
 	}
 
 	override render() {
-		return html` <div id="editor-container" ${ref(this.containerRef)}></div> `;
+		return html`
+			${this.#renderStyles()}
+			${when(this._loading, () => html`<div id="loader-container"><uui-loader></uui-loader></div>`)}
+			<div id="editor-container" ${ref(this.containerRef)}></div>
+		`;
+	}
+
+	#renderStyles() {
+		if (!this._styles) return;
+		return html`
+			<style>
+				${unsafeCSS(this._styles)}
+			</style>
+		`;
 	}
 
 	static override styles = [
-		monacoEditorStyles,
-		monacoJumpingCursorHack,
 		css`
 			:host {
 				display: block;
 			}
+
+			#loader-container {
+				display: grid;
+				place-items: center;
+				min-height: calc(100dvh - 260px);
+			}
+
 			#editor-container {
 				width: var(--editor-width);
 				height: var(--editor-height, 100%);
@@ -167,6 +211,12 @@ export class UmbCodeEditorElement extends UmbLitElement implements UmbCodeEditor
 				--vscode-scrollbarSlider-background: var(--uui-color-disabled-contrast);
 				--vscode-scrollbarSlider-hoverBackground: rgba(100, 100, 100, 0.7);
 				--vscode-scrollbarSlider-activeBackground: rgba(0, 0, 0, 0.6);
+
+				/* a hacky workaround this issue: https://github.com/microsoft/monaco-editor/issues/3217
+			   should probably be removed when the issue is fixed */
+				.view-lines {
+					font-feature-settings: revert !important;
+				}
 			}
 		`,
 	];
@@ -174,6 +224,6 @@ export class UmbCodeEditorElement extends UmbLitElement implements UmbCodeEditor
 
 declare global {
 	interface HTMLElementTagNameMap {
-		'umb-code-editor': UmbCodeEditorElement;
+		[elementName]: UmbCodeEditorElement;
 	}
 }

--- a/src/packages/templating/code-editor/code-editor.element.ts
+++ b/src/packages/templating/code-editor/code-editor.element.ts
@@ -32,6 +32,7 @@ const elementName = 'umb-code-editor';
  * @implements {UmbCodeEditorHost}
  * @fires input - Fired when the value of the editor changes.
  * @fires change - Fired when the entire model of editor is replaced.
+ * @fires loaded - Fired when the editor is loaded and ready to use.
  */
 @customElement(elementName)
 export class UmbCodeEditorElement extends UmbLitElement implements UmbCodeEditorHost {

--- a/src/packages/templating/code-editor/index.ts
+++ b/src/packages/templating/code-editor/index.ts
@@ -1,6 +1,12 @@
-export type { UmbCodeEditorElement } from './code-editor.element.js';
+export { UmbCodeEditorElement } from './code-editor.element.js';
+export { UmbCodeEditorLoadedEvent } from './code-editor-loaded.event.js';
 export type { UmbCodeEditorController } from './code-editor.controller.js';
+export type * from './code-editor.model.js';
 
+/**
+ * @deprecated Use `import from '@umbraco-cms/backoffice/code-editor';` directly.
+ * This function will be removed in Umbraco 15.
+ */
 export function loadCodeEditor() {
-	return import('./code-editor.element.js');
+	return import('@umbraco-cms/backoffice/code-editor');
 }

--- a/src/packages/templating/partial-views/workspace/partial-view-workspace-editor.element.ts
+++ b/src/packages/templating/partial-views/workspace/partial-view-workspace-editor.element.ts
@@ -82,22 +82,23 @@ export class UmbPartialViewWorkspaceEditorElement extends UmbLitElement {
 			<umb-workspace-editor alias="Umb.Workspace.PartialView">
 				<div id="workspace-header" slot="header">
 					<uui-input
-						placeholder="Enter name..."
+						placeholder=${this.localize.term('placeholders_entername')}
 						.value=${this._name}
 						@input=${this.#onNameInput}
-						label="Partial view name"
+						label=${this.localize.term('placeholders_entername')}
 						?readonly=${this._isNew === false}
 						${umbFocus()}></uui-input>
 				</div>
 				<uui-box>
 					<div slot="header" id="code-editor-menu-container">
 						<umb-templating-insert-menu @insert=${this.#insertSnippet} hidePartialViews></umb-templating-insert-menu>
-						<uui-button
+						<umb-localize
 							look="secondary"
 							id="query-builder-button"
-							label="Query builder"
+							label=${this.localize.term('template_queryBuilder')}
 							@click=${this.#openQueryBuilder}>
-							<uui-icon name="icon-wand"></uui-icon>Query builder
+							<uui-icon name="icon-wand"></uui-icon>
+							<umb-localize key="template_queryBuilder">Query builder</umb-localize>
 						</uui-button>
 					</div>
 					${this.#renderCodeEditor()}

--- a/src/packages/templating/partial-views/workspace/partial-view-workspace-editor.element.ts
+++ b/src/packages/templating/partial-views/workspace/partial-view-workspace-editor.element.ts
@@ -1,14 +1,14 @@
-import type { UmbTemplatingInsertMenuElement } from '../../local-components/insert-menu/index.js';
 import { getQuerySnippet } from '../../utils/index.js';
+import type { UmbTemplatingInsertMenuElement } from '../../local-components/insert-menu/index.js';
 import { UMB_PARTIAL_VIEW_WORKSPACE_CONTEXT } from './partial-view-workspace.context-token.js';
-import type { UUIInputElement } from '@umbraco-cms/backoffice/external/uui';
-import { css, html, customElement, query, state, nothing } from '@umbraco-cms/backoffice/external/lit';
+import { css, customElement, html, query, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement, umbFocus } from '@umbraco-cms/backoffice/lit-element';
 import { UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
 import { UMB_TEMPLATE_QUERY_BUILDER_MODAL } from '@umbraco-cms/backoffice/template';
 import type { UmbCodeEditorElement } from '@umbraco-cms/backoffice/code-editor';
+import type { UUIInputElement } from '@umbraco-cms/backoffice/external/uui';
 
-// import local components
+import '@umbraco-cms/backoffice/code-editor';
 import '../../local-components/insert-menu/index.js';
 
 @customElement('umb-partial-view-workspace-editor')
@@ -18,9 +18,6 @@ export class UmbPartialViewWorkspaceEditorElement extends UmbLitElement {
 
 	@state()
 	private _content?: string | null = '';
-
-	@state()
-	private _ready: boolean = false;
 
 	@state()
 	private _isNew?: boolean;
@@ -41,10 +38,6 @@ export class UmbPartialViewWorkspaceEditorElement extends UmbLitElement {
 
 			this.observe(this.#workspaceContext.content, (content) => {
 				this._content = content;
-			});
-
-			this.observe(this.#workspaceContext.isCodeEditorReady, (isReady) => {
-				this._ready = isReady;
 			});
 
 			this.observe(this.#workspaceContext.isNew, (isNew) => {
@@ -83,45 +76,44 @@ export class UmbPartialViewWorkspaceEditorElement extends UmbLitElement {
 			.catch(() => undefined);
 	}
 
-	#renderCodeEditor() {
-		return html`<umb-code-editor
-			language="razor"
-			id="content"
-			.code=${this._content ?? ''}
-			@input=${this.#onCodeEditorInput}></umb-code-editor>`;
+	override render() {
+		if (this._isNew === undefined) return;
+		return html`
+			<umb-workspace-editor alias="Umb.Workspace.PartialView">
+				<div id="workspace-header" slot="header">
+					<uui-input
+						placeholder="Enter name..."
+						.value=${this._name}
+						@input=${this.#onNameInput}
+						label="Partial view name"
+						?readonly=${this._isNew === false}
+						${umbFocus()}></uui-input>
+				</div>
+				<uui-box>
+					<div slot="header" id="code-editor-menu-container">
+						<umb-templating-insert-menu @insert=${this.#insertSnippet} hidePartialViews></umb-templating-insert-menu>
+						<uui-button
+							look="secondary"
+							id="query-builder-button"
+							label="Query builder"
+							@click=${this.#openQueryBuilder}>
+							<uui-icon name="icon-wand"></uui-icon>Query builder
+						</uui-button>
+					</div>
+					${this.#renderCodeEditor()}
+				</uui-box>
+			</umb-workspace-editor>
+		`;
 	}
 
-	override render() {
-		return this._isNew !== undefined
-			? html`<umb-workspace-editor alias="Umb.Workspace.PartialView">
-					<div id="workspace-header" slot="header">
-						<uui-input
-							placeholder="Enter name..."
-							.value=${this._name}
-							@input=${this.#onNameInput}
-							label="Partial view name"
-							?readonly=${this._isNew === false}
-							${umbFocus()}></uui-input>
-					</div>
-					<uui-box>
-						<div slot="header" id="code-editor-menu-container">
-							<umb-templating-insert-menu @insert=${this.#insertSnippet} hidePartialViews></umb-templating-insert-menu>
-							<uui-button
-								look="secondary"
-								id="query-builder-button"
-								label="Query builder"
-								@click=${this.#openQueryBuilder}>
-								<uui-icon name="icon-wand"></uui-icon>Query builder
-							</uui-button>
-						</div>
-						${this._ready
-							? this.#renderCodeEditor()
-							: html`<div id="loader-container">
-									<uui-loader></uui-loader>
-								</div>`}
-					</uui-box>
-				</umb-workspace-editor>`
-			: nothing;
+	#renderCodeEditor() {
+		return html`
+			<umb-code-editor
+				id="content"
+				language="razor"
+				.code=${this._content ?? ''}
+				@input=${this.#onCodeEditorInput}></umb-code-editor>
+		`;
 	}
 
 	static override styles = [
@@ -130,12 +122,6 @@ export class UmbPartialViewWorkspaceEditorElement extends UmbLitElement {
 				display: block;
 				width: 100%;
 				height: 100%;
-			}
-
-			#loader-container {
-				display: grid;
-				place-items: center;
-				min-height: calc(100dvh - 360px);
 			}
 
 			umb-code-editor {

--- a/src/packages/templating/partial-views/workspace/partial-view-workspace.context.ts
+++ b/src/packages/templating/partial-views/workspace/partial-view-workspace.context.ts
@@ -2,14 +2,13 @@ import { UmbPartialViewDetailRepository } from '../repository/partial-view-detai
 import type { UmbPartialViewDetailModel } from '../types.js';
 import { UMB_PARTIAL_VIEW_ENTITY_TYPE } from '../entity.js';
 import { UmbPartialViewWorkspaceEditorElement } from './partial-view-workspace-editor.element.js';
-import { UmbBooleanState, UmbObjectState } from '@umbraco-cms/backoffice/observable-api';
+import { UmbObjectState } from '@umbraco-cms/backoffice/observable-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import type { UmbRoutableWorkspaceContext, UmbSubmittableWorkspaceContext } from '@umbraco-cms/backoffice/workspace';
 import {
 	UmbSubmittableWorkspaceContextBase,
 	UmbWorkspaceIsNewRedirectController,
 } from '@umbraco-cms/backoffice/workspace';
-import { loadCodeEditor } from '@umbraco-cms/backoffice/code-editor';
 import { tryExecuteAndNotify } from '@umbraco-cms/backoffice/resources';
 import { PartialViewService } from '@umbraco-cms/backoffice/external/backend-api';
 import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
@@ -36,12 +35,8 @@ export class UmbPartialViewWorkspaceContext
 	readonly name = this.#data.asObservablePart((data) => data?.name);
 	readonly content = this.#data.asObservablePart((data) => data?.content);
 
-	#isCodeEditorReady = new UmbBooleanState(false);
-	readonly isCodeEditorReady = this.#isCodeEditorReady.asObservable();
-
 	constructor(host: UmbControllerHost) {
 		super(host, 'Umb.Workspace.PartialView');
-		this.#loadCodeEditor();
 
 		this.routes.setRoutes([
 			{
@@ -87,15 +82,6 @@ export class UmbPartialViewWorkspaceContext
 	protected override resetState(): void {
 		super.resetState();
 		this.#data.setValue(undefined);
-	}
-
-	async #loadCodeEditor() {
-		try {
-			await loadCodeEditor();
-			this.#isCodeEditorReady.setValue(true);
-		} catch (error) {
-			console.error(error);
-		}
 	}
 
 	getUnique() {

--- a/src/packages/templating/scripts/workspace/script-workspace-editor.element.ts
+++ b/src/packages/templating/scripts/workspace/script-workspace-editor.element.ts
@@ -1,9 +1,10 @@
 import { UMB_SCRIPT_WORKSPACE_CONTEXT } from './script-workspace.context-token.js';
-import type { UmbCodeEditorElement } from '@umbraco-cms/backoffice/code-editor';
-import { css, html, customElement, state, nothing } from '@umbraco-cms/backoffice/external/lit';
-import type { UUIInputElement } from '@umbraco-cms/backoffice/external/uui';
+import { css, html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement, umbFocus } from '@umbraco-cms/backoffice/lit-element';
-import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
+import type { UmbCodeEditorElement } from '@umbraco-cms/backoffice/code-editor';
+import type { UUIInputElement } from '@umbraco-cms/backoffice/external/uui';
+
+import '@umbraco-cms/backoffice/code-editor';
 
 @customElement('umb-script-workspace-editor')
 export class UmbScriptWorkspaceEditorElement extends UmbLitElement {
@@ -12,9 +13,6 @@ export class UmbScriptWorkspaceEditorElement extends UmbLitElement {
 
 	@state()
 	private _content?: string | null = '';
-
-	@state()
-	private _ready?: boolean = false;
 
 	@state()
 	private _isNew?: boolean;
@@ -35,10 +33,6 @@ export class UmbScriptWorkspaceEditorElement extends UmbLitElement {
 				this._content = content;
 			});
 
-			this.observe(this.#context.isCodeEditorReady, (isReady) => {
-				this._ready = isReady;
-			});
-
 			this.observe(this.#context.isNew, (isNew) => {
 				this._isNew = isNew;
 			});
@@ -57,51 +51,44 @@ export class UmbScriptWorkspaceEditorElement extends UmbLitElement {
 		this.#context?.setContent(value);
 	}
 
-	#renderCodeEditor() {
-		return html`<umb-code-editor
-			language="javascript"
-			id="content"
-			.code=${this._content ?? ''}
-			@input=${this.#onCodeEditorInput}></umb-code-editor>`;
+	override render() {
+		if (this._isNew === undefined) return;
+		return html`
+			<umb-workspace-editor alias="Umb.Workspace.Script">
+				<div id="workspace-header" slot="header">
+					<uui-input
+						placeholder="Enter name..."
+						.value=${this._name}
+						@input=${this.#onNameInput}
+						label="Script name"
+						?readonly=${this._isNew === false}
+						${umbFocus()}>
+					</uui-input>
+				</div>
+				<uui-box>
+					<!-- the div below in the header is to make the box display nicely with code editor -->
+					<div slot="header"></div>
+					${this.#renderCodeEditor()}
+				</uui-box>
+			</umb-workspace-editor>
+		`;
 	}
 
-	override render() {
-		return this._isNew !== undefined
-			? html`<umb-workspace-editor alias="Umb.Workspace.Script">
-					<div id="workspace-header" slot="header">
-						<uui-input
-							placeholder="Enter name..."
-							.value=${this._name}
-							@input=${this.#onNameInput}
-							label="Script name"
-							?readonly=${this._isNew === false}
-							${umbFocus()}></uui-input>
-					</div>
-					<uui-box>
-						<!-- the div below in the header is to make the box display nicely with code editor -->
-						<div slot="header"></div>
-						${this._ready
-							? this.#renderCodeEditor()
-							: html`<div id="loader-container">
-									<uui-loader></uui-loader>
-								</div>`}
-					</uui-box>
-				</umb-workspace-editor>`
-			: nothing;
+	#renderCodeEditor() {
+		return html`
+			<umb-code-editor
+				id="content"
+				language="javascript"
+				.code=${this._content ?? ''}
+				@input=${this.#onCodeEditorInput}></umb-code-editor>
+		`;
 	}
 
 	static override styles = [
-		UmbTextStyles,
 		css`
 			:host {
 				display: block;
 				width: 100%;
-			}
-
-			#loader-container {
-				display: grid;
-				place-items: center;
-				min-height: calc(100dvh - 260px);
 			}
 
 			umb-code-editor {

--- a/src/packages/templating/scripts/workspace/script-workspace-editor.element.ts
+++ b/src/packages/templating/scripts/workspace/script-workspace-editor.element.ts
@@ -57,10 +57,10 @@ export class UmbScriptWorkspaceEditorElement extends UmbLitElement {
 			<umb-workspace-editor alias="Umb.Workspace.Script">
 				<div id="workspace-header" slot="header">
 					<uui-input
-						placeholder="Enter name..."
+						placeholder=${this.localize.term('placeholders_entername')}
 						.value=${this._name}
 						@input=${this.#onNameInput}
-						label="Script name"
+						label=${this.localize.term('placeholders_entername')}
 						?readonly=${this._isNew === false}
 						${umbFocus()}>
 					</uui-input>

--- a/src/packages/templating/scripts/workspace/script-workspace.context.ts
+++ b/src/packages/templating/scripts/workspace/script-workspace.context.ts
@@ -3,7 +3,7 @@ import type { UmbScriptDetailModel } from '../types.js';
 import { UMB_SCRIPT_ENTITY_TYPE } from '../entity.js';
 import { UMB_SCRIPT_WORKSPACE_ALIAS } from './manifests.js';
 import { UmbScriptWorkspaceEditorElement } from './script-workspace-editor.element.js';
-import { UmbBooleanState, UmbObjectState } from '@umbraco-cms/backoffice/observable-api';
+import { UmbObjectState } from '@umbraco-cms/backoffice/observable-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import {
 	UmbSubmittableWorkspaceContextBase,
@@ -11,7 +11,6 @@ import {
 	type UmbSubmittableWorkspaceContext,
 	UmbWorkspaceIsNewRedirectController,
 } from '@umbraco-cms/backoffice/workspace';
-import { loadCodeEditor } from '@umbraco-cms/backoffice/code-editor';
 import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
 import {
 	UmbRequestReloadChildrenOfEntityEvent,
@@ -37,12 +36,8 @@ export class UmbScriptWorkspaceContext
 	readonly name = this.#data.asObservablePart((data) => data?.name);
 	readonly content = this.#data.asObservablePart((data) => data?.content);
 
-	#isCodeEditorReady = new UmbBooleanState(false);
-	readonly isCodeEditorReady = this.#isCodeEditorReady.asObservable();
-
 	constructor(host: UmbControllerHost) {
 		super(host, UMB_SCRIPT_WORKSPACE_ALIAS);
-		this.#loadCodeEditor();
 
 		this.routes.setRoutes([
 			{
@@ -74,15 +69,6 @@ export class UmbScriptWorkspaceContext
 	protected override resetState(): void {
 		super.resetState();
 		this.#data.setValue(undefined);
-	}
-
-	async #loadCodeEditor() {
-		try {
-			await loadCodeEditor();
-			this.#isCodeEditorReady.setValue(true);
-		} catch (error) {
-			console.error(error);
-		}
 	}
 
 	getEntityType(): string {

--- a/src/packages/templating/stylesheets/workspace/stylesheet-workspace.context.ts
+++ b/src/packages/templating/stylesheets/workspace/stylesheet-workspace.context.ts
@@ -10,8 +10,7 @@ import {
 	type UmbRoutableWorkspaceContext,
 } from '@umbraco-cms/backoffice/workspace';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
-import { UmbBooleanState, UmbObjectState } from '@umbraco-cms/backoffice/observable-api';
-import { loadCodeEditor } from '@umbraco-cms/backoffice/code-editor';
+import { UmbObjectState } from '@umbraco-cms/backoffice/observable-api';
 import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
 import {
 	UmbRequestReloadChildrenOfEntityEvent,
@@ -36,12 +35,8 @@ export class UmbStylesheetWorkspaceContext
 	readonly name = this.#data.asObservablePart((data) => data?.name);
 	readonly content = this.#data.asObservablePart((data) => data?.content);
 
-	#isCodeEditorReady = new UmbBooleanState(false);
-	readonly isCodeEditorReady = this.#isCodeEditorReady.asObservable();
-
 	constructor(host: UmbControllerHost) {
 		super(host, UMB_STYLESHEET_WORKSPACE_ALIAS);
-		this.#loadCodeEditor();
 
 		this.routes.setRoutes([
 			{
@@ -74,15 +69,6 @@ export class UmbStylesheetWorkspaceContext
 	protected override resetState(): void {
 		super.resetState();
 		this.#data.setValue(undefined);
-	}
-
-	async #loadCodeEditor() {
-		try {
-			await loadCodeEditor();
-			this.#isCodeEditorReady.setValue(true);
-		} catch (error) {
-			console.error(error);
-		}
 	}
 
 	getEntityType(): string {

--- a/src/packages/templating/stylesheets/workspace/views/code-editor/stylesheet-code-editor-workspace-view.element.ts
+++ b/src/packages/templating/stylesheets/workspace/views/code-editor/stylesheet-code-editor-workspace-view.element.ts
@@ -5,13 +5,12 @@ import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { UmbCodeEditorElement } from '@umbraco-cms/backoffice/code-editor';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 
+import '@umbraco-cms/backoffice/code-editor';
+
 @customElement('umb-stylesheet-code-editor-workspace-view')
 export class UmbStylesheetCodeEditorWorkspaceViewElement extends UmbLitElement {
 	@state()
 	private _content?: string | null = '';
-
-	@state()
-	private _ready?: boolean = false;
 
 	#stylesheetWorkspaceContext?: UmbStylesheetWorkspaceContext;
 
@@ -24,10 +23,6 @@ export class UmbStylesheetCodeEditorWorkspaceViewElement extends UmbLitElement {
 			this.observe(this.#stylesheetWorkspaceContext.content, (content) => {
 				this._content = content;
 			});
-
-			this.observe(this.#stylesheetWorkspaceContext.isCodeEditorReady, (isReady) => {
-				this._ready = isReady;
-			});
 		});
 	}
 
@@ -37,23 +32,21 @@ export class UmbStylesheetCodeEditorWorkspaceViewElement extends UmbLitElement {
 		this.#stylesheetWorkspaceContext?.setContent(value);
 	}
 
-	#renderCodeEditor() {
-		return html`<umb-code-editor
-			language="css"
-			id="content"
-			.code=${this._content ?? ''}
-			@input=${this.#onCodeEditorInput}></umb-code-editor>`;
-	}
-
 	override render() {
 		return html` <uui-box>
 			<div slot="header" id="code-editor-menu-container"></div>
-			${this._ready
-				? this.#renderCodeEditor()
-				: html`<div id="loader-container">
-						<uui-loader></uui-loader>
-					</div>`}
+			${this.#renderCodeEditor()}
 		</uui-box>`;
+	}
+
+	#renderCodeEditor() {
+		return html`
+			<umb-code-editor
+				id="content"
+				language="css"
+				.code=${this._content ?? ''}
+				@input=${this.#onCodeEditorInput}></umb-code-editor>
+		`;
 	}
 
 	static override styles = [
@@ -62,12 +55,6 @@ export class UmbStylesheetCodeEditorWorkspaceViewElement extends UmbLitElement {
 			:host {
 				display: block;
 				width: 100%;
-			}
-
-			#loader-container {
-				display: grid;
-				place-items: center;
-				min-height: calc(100dvh - 300px);
 			}
 
 			umb-code-editor {

--- a/src/packages/templating/templates/workspace/template-workspace-editor.element.ts
+++ b/src/packages/templating/templates/workspace/template-workspace-editor.element.ts
@@ -13,7 +13,7 @@ import { Subject, debounceTime } from '@umbraco-cms/backoffice/external/rxjs';
 import type { UmbCodeEditorElement } from '@umbraco-cms/backoffice/code-editor';
 import { UMB_TEMPLATE_PICKER_MODAL } from '@umbraco-cms/backoffice/template';
 
-// import local components
+import '@umbraco-cms/backoffice/code-editor';
 import '../../local-components/insert-menu/index.js';
 
 @customElement('umb-template-workspace-editor')
@@ -28,9 +28,6 @@ export class UmbTemplateWorkspaceEditorElement extends UmbLitElement {
 
 	@state()
 	private _alias?: string | null = '';
-
-	@state()
-	private _ready?: boolean = false;
 
 	@state()
 	private _masterTemplateName?: string | null = null;
@@ -74,10 +71,6 @@ export class UmbTemplateWorkspaceEditorElement extends UmbLitElement {
 
 			this.observe(this.#templateWorkspaceContext.isNew, (isNew) => {
 				this.#isNew = !!isNew;
-			});
-
-			this.observe(this.#templateWorkspaceContext.isCodeEditorReady, (isReady) => {
-				this._ready = isReady;
 			});
 
 			this.inputQuery$.pipe(debounceTime(250)).subscribe((nameInputValue) => {
@@ -182,54 +175,54 @@ export class UmbTemplateWorkspaceEditorElement extends UmbLitElement {
 		`;
 	}
 
-	#renderCodeEditor() {
-		return html`<umb-code-editor
-			language="razor"
-			id="content"
-			.code=${this._content ?? ''}
-			@input=${this.#onCodeEditorInput}></umb-code-editor>`;
-	}
-
 	override render() {
 		// TODO: add correct UI elements
-		return html`<umb-workspace-editor alias="Umb.Workspace.Template">
-			<uui-input
-				placeholder=${this.localize.term('placeholders_entername')}
-				slot="header"
-				.value=${this._name}
-				@input=${this.#onNameInput}
-				label=${this.localize.term('template_template')}
-				${umbFocus()}>
-				<uui-input-lock slot="append" value=${ifDefined(this._alias!)} @input=${this.#onAliasInput}></uui-input-lock>
-			</uui-input>
+		return html`
+			<umb-workspace-editor alias="Umb.Workspace.Template">
+				<uui-input
+					placeholder=${this.localize.term('placeholders_entername')}
+					slot="header"
+					.value=${this._name}
+					@input=${this.#onNameInput}
+					label=${this.localize.term('template_template')}
+					${umbFocus()}>
+					<uui-input-lock slot="append" value=${ifDefined(this._alias!)} @input=${this.#onAliasInput}></uui-input-lock>
+				</uui-input>
 
-			<uui-box>
-				<div slot="header" id="code-editor-menu-container">${this.#renderMasterTemplatePicker()}</div>
-				<div slot="header-actions">
-					<umb-templating-insert-menu @insert=${this.#insertSnippet}></umb-templating-insert-menu>
-					<uui-button
-						look="secondary"
-						id="query-builder-button"
-						label=${this.localize.term('template_queryBuilder')}
-						@click=${this.#openQueryBuilder}>
-						<uui-icon name="icon-wand"></uui-icon> ${this.localize.term('template_queryBuilder')}
-					</uui-button>
-					<uui-button
-						look="secondary"
-						id="sections-button"
-						label=${this.localize.term('template_insertSections')}
-						@click=${this.#openInsertSectionModal}>
-						<uui-icon name="icon-indent"></uui-icon> ${this.localize.term('template_insertSections')}
-					</uui-button>
-				</div>
+				<uui-box>
+					<div slot="header" id="code-editor-menu-container">${this.#renderMasterTemplatePicker()}</div>
+					<div slot="header-actions">
+						<umb-templating-insert-menu @insert=${this.#insertSnippet}></umb-templating-insert-menu>
+						<uui-button
+							look="secondary"
+							id="query-builder-button"
+							label=${this.localize.term('template_queryBuilder')}
+							@click=${this.#openQueryBuilder}>
+							<uui-icon name="icon-wand"></uui-icon> ${this.localize.term('template_queryBuilder')}
+						</uui-button>
+						<uui-button
+							look="secondary"
+							id="sections-button"
+							label=${this.localize.term('template_insertSections')}
+							@click=${this.#openInsertSectionModal}>
+							<uui-icon name="icon-indent"></uui-icon> ${this.localize.term('template_insertSections')}
+						</uui-button>
+					</div>
 
-				${this._ready
-					? this.#renderCodeEditor()
-					: html`<div id="loader-container">
-							<uui-loader></uui-loader>
-						</div>`}
-			</uui-box>
-		</umb-workspace-editor>`;
+					${this.#renderCodeEditor()}
+				</uui-box>
+			</umb-workspace-editor>
+		`;
+	}
+
+	#renderCodeEditor() {
+		return html`
+			<umb-code-editor
+				id="content"
+				language="razor"
+				.code=${this._content ?? ''}
+				@input=${this.#onCodeEditorInput}></umb-code-editor>
+		`;
 	}
 
 	static override styles = [

--- a/src/packages/templating/templates/workspace/template-workspace.context.ts
+++ b/src/packages/templating/templates/workspace/template-workspace.context.ts
@@ -3,13 +3,12 @@ import type { UmbTemplateItemModel } from '../repository/index.js';
 import { UmbTemplateDetailRepository, UmbTemplateItemRepository } from '../repository/index.js';
 import { UMB_TEMPLATE_WORKSPACE_ALIAS } from './manifests.js';
 import { UmbTemplateWorkspaceEditorElement } from './template-workspace-editor.element.js';
-import { loadCodeEditor } from '@umbraco-cms/backoffice/code-editor';
 import type { UmbRoutableWorkspaceContext, UmbSubmittableWorkspaceContext } from '@umbraco-cms/backoffice/workspace';
 import {
 	UmbSubmittableWorkspaceContextBase,
 	UmbWorkspaceIsNewRedirectController,
 } from '@umbraco-cms/backoffice/workspace';
-import { UmbBooleanState, UmbObjectState } from '@umbraco-cms/backoffice/observable-api';
+import { UmbObjectState } from '@umbraco-cms/backoffice/observable-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
 import {
@@ -40,12 +39,8 @@ export class UmbTemplateWorkspaceContext
 	readonly entityType = this.#data.asObservablePart((data) => data?.entityType);
 	masterTemplateUnique = this.#data.asObservablePart((data) => data?.masterTemplate?.unique);
 
-	#isCodeEditorReady = new UmbBooleanState(false);
-	isCodeEditorReady = this.#isCodeEditorReady.asObservable();
-
 	constructor(host: UmbControllerHost) {
 		super(host, UMB_TEMPLATE_WORKSPACE_ALIAS);
-		this.#loadCodeEditor();
 
 		this.routes.setRoutes([
 			{
@@ -77,15 +72,6 @@ export class UmbTemplateWorkspaceContext
 	protected override resetState(): void {
 		super.resetState();
 		this.#data.setValue(undefined);
-	}
-
-	async #loadCodeEditor() {
-		try {
-			await loadCodeEditor();
-			this.#isCodeEditorReady.setValue(true);
-		} catch (error) {
-			console.error(error);
-		}
 	}
 
 	getEntityType(): string {


### PR DESCRIPTION
## Description

Refactors the `<umb-code-editor>` component to asynchronously load the Monaco editor dependencies.

The `loadCodeEditor` function has been marked as deprecated.

## Types of changes

- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

With the recent bundling efforts, the existing `loadCodeEditor` function has become legacy code.

## How to test?

Check that the following areas load in the Code Editor (Monaco editor)...

- Template workspace
- Partial View workspace
- Stylesheets workspace
- Scripts workspace
- Rich Text Editor property-editor (TinyMCE) view source button, opens a Code Editor modal
- Markdown property-editor, loads and plugins are functional

