### PR TITLE
Bugfix: Enables document blueprint create menu

### DIFF
--- a/src/packages/documents/documents/entity-actions/create/document-create-options-modal.element.ts
+++ b/src/packages/documents/documents/entity-actions/create/document-create-options-modal.element.ts
@@ -119,7 +119,7 @@ export class UmbDocumentCreateOptionsModalElement extends UmbModalBaseElement<
 		return html`
 			<umb-body-layout headline=${this.localize.term('actions_create')}>
 				${when(
-					this._availableBlueprints.length === 0 && this.#documentTypeUnique,
+					this._availableBlueprints.length && this.#documentTypeUnique,
 					() => this.#renderBlueprints(),
 					() => this.#renderDocumentTypes(),
 				)}


### PR DESCRIPTION
## Description

The Document Blueprint create menu wasn't displaying, now it does.

Fixes https://github.com/umbraco/Umbraco-CMS/issues/16721.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## How to test?

- Create a document blueprint (from an existing document type).
- Try to create new content from the document blueprint, if the menu appears and you can select a blueprint, then all good.
