### PR TITLE
Bugfix: Document Blueprints are not named consistently

### DIFF
--- a/.github/localization_overview.md
+++ b/.github/localization_overview.md
@@ -75,7 +75,7 @@ Before you start:
 	- [ ] Section: Info
 - [ ] Relation Types
 - [ ] Log Viewer
-- [ ] Document Blueprints
+- [x] Document Blueprints
 - [ ] Languages
 - [ ] Extensions
 - [ ] Templates

--- a/src/assets/lang/da-dk.ts
+++ b/src/assets/lang/da-dk.ts
@@ -329,6 +329,7 @@ export default {
 	},
 	blueprints: {
 		createBlueprintFrom: 'Opret en ny indholdsskabelon fra <em>%0%</em>',
+		createBlueprintFolderUnder: 'Opret en ny mappe under "%0%"',
 		blankBlueprint: 'Blank',
 		selectBlueprint: 'Vælg en indholdsskabelon',
 		createdBlueprintHeading: 'Indholdsskabelon oprettet',
@@ -2109,7 +2110,7 @@ export default {
 		protectDescription: 'Opsæt offentlig adgang på %0%',
 		rightsDescription: 'Opsæt rettigheder på %0%',
 		sortDescription: 'Juster soterings rækkefølgen for %0%',
-		createblueprintDescription: 'Opret indholds skabelon baseret på %0%',
+		createblueprintDescription: 'Opret indholdsskabelon baseret på %0%',
 		openContextMenu: 'Åben kontext menu for',
 		currentLanguage: 'Aktivt sprog',
 		switchLanguage: 'Skift sprog til',

--- a/src/assets/lang/da-dk.ts
+++ b/src/assets/lang/da-dk.ts
@@ -328,8 +328,9 @@ export default {
 		variantUnpublishNotAllowed: 'Unpublish is not allowed',
 	},
 	blueprints: {
-		createBlueprintFrom: 'Opret en ny indholdsskabelon fra <em>%0%</em>',
-		createBlueprintFolderUnder: 'Opret en ny mappe under "%0%"',
+		createBlueprintFrom: "Opret en ny indholdsskabelon fra '%0%'",
+		createBlueprintItemUnder: "Opret en ny indholdsskabelon under '%0%'",
+		createBlueprintFolderUnder: "Opret en ny mappe under '%0%'",
 		blankBlueprint: 'Blank',
 		selectBlueprint: 'Vælg en indholdsskabelon',
 		createdBlueprintHeading: 'Indholdsskabelon oprettet',

--- a/src/assets/lang/en-us.ts
+++ b/src/assets/lang/en-us.ts
@@ -336,6 +336,7 @@ export default {
 	},
 	blueprints: {
 		createBlueprintFrom: 'Create a new Document Blueprint from <em>%0%</em>',
+		createBlueprintFolderUnder: 'Create a new folder under "%0%"',
 		blankBlueprint: 'Blank',
 		selectBlueprint: 'Select a Document Blueprint',
 		createdBlueprintHeading: 'Document Blueprint created',
@@ -384,7 +385,7 @@ export default {
 	create: {
 		chooseNode: 'Where do you want to create the new %0%',
 		createUnder: 'Create an item under',
-		createContentBlueprint: 'Select the Document Type you want to make a content blueprint for',
+		createContentBlueprint: 'Select the Document Type you want to make a Document Blueprint for',
 		enterFolderName: 'Enter a folder name',
 		updateData: 'Choose a type and a title',
 		noDocumentTypes:
@@ -1372,7 +1373,7 @@ export default {
 		editMultiContentPublishedText: '%0% documents published and visible on the website',
 		editVariantPublishedText: '%0% published and visible on the website',
 		editMultiVariantPublishedText: '%0% documents published for languages %1% and visible on the website',
-		editBlueprintSavedHeader: 'Content Blueprint saved',
+		editBlueprintSavedHeader: 'Document Blueprint saved',
 		editBlueprintSavedText: 'Changes have been successfully saved',
 		editContentSavedHeader: 'Content saved',
 		editContentSavedText: 'Remember to publish to make changes visible',
@@ -1785,7 +1786,7 @@ export default {
 	},
 	treeHeaders: {
 		content: 'Content',
-		contentBlueprints: 'Content Blueprints',
+		contentBlueprints: 'Document Blueprints',
 		media: 'Media',
 		cacheBrowser: 'Cache Browser',
 		contentRecycleBin: 'Recycle Bin',
@@ -2177,7 +2178,7 @@ export default {
 		protectDescription: 'Setup access restrictions on %0%',
 		rightsDescription: 'Setup Permissions on %0%',
 		sortDescription: 'Change sort order for %0%',
-		createblueprintDescription: 'Create Content Blueprint based on %0%',
+		createblueprintDescription: 'Create Document Blueprint based on %0%',
 		openContextMenu: 'Open context menu for',
 		currentLanguage: 'Current language',
 		switchLanguage: 'Switch language to',
@@ -2483,15 +2484,15 @@ export default {
 		addColumnSpanOption: 'Add spanning %0% columns option',
 	},
 	contentTemplatesDashboard: {
-		whatHeadline: 'What are Content Blueprints?',
+		whatHeadline: 'What are Document Blueprints?',
 		whatDescription:
-			'Content Blueprints are pre-defined content that can be selected when creating a new content node.',
-		createHeadline: 'How do I create a Content Blueprint?',
+			'Document Blueprints are pre-defined content that can be selected when creating a new content node.',
+		createHeadline: 'How do I create a Document Blueprint?',
 		createDescription:
-			'<p>There are two ways to create a Content Blueprint:</p><ul><li>Right-click a content node and select "Create Content Blueprint" to create a new Content Blueprint.</li><li>Right-click the Content Blueprints tree in the Settings section and select the Document Type you want to create a Content Blueprint for.</li></ul><p>Once given a name, editors can start using the Content Blueprint as a foundation for their new page.</p>',
-		manageHeadline: 'How do I manage Content Blueprints?',
+			'<p>There are two ways to create a Document Blueprint:</p><ul><li>Right-click a content node and select "Create Document Blueprint" to create a new Document Blueprint.</li><li>Right-click the Document Blueprints tree in the Settings section and select the Document Type you want to create a Document Blueprint for.</li></ul><p>Once given a name, editors can start using the Document Blueprint as a foundation for their new page.</p>',
+		manageHeadline: 'How do I manage Document Blueprints?',
 		manageDescription:
-			'You can edit and delete Content Blueprints from the "Content Blueprints" tree in the Settings section. Expand the Document Type which the Content Blueprint is based on and click it to edit or delete it.',
+			'You can edit and delete Document Blueprints from the "Document Blueprints" tree in the Settings section. Expand the Document Type which the Document Blueprint is based on and click it to edit or delete it.',
 	},
 	preview: {
 		endLabel: 'End',

--- a/src/assets/lang/en-us.ts
+++ b/src/assets/lang/en-us.ts
@@ -335,8 +335,9 @@ export default {
 		variantUnpublishNotAllowed: 'Unpublish is not allowed',
 	},
 	blueprints: {
-		createBlueprintFrom: 'Create a new Document Blueprint from <em>%0%</em>',
-		createBlueprintFolderUnder: 'Create a new folder under "%0%"',
+		createBlueprintFrom: "Create a new Document Blueprint from '%0%'",
+		createBlueprintItemUnder: "Create a new item under '%0%'",
+		createBlueprintFolderUnder: "Create a new folder under '%0%'",
 		blankBlueprint: 'Blank',
 		selectBlueprint: 'Select a Document Blueprint',
 		createdBlueprintHeading: 'Document Blueprint created',

--- a/src/assets/lang/en.ts
+++ b/src/assets/lang/en.ts
@@ -343,8 +343,9 @@ export default {
 		selectAllVariants: 'Select all variants',
 	},
 	blueprints: {
-		createBlueprintFrom: 'Create a new Document Blueprint from <em>%0%</em>',
-		createBlueprintFolderUnder: 'Create a new folder under "%0%"',
+		createBlueprintFrom: "Create a new Document Blueprint from '%0%'",
+		createBlueprintItemUnder: "Create a new item under '%0%'",
+		createBlueprintFolderUnder: "Create a new folder under '%0%'",
 		blankBlueprint: 'Blank',
 		selectBlueprint: 'Select a Document Blueprint',
 		createdBlueprintHeading: 'Document Blueprint created',

--- a/src/assets/lang/en.ts
+++ b/src/assets/lang/en.ts
@@ -95,7 +95,7 @@ export default {
 		sort: 'Allow access to change the sort order for nodes',
 		translate: 'Allow access to translate a node',
 		update: 'Allow access to save a node',
-		createblueprint: 'Allow access to create a Content Template',
+		createblueprint: 'Allow access to create a Document Blueprint',
 		notify: 'Allow access to setup notifications for content nodes',
 	},
 	apps: {
@@ -343,14 +343,15 @@ export default {
 		selectAllVariants: 'Select all variants',
 	},
 	blueprints: {
-		createBlueprintFrom: 'Create a new Content Template from <em>%0%</em>',
+		createBlueprintFrom: 'Create a new Document Blueprint from <em>%0%</em>',
+		createBlueprintFolderUnder: 'Create a new folder under "%0%"',
 		blankBlueprint: 'Blank',
-		selectBlueprint: 'Select a Content Template',
-		createdBlueprintHeading: 'Content Template created',
-		createdBlueprintMessage: "A Content Template was created from '%0%'",
-		duplicateBlueprintMessage: 'Another Content Template with the same name already exists',
+		selectBlueprint: 'Select a Document Blueprint',
+		createdBlueprintHeading: 'Document Blueprint created',
+		createdBlueprintMessage: "A Document Blueprint was created from '%0%'",
+		duplicateBlueprintMessage: 'Another Document Blueprint with the same name already exists',
 		blueprintDescription:
-			'A Content Template is predefined content that an editor can select to use as the\n      basis for creating new content\n    ',
+			'A Document Blueprint is predefined content that an editor can select to use as the\n      basis for creating new content\n    ',
 	},
 	media: {
 		clickToUpload: 'Click to upload',
@@ -393,7 +394,7 @@ export default {
 	create: {
 		chooseNode: 'Where do you want to create the new %0%',
 		createUnder: 'Create an item under',
-		createContentBlueprint: 'Select the Document Type you want to make a content template for',
+		createContentBlueprint: 'Select the Document Type you want to make a Document Blueprint for',
 		enterFolderName: 'Enter a folder name',
 		updateData: 'Choose a type and a title',
 		noDocumentTypes:
@@ -1389,7 +1390,7 @@ export default {
 		editContentPublishedFailedByParent: 'Content could not be published, because a parent page is not published',
 		editContentPublishedHeader: 'Content published',
 		editContentPublishedText: 'and visible on the website',
-		editBlueprintSavedHeader: 'Content Template saved',
+		editBlueprintSavedHeader: 'Document Blueprint saved',
 		editBlueprintSavedText: 'Changes have been successfully saved',
 		editContentSavedHeader: 'Content saved',
 		editContentSavedText: 'Remember to publish to make changes visible',
@@ -1836,7 +1837,7 @@ export default {
 	},
 	treeHeaders: {
 		content: 'Content',
-		contentBlueprints: 'Content Templates',
+		contentBlueprints: 'Document Blueprints',
 		media: 'Media',
 		cacheBrowser: 'Cache Browser',
 		contentRecycleBin: 'Recycle Bin',
@@ -2236,7 +2237,7 @@ export default {
 		protectDescription: 'Setup access restrictions on %0%',
 		rightsDescription: 'Setup Permissions on %0%',
 		sortDescription: 'Change sort order for %0%',
-		createblueprintDescription: 'Create Content Template based on %0%',
+		createblueprintDescription: 'Create Document Blueprint based on %0%',
 		openContextMenu: 'Open context menu for',
 		currentLanguage: 'Current language',
 		switchLanguage: 'Switch language to',
@@ -2550,15 +2551,15 @@ export default {
 		labelInlineMode: 'Display inline with text',
 	},
 	contentTemplatesDashboard: {
-		whatHeadline: 'What are Content Templates?',
+		whatHeadline: 'What are Document Blueprints?',
 		whatDescription:
-			'Content Templates are pre-defined content that can be selected when creating a new\n      content node.\n    ',
-		createHeadline: 'How do I create a Content Template?',
+			'Document Blueprints are pre-defined content that can be selected when creating a new\n      content node.\n    ',
+		createHeadline: 'How do I create a Document Blueprint?',
 		createDescription:
-			'\n            <p>There are two ways to create a Content Template:</p>\n            <ul>\n                <li>Right-click a content node and select "Create Content Template" to create a new Content Template.</li>\n                <li>Right-click the Content Templates tree in the Settings section and select the Document Type you want to create a Content Template for.</li>\n            </ul>\n            <p>Once given a name, editors can start using the Content Template as a foundation for their new page.</p>\n        ',
-		manageHeadline: 'How do I manage Content Templates?',
+			'\n            <p>There are two ways to create a Document Blueprint:</p>\n            <ul>\n                <li>Right-click a content node and select "Create Document Blueprint" to create a new Document Blueprint.</li>\n                <li>Right-click the Document Blueprints tree in the Settings section and select the Document Type you want to create a Document Blueprint for.</li>\n            </ul>\n            <p>Once given a name, editors can start using the Document Blueprint as a foundation for their new page.</p>\n        ',
+		manageHeadline: 'How do I manage Document Blueprints?',
 		manageDescription:
-			'You can edit and delete Content Templates from the "Content Templates" tree in the\n      Settings section. Expand the Document Type which the Content Template is based on and click it to edit or delete\n      it.\n    ',
+			'You can edit and delete Document Blueprints from the "Document Blueprints" tree in the\n      Settings section. Expand the Document Type which the Document Blueprint is based on and click it to edit or delete\n      it.\n    ',
 	},
 	preview: {
 		endLabel: 'End',

--- a/src/packages/core/components/body-layout/body-layout.element.ts
+++ b/src/packages/core/components/body-layout/body-layout.element.ts
@@ -18,6 +18,7 @@ import {
  * @slot - Slot for main content
  * @slot icon - Slot for icon
  * @slot name - Slot for name
+ * @slot header - Slot for header element
  * @slot footer - Slot for footer element
  * @slot footer-info - Slot for info in the footer
  * @slot actions - Slot for actions in the footer

--- a/src/packages/documents/document-blueprints/entity-actions/create/modal/document-blueprint-options-create-modal.element.ts
+++ b/src/packages/documents/document-blueprints/entity-actions/create/modal/document-blueprint-options-create-modal.element.ts
@@ -39,7 +39,7 @@ export class UmbDocumentBlueprintOptionsCreateModalElement extends UmbModalBaseE
 			entityType: this.data.parent.entityType,
 			meta: {
 				icon: 'icon-folder',
-				label: 'New Folder...',
+				label: this.localize.term('create_newFolder'),
 				folderRepositoryAlias: UMB_DOCUMENT_BLUEPRINT_FOLDER_REPOSITORY_ALIAS,
 			},
 		});
@@ -68,13 +68,13 @@ export class UmbDocumentBlueprintOptionsCreateModalElement extends UmbModalBaseE
 		return html`
 			<umb-body-layout headline=${this.localize.term('actions_createblueprint')}>
 				<uui-box headline=${this.localize.term('blueprints_createBlueprintFolderUnder', this._parentName)}>
-					<uui-menu-item @click=${this.#onCreateFolderClick} label="New Folder...">
+					<uui-menu-item @click=${this.#onCreateFolderClick} label=${this.localize.term('create_newFolder') + '...'}>
 						<uui-icon slot="icon" name="icon-folder"></uui-icon>
 					</uui-menu-item>
 				</uui-box>
-				<uui-box headline="Create an item under Content Templates">
+				<uui-box headline=${this.localize.term('blueprints_createBlueprintItemUnder', this._parentName)}>
 					<umb-localize key="create_createContentBlueprint">
-						Select the Document Type you want to make a content blueprint for
+						Select the Document Type you want to make a Document Blueprint for
 					</umb-localize>
 					<umb-tree
 						alias="Umb.Tree.DocumentType"
@@ -84,7 +84,11 @@ export class UmbDocumentBlueprintOptionsCreateModalElement extends UmbModalBaseE
 						}}
 						@selected=${this.#onSelected}></umb-tree>
 				</uui-box>
-				<uui-button slot="actions" id="cancel" label="Cancel" @click="${this._rejectModal}"></uui-button>
+				<uui-button
+					slot="actions"
+					id="cancel"
+					label=${this.localize.term('buttons_confirmActionCancel')}
+					@click="${this._rejectModal}"></uui-button>
 			</umb-body-layout>
 		`;
 	}

--- a/src/packages/documents/document-blueprints/menu-item/manifests.ts
+++ b/src/packages/documents/document-blueprints/menu-item/manifests.ts
@@ -9,7 +9,7 @@ const menuItem: ManifestTypes = {
 	weight: 100,
 	meta: {
 		treeAlias: UMB_DOCUMENT_BLUEPRINT_TREE_ALIAS,
-		label: 'Document Blueprints',
+		label: '#treeHeaders_contentBlueprints',
 		menus: ['Umb.Menu.StructureSettings'],
 	},
 };

--- a/src/packages/documents/document-blueprints/tree/document-blueprint-tree.repository.ts
+++ b/src/packages/documents/document-blueprints/tree/document-blueprint-tree.repository.ts
@@ -5,11 +5,14 @@ import type { UmbDocumentBlueprintTreeItemModel, UmbDocumentBlueprintTreeRootMod
 import { UmbTreeRepositoryBase } from '@umbraco-cms/backoffice/tree';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
+import { UmbLocalizationController } from '@umbraco-cms/backoffice/localization-api';
 
 export class UmbDocumentBlueprintTreeRepository
 	extends UmbTreeRepositoryBase<UmbDocumentBlueprintTreeItemModel, UmbDocumentBlueprintTreeRootModel>
 	implements UmbApi
 {
+	#localize = new UmbLocalizationController(this);
+
 	constructor(host: UmbControllerHost) {
 		super(host, UmbDocumentBlueprintTreeServerDataSource, UMB_DOCUMENT_BLUEPRINT_TREE_STORE_CONTEXT);
 	}
@@ -21,7 +24,7 @@ export class UmbDocumentBlueprintTreeRepository
 		const data: UmbDocumentBlueprintTreeRootModel = {
 			unique: null,
 			entityType: UMB_DOCUMENT_BLUEPRINT_ROOT_ENTITY_TYPE,
-			name: 'Document Blueprints',
+			name: this.#localize.term('treeHeaders_contentBlueprints'),
 			hasChildren,
 			isFolder: true,
 		};

--- a/src/packages/documents/document-blueprints/workspace/document-blueprint-root-workspace.element.ts
+++ b/src/packages/documents/document-blueprints/workspace/document-blueprint-root-workspace.element.ts
@@ -5,41 +5,44 @@ import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 @customElement('umb-document-blueprint-root-workspace')
 export class UmbDocumentBlueprintRootWorkspaceElement extends UmbLitElement {
 	override render() {
-		return html`<umb-workspace-editor alias=${UMB_DOCUMENT_BLUEPRINT_WORKSPACE_ALIAS} headline="Document Blueprints">
+		return html`<umb-workspace-editor
+			alias=${UMB_DOCUMENT_BLUEPRINT_WORKSPACE_ALIAS}
+			headline=${this.localize.term('treeHeaders_contentBlueprints')}>
 			<div id="wrapper">
 				<uui-box>
 					<h2>
-						<umb-localize key="contentTemplatesDashboard_whatHeadline"> What are Content Blueprints? </umb-localize>
+						<umb-localize key="contentTemplatesDashboard_whatHeadline"> What are Document Blueprints? </umb-localize>
 					</h2>
 					<umb-localize key="contentTemplatesDashboard_whatDescription">
-						Content Blueprints are pre-defined content that can be selected when creating a new content node.
+						Document Blueprints are pre-defined content that can be selected when creating a new content node.
 					</umb-localize>
 					<h2>
 						<umb-localize key="contentTemplatesDashboard_createHeadline">
-							How do I create a Content Blueprint?
+							How do I create a Document Blueprint?
 						</umb-localize>
 					</h2>
 					<umb-localize key="contentTemplatesDashboard_createDescription">
 						<p>There are two ways to create a Content Blueprint:</p>
 						<ul>
 							<li>
-								Right-click a content node and select "Create Content Blueprint" to create a new Content Blueprint.
+								Click "Create Document Blueprint" in the action menu on a content node to create a new Document
+								Blueprint.
 							</li>
 							<li>
-								Right-click the Content Blueprints tree in the Settings section and select the Document Type you want to
-								create a Content Blueprint for.
+								Click the "+" button in the Document Blueprints tree in the Settings section and select the Document
+								Type you want to create a Document Blueprint for.
 							</li>
 						</ul>
-						<p>Once given a name, editors can start using the Content Blueprint as a foundation for their new page.</p>
+						<p>Once given a name, editors can start using the Document Blueprint as a foundation for their new page.</p>
 					</umb-localize>
 					<h2>
 						<umb-localize key="contentTemplatesDashboard_manageHeadline">
-							How do I manage Content Blueprints?
+							How do I manage Document Blueprints?
 						</umb-localize>
 					</h2>
 					<umb-localize key="contentTemplatesDashboard_manageDescription">
-						You can edit and delete Content Blueprints from the "Content Blueprints" tree in the Settings section.
-						Expand the Document Type which the Content Blueprint is based on and click it to edit or delete it.
+						You can edit and delete Document Blueprints from the "Document Blueprints" tree in the Settings section.
+						Expand the Document Type which the Document Blueprint is based on and click it to edit or delete it.
 					</umb-localize>
 				</uui-box>
 			</div>

--- a/src/packages/documents/document-blueprints/workspace/document-blueprint-root-workspace.element.ts
+++ b/src/packages/documents/document-blueprints/workspace/document-blueprint-root-workspace.element.ts
@@ -1,61 +1,50 @@
-import { UMB_DOCUMENT_BLUEPRINT_WORKSPACE_ALIAS } from './manifests.js';
-import { html, customElement, css } from '@umbraco-cms/backoffice/external/lit';
+import { html, customElement } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 
 @customElement('umb-document-blueprint-root-workspace')
 export class UmbDocumentBlueprintRootWorkspaceElement extends UmbLitElement {
 	override render() {
-		return html`<umb-workspace-editor
-			alias=${UMB_DOCUMENT_BLUEPRINT_WORKSPACE_ALIAS}
-			headline=${this.localize.term('treeHeaders_contentBlueprints')}>
-			<div id="wrapper">
-				<uui-box>
-					<h2>
-						<umb-localize key="contentTemplatesDashboard_whatHeadline"> What are Document Blueprints? </umb-localize>
-					</h2>
-					<umb-localize key="contentTemplatesDashboard_whatDescription">
-						Document Blueprints are pre-defined content that can be selected when creating a new content node.
+		return html`<umb-body-layout .headline=${this.localize.term('treeHeaders_contentBlueprints')}>
+			<uui-box>
+				<h2>
+					<umb-localize key="contentTemplatesDashboard_whatHeadline"> What are Document Blueprints? </umb-localize>
+				</h2>
+				<umb-localize key="contentTemplatesDashboard_whatDescription">
+					Document Blueprints are pre-defined content that can be selected when creating a new content node.
+				</umb-localize>
+				<h2>
+					<umb-localize key="contentTemplatesDashboard_createHeadline">
+						How do I create a Document Blueprint?
 					</umb-localize>
-					<h2>
-						<umb-localize key="contentTemplatesDashboard_createHeadline">
-							How do I create a Document Blueprint?
-						</umb-localize>
-					</h2>
-					<umb-localize key="contentTemplatesDashboard_createDescription">
-						<p>There are two ways to create a Content Blueprint:</p>
-						<ul>
-							<li>
-								Click "Create Document Blueprint" in the action menu on a content node to create a new Document
-								Blueprint.
-							</li>
-							<li>
-								Click the "+" button in the Document Blueprints tree in the Settings section and select the Document
-								Type you want to create a Document Blueprint for.
-							</li>
-						</ul>
-						<p>Once given a name, editors can start using the Document Blueprint as a foundation for their new page.</p>
+				</h2>
+				<umb-localize key="contentTemplatesDashboard_createDescription">
+					<p>There are two ways to create a Content Blueprint:</p>
+					<ul>
+						<li>
+							Click "Create Document Blueprint" in the action menu on a content node to create a new Document Blueprint.
+						</li>
+						<li>
+							Click the "+" button in the Document Blueprints tree in the Settings section and select the Document Type
+							you want to create a Document Blueprint for.
+						</li>
+					</ul>
+					<p>Once given a name, editors can start using the Document Blueprint as a foundation for their new page.</p>
+				</umb-localize>
+				<h2>
+					<umb-localize key="contentTemplatesDashboard_manageHeadline">
+						How do I manage Document Blueprints?
 					</umb-localize>
-					<h2>
-						<umb-localize key="contentTemplatesDashboard_manageHeadline">
-							How do I manage Document Blueprints?
-						</umb-localize>
-					</h2>
-					<umb-localize key="contentTemplatesDashboard_manageDescription">
-						You can edit and delete Document Blueprints from the "Document Blueprints" tree in the Settings section.
-						Expand the Document Type which the Document Blueprint is based on and click it to edit or delete it.
-					</umb-localize>
-				</uui-box>
-			</div>
-		</umb-workspace-editor> `;
+				</h2>
+				<umb-localize key="contentTemplatesDashboard_manageDescription">
+					You can edit and delete Document Blueprints from the "Document Blueprints" tree in the Settings section.
+					Expand the Document Type which the Document Blueprint is based on and click it to edit or delete it.
+				</umb-localize>
+			</uui-box>
+		</umb-body-layout> `;
 	}
 
-	static override styles = [
-		css`
-			#wrapper {
-				margin: var(--uui-size-layout-1);
-			}
-		`,
-	];
+	static override styles = [UmbTextStyles];
 }
 
 export default UmbDocumentBlueprintRootWorkspaceElement;

--- a/src/packages/documents/document-blueprints/workspace/document-blueprint-workspace.context.ts
+++ b/src/packages/documents/document-blueprints/workspace/document-blueprint-workspace.context.ts
@@ -139,10 +139,6 @@ export class UmbDocumentBlueprintWorkspaceContext
 				},
 			},
 			{
-				path: 'edit/null',
-				component: () => import('./document-blueprint-root-workspace.element.js'),
-			},
-			{
 				path: 'edit/:unique',
 				component: () => import('./document-blueprint-workspace-editor.element.js'),
 				setup: (_component, info) => {

--- a/src/packages/documents/document-blueprints/workspace/manifests.ts
+++ b/src/packages/documents/document-blueprints/workspace/manifests.ts
@@ -1,10 +1,9 @@
-import { UMB_DOCUMENT_BLUEPRINT_ENTITY_TYPE } from '../entity.js';
+import { UMB_DOCUMENT_BLUEPRINT_ENTITY_TYPE, UMB_DOCUMENT_BLUEPRINT_ROOT_ENTITY_TYPE } from '../entity.js';
 import { UmbSaveWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
 import type {
 	ManifestTypes,
 	ManifestWorkspace,
 	ManifestWorkspaceActions,
-	ManifestWorkspaceView,
 } from '@umbraco-cms/backoffice/extension-registry';
 
 export const UMB_DOCUMENT_BLUEPRINT_WORKSPACE_ALIAS = 'Umb.Workspace.DocumentBlueprint';
@@ -20,26 +19,16 @@ const workspace: ManifestWorkspace = {
 	},
 };
 
-const workspaceViews: Array<ManifestWorkspaceView> = [
-	{
-		type: 'workspaceView',
-		kind: 'contentEditor',
-		alias: 'Umb.WorkspaceView.DocumentBlueprint.Edit',
-		name: 'Document Blueprint Workspace Edit View',
-		weight: 200,
-		meta: {
-			label: '#general_content',
-			pathname: 'content',
-			icon: 'document',
-		},
-		conditions: [
-			{
-				alias: 'Umb.Condition.WorkspaceAlias',
-				match: workspace.alias,
-			},
-		],
+const rootWorkspace: ManifestWorkspace = {
+	type: 'workspace',
+	kind: 'routable',
+	alias: 'Umb.Workspace.DocumentBlueprint.Root',
+	name: 'Document Blueprint Root Workspace',
+	api: () => import('./document-blueprint-workspace.context.js'),
+	meta: {
+		entityType: UMB_DOCUMENT_BLUEPRINT_ROOT_ENTITY_TYPE,
 	},
-];
+};
 
 const workspaceActions: Array<ManifestWorkspaceActions> = [
 	{
@@ -63,4 +52,4 @@ const workspaceActions: Array<ManifestWorkspaceActions> = [
 	},
 ];
 
-export const manifests: Array<ManifestTypes> = [workspace, ...workspaceViews, ...workspaceActions];
+export const manifests: Array<ManifestTypes> = [rootWorkspace, workspace, ...workspaceActions];

--- a/src/packages/documents/document-blueprints/workspace/manifests.ts
+++ b/src/packages/documents/document-blueprints/workspace/manifests.ts
@@ -1,4 +1,8 @@
-import { UMB_DOCUMENT_BLUEPRINT_ENTITY_TYPE, UMB_DOCUMENT_BLUEPRINT_ROOT_ENTITY_TYPE } from '../entity.js';
+import {
+	UMB_DOCUMENT_BLUEPRINT_ENTITY_TYPE,
+	UMB_DOCUMENT_BLUEPRINT_FOLDER_ENTITY_TYPE,
+	UMB_DOCUMENT_BLUEPRINT_ROOT_ENTITY_TYPE,
+} from '../entity.js';
 import { UmbSaveWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
 import type {
 	ManifestTypes,
@@ -27,6 +31,16 @@ const rootWorkspace: ManifestWorkspace = {
 	element: () => import('./document-blueprint-root-workspace.element.js'),
 	meta: {
 		entityType: UMB_DOCUMENT_BLUEPRINT_ROOT_ENTITY_TYPE,
+	},
+};
+
+const folderWorkspace: ManifestWorkspace = {
+	type: 'workspace',
+	alias: 'Umb.Workspace.DocumentBlueprint.Folder',
+	name: 'Document Blueprint Folder Workspace',
+	element: () => import('./document-blueprint-root-workspace.element.js'),
+	meta: {
+		entityType: UMB_DOCUMENT_BLUEPRINT_FOLDER_ENTITY_TYPE,
 	},
 };
 
@@ -73,4 +87,10 @@ const workspaceActions: Array<ManifestWorkspaceActions> = [
 	},
 ];
 
-export const manifests: Array<ManifestTypes> = [rootWorkspace, workspace, ...workspaceViews, ...workspaceActions];
+export const manifests: Array<ManifestTypes> = [
+	rootWorkspace,
+	folderWorkspace,
+	workspace,
+	...workspaceViews,
+	...workspaceActions,
+];

--- a/src/packages/documents/document-blueprints/workspace/manifests.ts
+++ b/src/packages/documents/document-blueprints/workspace/manifests.ts
@@ -4,6 +4,7 @@ import type {
 	ManifestTypes,
 	ManifestWorkspace,
 	ManifestWorkspaceActions,
+	ManifestWorkspaceView,
 } from '@umbraco-cms/backoffice/extension-registry';
 
 export const UMB_DOCUMENT_BLUEPRINT_WORKSPACE_ALIAS = 'Umb.Workspace.DocumentBlueprint';
@@ -30,6 +31,27 @@ const rootWorkspace: ManifestWorkspace = {
 	},
 };
 
+const workspaceViews: Array<ManifestWorkspaceView> = [
+	{
+		type: 'workspaceView',
+		kind: 'contentEditor',
+		alias: 'Umb.WorkspaceView.DocumentBlueprint.Edit',
+		name: 'Document Blueprint Workspace Edit View',
+		weight: 200,
+		meta: {
+			label: '#general_content',
+			pathname: 'content',
+			icon: 'document',
+		},
+		conditions: [
+			{
+				alias: 'Umb.Condition.WorkspaceAlias',
+				match: workspace.alias,
+			},
+		],
+	},
+];
+
 const workspaceActions: Array<ManifestWorkspaceActions> = [
 	{
 		type: 'workspaceAction',
@@ -52,4 +74,4 @@ const workspaceActions: Array<ManifestWorkspaceActions> = [
 	},
 ];
 
-export const manifests: Array<ManifestTypes> = [rootWorkspace, workspace, ...workspaceActions];
+export const manifests: Array<ManifestTypes> = [rootWorkspace, workspace, ...workspaceViews, ...workspaceActions];

--- a/src/packages/documents/document-blueprints/workspace/manifests.ts
+++ b/src/packages/documents/document-blueprints/workspace/manifests.ts
@@ -22,10 +22,9 @@ const workspace: ManifestWorkspace = {
 
 const rootWorkspace: ManifestWorkspace = {
 	type: 'workspace',
-	kind: 'routable',
 	alias: 'Umb.Workspace.DocumentBlueprint.Root',
 	name: 'Document Blueprint Root Workspace',
-	api: () => import('./document-blueprint-workspace.context.js'),
+	element: () => import('./document-blueprint-root-workspace.element.js'),
 	meta: {
 		entityType: UMB_DOCUMENT_BLUEPRINT_ROOT_ENTITY_TYPE,
 	},

--- a/src/packages/log-viewer/workspace/logviewer-workspace.context.ts
+++ b/src/packages/log-viewer/workspace/logviewer-workspace.context.ts
@@ -124,7 +124,7 @@ export class UmbLogViewerWorkspaceContext extends UmbControllerBase implements U
 
 	onChangeState = () => {
 		const searchQuery = query();
-		this.setFilterExpression(searchQuery.lq);
+		this.setFilterExpression(searchQuery.lq ?? '');
 
 		let validLogLevels: LogLevelModel[] = [];
 		if (searchQuery.loglevels) {


### PR DESCRIPTION
## Changes

- Following the changes in PR #893 the `en.ts` file was introduced with the former name of Document Blueprints (content templates). This has been corrected.
- Introduced a routable workspace for blueprint root so that the previously hidden element detailing how to use blueprints is now being shown
- Introduced new variables to account for new texts in the Create modal
- Replaced static texts with localization keys everywhere I could think of

Fixes https://github.com/umbraco/Umbraco-CMS/issues/16410

## How to test

- Check that all static texts are localized
- Try to create a Folder and check that the name of the folder is used correctly in the Create dialog when creating a new blueprint underneath a folder
- Check that notifications show the correct localization when creating, deleting, etc.

## Screenshots

![image](https://github.com/user-attachments/assets/ebcfc943-479b-487c-bf6f-ae27db7081ea)

![image](https://github.com/user-attachments/assets/37507bff-4ee3-4db1-ad2c-87d72b804fff)

![image](https://github.com/user-attachments/assets/a1474eca-3dc5-4160-aad3-446b76a2058d)
