### PR TITLE
Chore: Do not redefine `clamp`

### DIFF
--- a/src/packages/core/components/split-panel/split-panel.element.ts
+++ b/src/packages/core/components/split-panel/split-panel.element.ts
@@ -8,6 +8,7 @@ import {
 	query,
 	state,
 } from '@umbraco-cms/backoffice/external/lit';
+import { clamp } from '@umbraco-cms/backoffice/utils';
 
 /**
  * Custom element for a split panel with adjustable divider.
@@ -89,13 +90,9 @@ export class UmbSplitPanelElement extends LitElement {
 		}
 	}
 
-	#clamp(value: number, min: number, max: number) {
-		return Math.min(Math.max(value, min), max);
-	}
-
 	#setPosition(pos: number) {
 		const { width } = this.mainElement.getBoundingClientRect();
-		const localPos = this.#clamp(pos, 0, width);
+		const localPos = clamp(pos, 0, width);
 		const percentagePos = (localPos / width) * 100;
 		this.position = percentagePos + '%';
 	}
@@ -127,7 +124,7 @@ export class UmbSplitPanelElement extends LitElement {
 		const move = (event: PointerEvent) => {
 			const { clientX } = event;
 			const { left, width } = this.mainElement.getBoundingClientRect();
-			const localPos = this.#clamp(clientX - left, 0, width);
+			const localPos = clamp(clientX - left, 0, width);
 			const mappedPos = mapXAxisToSnap(localPos, width);
 
 			this.#lockedPanelWidth = this.lock === 'start' ? mappedPos : width - mappedPos;

--- a/src/packages/core/temporary-file/components/temporary-file-badge.element.ts
+++ b/src/packages/core/temporary-file/components/temporary-file-badge.element.ts
@@ -1,6 +1,6 @@
 import { css, customElement, html, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import { clamp } from '@umbraco-cms/backoffice/external/uui';
+import { clamp } from '@umbraco-cms/backoffice/utils';
 
 @customElement('umb-temporary-file-badge')
 export class UmbTemporaryFileBadgeElement extends UmbLitElement {

--- a/src/packages/core/utils/math/math.ts
+++ b/src/packages/core/utils/math/math.ts
@@ -1,36 +1,5 @@
-/**
- * Clamps a value to be within a specified range defined by a minimum and maximum value.
- *
- * @param {number} value - The value to be clamped.
- * @param {number} min - The minimum value allowed in the range.
- * @param {number} max - The maximum value allowed in the range.
- *
- * @returns {number} The clamped value, which is limited to the range between `min` and `max`.
- *   - If `value` is less than `min`, it is set to `min`.
- *   - If `value` is greater than `max`, it is set to `max`.
- *   - If `value` is already within the range [min, max], it remains unchanged.
- *
- * @example
- * // Clamp a value to ensure it falls within a specific range.
- * const inputValue = 15;
- * const minValue = 10;
- * const maxValue = 20;
- * const result = clamp(inputValue, minValue, maxValue);
- * // result is 15, as it falls within the range [minValue, maxValue].
- *
- * // Clamp a value that is outside the specified range.
- * const outsideValue = 5;
- * const result2 = clamp(outsideValue, minValue, maxValue);
- * // result2 is 10, as it's clamped to the minimum value (minValue).
- *
- * // Clamp a value that exceeds the maximum limit.
- * const exceedingValue = 25;
- * const result3 = clamp(exceedingValue, minValue, maxValue);
- * // result3 is 20, as it's clamped to the maximum value (maxValue).
- */
-export function clamp(value: number, min: number, max: number): number {
-	return Math.min(Math.max(value, min), max);
-}
+import { clamp } from '@umbraco-cms/backoffice/external/uui';
+export { clamp };
 
 /**
  * Performs linear interpolation (lerp) between two numbers based on a blending factor.


### PR DESCRIPTION
## Description

The UI Library already exports a `clamp` function, so use that instead of redefining it.

Ref https://github.com/umbraco/Umbraco.CMS.Backoffice/pull/1021#issuecomment-2118387247