### PR TITLE
Bugfix: Textarea does not show validation

### DIFF
--- a/src/packages/property-editors/text-box/property-editor-ui-text-box.element.ts
+++ b/src/packages/property-editors/text-box/property-editor-ui-text-box.element.ts
@@ -1,13 +1,5 @@
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
-import {
-	css,
-	html,
-	customElement,
-	state,
-	ifDefined,
-	type PropertyValueMap,
-	property,
-} from '@umbraco-cms/backoffice/external/lit';
+import { css, html, customElement, state, ifDefined, property } from '@umbraco-cms/backoffice/external/lit';
 import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import {
@@ -54,12 +46,11 @@ export class UmbPropertyEditorUITextBoxElement
 		this._placeholder = config?.getValueByAlias('placeholder');
 	}
 
-	protected override firstUpdated(_changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>): void {
-		super.firstUpdated(_changedProperties);
+	protected override firstUpdated(): void {
 		this.addFormControlElement(this.shadowRoot!.querySelector('uui-input')!);
 	}
 
-	private onChange(e: Event) {
+	#onInput(e: InputEvent) {
 		const newValue = (e.target as HTMLInputElement).value;
 		if (newValue === this.value) return;
 		this.value = newValue;
@@ -73,7 +64,7 @@ export class UmbPropertyEditorUITextBoxElement
 			placeholder=${ifDefined(this._placeholder)}
 			inputMode=${ifDefined(this._inputMode)}
 			maxlength=${ifDefined(this._maxChars)}
-			@input=${this.onChange}
+			@input=${this.#onInput}
 			?readonly=${this.readonly}></uui-input>`;
 	}
 

--- a/src/packages/property-editors/textarea/property-editor-ui-textarea.element.ts
+++ b/src/packages/property-editors/textarea/property-editor-ui-textarea.element.ts
@@ -1,16 +1,17 @@
-import { css, customElement, html, property, state, styleMap } from '@umbraco-cms/backoffice/external/lit';
+import { css, customElement, html, ifDefined, property, state, styleMap } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbPropertyValueChangeEvent } from '@umbraco-cms/backoffice/property-editor';
 import type { StyleInfo } from '@umbraco-cms/backoffice/external/lit';
 import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
 import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extension-registry';
-import type { UUITextareaElement } from '@umbraco-cms/backoffice/external/uui';
+import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
+import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 
 @customElement('umb-property-editor-ui-textarea')
-export class UmbPropertyEditorUITextareaElement extends UmbLitElement implements UmbPropertyEditorUiElement {
-	@property()
-	value = '';
-
+export class UmbPropertyEditorUITextareaElement
+	extends UmbFormControlMixin<string>(UmbLitElement, undefined)
+	implements UmbPropertyEditorUiElement
+{
 	/**
 	 * Sets the input to readonly mode, meaning value cannot be changed but still able to read and select its content.
 	 * @type {boolean}
@@ -47,8 +48,14 @@ export class UmbPropertyEditorUITextareaElement extends UmbLitElement implements
 		};
 	}
 
-	#onInput(event: InputEvent & { target: UUITextareaElement }) {
-		this.value = event.target.value as string;
+	protected override firstUpdated(): void {
+		this.addFormControlElement(this.shadowRoot!.querySelector('uui-textarea')!);
+	}
+
+	#onInput(event: InputEvent) {
+		const newValue = (event.target as HTMLTextAreaElement).value;
+		if (newValue === this.value) return;
+		this.value = newValue;
 		this.dispatchEvent(new UmbPropertyValueChangeEvent());
 	}
 
@@ -58,15 +65,16 @@ export class UmbPropertyEditorUITextareaElement extends UmbLitElement implements
 				label="Textarea"
 				style=${styleMap(this._css)}
 				.autoHeight=${this._rows ? false : true}
-				.maxlength=${this._maxChars}
-				.rows=${this._rows}
+				maxlength=${ifDefined(this._maxChars)}
+				rows=${ifDefined(this._rows)}
 				.value=${this.value ?? ''}
 				@input=${this.#onInput}
 				?readonly=${this.readonly}></uui-textarea>
 		`;
 	}
 
-	static override styles = [
+	static styles = [
+		UmbTextStyles,
 		css`
 			uui-textarea {
 				width: 100%;


### PR DESCRIPTION
## Description

The textarea property editor ui should show validation. This is fixed by converting the element into a form mixin that supports validation.

Fixes https://github.com/umbraco/Umbraco-CMS/issues/16436

## How to test

1. Set the "max length" of a textarea data type
2. Verify that a validation message is shown in the UI

## Screenshots

![image](https://github.com/user-attachments/assets/aeedcc2c-55aa-4a26-96db-da666e2536d4)
