### PR TITLE
fix: allow datepicker to send empty values

### DIFF
--- a/src/packages/property-editors/date-picker/property-editor-ui-date-picker.element.ts
+++ b/src/packages/property-editors/date-picker/property-editor-ui-date-picker.element.ts
@@ -75,6 +75,11 @@ export class UmbPropertyEditorUIDatePickerElement extends UmbLitElement implemen
 	#onChange(event: CustomEvent & { target: UmbInputDateElement }) {
 		let value = event.target.value.toString();
 
+		if (!value) {
+			this.#syncValue(undefined);
+			return;
+		}
+
 		switch (this._inputType) {
 			case 'time':
 				value = `0001-01-01 ${value}`;
@@ -120,7 +125,7 @@ export class UmbPropertyEditorUIDatePickerElement extends UmbLitElement implemen
 		}
 	}
 
-	#syncValue(value: string) {
+	#syncValue(value?: string) {
 		const valueHasChanged = this.value !== value;
 		if (valueHasChanged) {
 			this.value = value;

--- a/src/packages/property-editors/date-picker/property-editor-ui-date-picker.test.ts
+++ b/src/packages/property-editors/date-picker/property-editor-ui-date-picker.test.ts
@@ -98,5 +98,14 @@ describe('UmbPropertyEditorUIDatePickerElement', () => {
 			await element.updateComplete;
 			expect(element.value).to.equal('0001-01-01 10:44:00');
 		});
+
+		it('should be able to clear the value', async () => {
+			element.value = '2024-05-03 10:44:00';
+			await element.updateComplete;
+			inputElement.value = '';
+			inputElement.dispatchEvent(new CustomEvent('change'));
+			await element.updateComplete;
+			expect(element.value).to.be.undefined;
+		});
 	});
 });


### PR DESCRIPTION
## Description

This fixes https://github.com/umbraco/Umbraco-CMS/issues/16793

The Datepicker UI should be allowed to send empty values to clear the saved value.