### PR TITLE
Bugfix: Log Viewer shows `undefined` in search field

### DIFF
--- a/src/external/router-slot/util/url.ts
+++ b/src/external/router-slot/util/url.ts
@@ -70,7 +70,7 @@ export function queryString(): string {
  * @returns Params
  */
 export function query(): Query {
-	return toQuery(queryString().substr(1));
+	return toQuery(queryString().substring(1));
 }
 
 /**

--- a/src/packages/log-viewer/workspace/logviewer-workspace.context.ts
+++ b/src/packages/log-viewer/workspace/logviewer-workspace.context.ts
@@ -124,7 +124,7 @@ export class UmbLogViewerWorkspaceContext extends UmbControllerBase implements U
 
 	onChangeState = () => {
 		const searchQuery = query();
-		this.setFilterExpression(searchQuery.lq);
+		this.setFilterExpression(searchQuery.lq ?? '');
 
 		let validLogLevels: LogLevelModel[] = [];
 		if (searchQuery.loglevels) {


### PR DESCRIPTION
## Description

This fixes https://github.com/umbraco/Umbraco-CMS/issues/16767

The Log Viewer should not show "undefined" in the search field if you do not have a search string.