### PR TITLE
Bugfix: UFM review, fixes and amends

### DIFF
--- a/src/packages/core/components/table/table.element.ts
+++ b/src/packages/core/components/table/table.element.ts
@@ -279,7 +279,7 @@ export class UmbTableElement extends LitElement {
 			const element = document.createElement('umb-ufm-render') as UmbUfmRenderElement;
 			element.inline = true;
 			element.markdown = column.labelTemplate;
-			element.value = value;
+			element.value = { value };
 			return element;
 		}
 

--- a/src/packages/core/extension-registry/models/ufm-component.model.ts
+++ b/src/packages/core/extension-registry/models/ufm-component.model.ts
@@ -1,8 +1,8 @@
 import type { ManifestApi, UmbApi } from '@umbraco-cms/backoffice/extension-api';
-import type { Tokens } from '@umbraco-cms/backoffice/external/marked';
+import type { UfmToken } from '@umbraco-cms/backoffice/ufm';
 
 export interface UmbUfmComponentApi extends UmbApi {
-	render(token: Tokens.Generic): string | undefined;
+	render(token: UfmToken): string | undefined;
 }
 
 export interface MetaUfmComponent {

--- a/src/packages/documents/documents/collection/views/grid/document-grid-collection-view.element.ts
+++ b/src/packages/documents/documents/collection/views/grid/document-grid-collection-view.element.ts
@@ -172,23 +172,23 @@ export class UmbDocumentGridCollectionViewElement extends UmbLitElement {
 				${repeat(
 					this._userDefinedProperties,
 					(column) => column.alias,
-					(column) => html`
-						<li>
-							<span>${column.header}:</span>
-							${when(
-								column.nameTemplate,
-								() => html`
-									<umb-ufm-render
-										inline
-										.markdown=${column.nameTemplate}
-										.value=${getPropertyValueByAlias(item, column.alias)}></umb-ufm-render>
-								`,
-								() => html`${getPropertyValueByAlias(item, column.alias)}`,
-							)}
-						</li>
-					`,
+					(column) => this.#renderProperty(item, column),
 				)}
 			</ul>
+		`;
+	}
+
+	#renderProperty(item: UmbDocumentCollectionItemModel, column: UmbCollectionColumnConfiguration) {
+		const value = getPropertyValueByAlias(item, column.alias);
+		return html`
+			<li>
+				<span>${column.header}:</span>
+				${when(
+					column.nameTemplate,
+					() => html`<umb-ufm-render inline .markdown=${column.nameTemplate} .value=${{ value }}></umb-ufm-render>`,
+					() => html`${value}`,
+				)}
+			</li>
 		`;
 	}
 

--- a/src/packages/ufm/components/ufm-render/ufm-render.element.ts
+++ b/src/packages/ufm/components/ufm-render/ufm-render.element.ts
@@ -28,7 +28,7 @@ UmbDomPurify.addHook('afterSanitizeAttributes', function (node) {
 	}
 });
 
-const UmbMarked = new Marked({
+export const UmbMarked = new Marked({
 	async: true,
 	gfm: true,
 	breaks: true,

--- a/src/packages/ufm/manifests.ts
+++ b/src/packages/ufm/manifests.ts
@@ -4,19 +4,15 @@ export const manifests: Array<ManifestUfmComponent> = [
 	{
 		type: 'ufmComponent',
 		alias: 'Umb.Markdown.LabelValue',
-		name: 'Label Value Markdown Component',
+		name: 'Label Value UFM Component',
 		api: () => import('./ufm-components/label-value.component.js'),
-		meta: {
-			marker: '=',
-		},
+		meta: { marker: '=' },
 	},
 	{
 		type: 'ufmComponent',
 		alias: 'Umb.Markdown.Localize',
-		name: 'Localize Markdown Component',
+		name: 'Localize UFM Component',
 		api: () => import('./ufm-components/localize.component.js'),
-		meta: {
-			marker: '#',
-		},
+		meta: { marker: '#' },
 	},
 ];

--- a/src/packages/ufm/plugins/marked-ufm.plugin.ts
+++ b/src/packages/ufm/plugins/marked-ufm.plugin.ts
@@ -3,7 +3,11 @@ import type { MarkedExtension, Tokens } from '@umbraco-cms/backoffice/external/m
 export interface UfmPlugin {
 	alias: string;
 	marker: string;
-	render?: (token: Tokens.Generic) => string | undefined;
+	render?: (token: UfmToken) => string | undefined;
+}
+
+export interface UfmToken extends Tokens.Generic {
+	text?: string;
 }
 
 export function ufm(plugins: Array<UfmPlugin> = []): MarkedExtension {

--- a/src/packages/ufm/plugins/marked-ufm.plugin.ts
+++ b/src/packages/ufm/plugins/marked-ufm.plugin.ts
@@ -16,13 +16,9 @@ export function ufm(plugins: Array<UfmPlugin> = []): MarkedExtension {
 			return {
 				name: alias,
 				level: 'inline',
-				start: (src: string) => {
-					const regex = new RegExp(`\\{${marker}`);
-					const match = src.match(regex);
-					return match ? match.index : -1;
-				},
-				tokenizer(src: string): Tokens.Generic | undefined {
-					const pattern = `^(?<!\\\\){{?${marker}((?:[a-zA-Z][\\w-]*|[\\{].*?[\\}]+|[\\[].*?[\\]])+)(?<!\\\\)}}?`;
+				start: (src: string) => src.indexOf(`{${marker}`),
+				tokenizer: (src: string) => {
+					const pattern = `^\\{${marker}([^}]*)\\}`;
 					const regex = new RegExp(pattern);
 					const match = src.match(regex);
 

--- a/src/packages/ufm/plugins/marked-ufm.test.ts
+++ b/src/packages/ufm/plugins/marked-ufm.test.ts
@@ -1,0 +1,32 @@
+import { expect } from '@open-wc/testing';
+import { ufm } from './marked-ufm.plugin.js';
+import { UmbMarked } from '../index.js';
+import { UmbUfmLabelValueComponent } from '../ufm-components/label-value.component.js';
+import { UmbUfmLocalizeComponent } from '../ufm-components/localize.component.js';
+
+describe('UmbMarkedUfm', () => {
+	describe('UFM parsing', () => {
+		const runs = [
+			{ ufm: '{=prop1}', expected: '<ufm-label-value alias="prop1"></ufm-label-value>' },
+			{ ufm: '{= prop1}', expected: '<ufm-label-value alias="prop1"></ufm-label-value>' },
+			{ ufm: '{= prop1 }', expected: '<ufm-label-value alias="prop1"></ufm-label-value>' },
+			{ ufm: '{{=prop1}}', expected: '{<ufm-label-value alias="prop1"></ufm-label-value>}' },
+			{ ufm: '{#general_add}', expected: '<umb-localize key="general_add"></umb-localize>' },
+		];
+
+		// Manually configuring the UFM components for testing.
+		UmbMarked.use(
+			ufm([
+				{ alias: 'Umb.Markdown.LabelValue', marker: '=', render: new UmbUfmLabelValueComponent().render },
+				{ alias: 'Umb.Markdown.Localize', marker: '#', render: new UmbUfmLocalizeComponent().render },
+			]),
+		);
+
+		runs.forEach((run) => {
+			it(`Parsing "${run.ufm}"`, async () => {
+				const markup = await UmbMarked.parseInline(run.ufm);
+				expect(markup).to.equal(run.expected);
+			});
+		});
+	});
+});

--- a/src/packages/ufm/ufm-components/label-value.component.ts
+++ b/src/packages/ufm/ufm-components/label-value.component.ts
@@ -1,10 +1,11 @@
+import type { UfmToken } from '../plugins/marked-ufm.plugin.js';
 import { UmbUfmComponentBase } from './ufm-component-base.js';
-import type { Tokens } from '@umbraco-cms/backoffice/external/marked';
 
 import './label-value.element.js';
 
 export class UmbUfmLabelValueComponent extends UmbUfmComponentBase {
-	render(token: Tokens.Generic) {
+	render(token: UfmToken) {
+		if (!token.text) return;
 		return `<ufm-label-value alias="${token.text}"></ufm-label-value>`;
 	}
 }

--- a/src/packages/ufm/ufm-components/label-value.element.ts
+++ b/src/packages/ufm/ufm-components/label-value.element.ts
@@ -1,5 +1,5 @@
 import { UMB_UFM_RENDER_CONTEXT } from '../components/ufm-render/index.js';
-import { customElement, property, state } from '@umbraco-cms/backoffice/external/lit';
+import { customElement, nothing, property, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 
 const elementName = 'ufm-label-value';
@@ -31,7 +31,7 @@ export class UmbUfmLabelValueElement extends UmbLitElement {
 	}
 
 	override render() {
-		return this._value ?? `{${this.alias}}`;
+		return this._value !== undefined ? this._value : nothing;
 	}
 }
 

--- a/src/packages/ufm/ufm-components/localize.component.ts
+++ b/src/packages/ufm/ufm-components/localize.component.ts
@@ -1,8 +1,9 @@
+import type { UfmToken } from '../plugins/marked-ufm.plugin.js';
 import { UmbUfmComponentBase } from './ufm-component-base.js';
-import type { Tokens } from '@umbraco-cms/backoffice/external/marked';
 
 export class UmbUfmLocalizeComponent extends UmbUfmComponentBase {
-	render(token: Tokens.Generic) {
+	render(token: UfmToken) {
+		if (!token.text) return;
 		return `<umb-localize key="${token.text}"></umb-localize>`;
 	}
 }

--- a/src/packages/ufm/ufm-components/ufm-component-base.ts
+++ b/src/packages/ufm/ufm-components/ufm-component-base.ts
@@ -1,7 +1,7 @@
-import type { Tokens } from '@umbraco-cms/backoffice/external/marked';
+import type { UfmToken } from '../plugins/marked-ufm.plugin.js';
 import type { UmbUfmComponentApi } from '@umbraco-cms/backoffice/extension-registry';
 
 export abstract class UmbUfmComponentBase implements UmbUfmComponentApi {
-	abstract render(token: Tokens.Generic): string | undefined;
+	abstract render(token: UfmToken): string | undefined;
 	destroy() {}
 }


### PR DESCRIPTION
## Description

Review of UFM code, made fixes and amends, includes...

- Introduces `UfmToken` interface type, so to no longer expose Marked library's `Tokens.Generic`.
  - This isn't a breaking-change, as `UfmToken` extends `Tokens.Generic`, which itself was an extendable interface.
- Adds tests for parsing the UFM syntax
- Simplified the UFM regular expression; also handles whitespace better.
- For Collection Views (Table and Grid), wraps the value in an object property, e.g. `{ value }`.
  - So that accessing the value it works similar to v13 ListView. UFM syntax is now `{=value}`.
- Loosened the rendering in `<ufm-label-value>` so that non-undefined falsy values can be rendered.

Fixes https://github.com/umbraco/Umbraco-CMS/issues/16776.


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## How to test?

General testing for dynamic labels in Collection Views, Block List/Grid and Document property descriptions.
