### PR TITLE
Use constant for language workspace alias

### DIFF
--- a/src/packages/language/workspace/language/constants.ts
+++ b/src/packages/language/workspace/language/constants.ts
@@ -1,0 +1,1 @@
+export const UMB_LANGUAGE_WORKSPACE_ALIAS = 'Umb.Workspace.Language';

--- a/src/packages/language/workspace/language/language-workspace.context.ts
+++ b/src/packages/language/workspace/language/language-workspace.context.ts
@@ -1,6 +1,7 @@
 import { UmbLanguageDetailRepository } from '../../repository/index.js';
 import type { UmbLanguageDetailModel } from '../../types.js';
 import { UmbLanguageWorkspaceEditorElement } from './language-workspace-editor.element.js';
+import { UMB_LANGUAGE_WORKSPACE_ALIAS } from './manifests.js';
 import {
 	type UmbSubmittableWorkspaceContext,
 	UmbSubmittableWorkspaceContextBase,
@@ -27,7 +28,7 @@ export class UmbLanguageWorkspaceContext
 	readonly validationErrors = this.#validationErrors.asObservable();
 
 	constructor(host: UmbControllerHost) {
-		super(host, 'Umb.Workspace.Language');
+		super(host, UMB_LANGUAGE_WORKSPACE_ALIAS);
 
 		this.routes.setRoutes([
 			{

--- a/src/packages/language/workspace/language/language-workspace.context.ts
+++ b/src/packages/language/workspace/language/language-workspace.context.ts
@@ -1,7 +1,7 @@
 import { UmbLanguageDetailRepository } from '../../repository/index.js';
 import type { UmbLanguageDetailModel } from '../../types.js';
 import { UmbLanguageWorkspaceEditorElement } from './language-workspace-editor.element.js';
-import { UMB_LANGUAGE_WORKSPACE_ALIAS } from './manifests.js';
+import { UMB_LANGUAGE_WORKSPACE_ALIAS } from './constants.js';
 import {
 	type UmbSubmittableWorkspaceContext,
 	UmbSubmittableWorkspaceContextBase,

--- a/src/packages/language/workspace/language/manifests.ts
+++ b/src/packages/language/workspace/language/manifests.ts
@@ -1,3 +1,4 @@
+import { UMB_LANGUAGE_WORKSPACE_ALIAS } from './constants.js';
 import { UmbSubmitWorkspaceAction } from '@umbraco-cms/backoffice/workspace';
 import type {
 	ManifestWorkspaces,
@@ -5,8 +6,6 @@ import type {
 	ManifestWorkspaceView,
 	ManifestTypes,
 } from '@umbraco-cms/backoffice/extension-registry';
-
-export const UMB_LANGUAGE_WORKSPACE_ALIAS = 'Umb.Workspace.Language';
 
 const workspace: ManifestWorkspaces = {
 	type: 'workspace',

--- a/src/packages/language/workspace/language/manifests.ts
+++ b/src/packages/language/workspace/language/manifests.ts
@@ -6,10 +6,12 @@ import type {
 	ManifestTypes,
 } from '@umbraco-cms/backoffice/extension-registry';
 
+export const UMB_LANGUAGE_WORKSPACE_ALIAS = 'Umb.Workspace.Language';
+
 const workspace: ManifestWorkspaces = {
 	type: 'workspace',
 	kind: 'routable',
-	alias: 'Umb.Workspace.Language',
+	alias: UMB_LANGUAGE_WORKSPACE_ALIAS,
 	name: 'Language Workspace',
 	api: () => import('./language-workspace.context.js'),
 	meta: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This add a constant for language workspace alias similar to other `ManifestWorkspaces`.
However it doesn't really seems consistent. Some are included in `manifests.ts` as here:
https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/4e840b9de043f8ddb03352897c5ef2a575ca8776/src/packages/documents/document-blueprints/workspace/manifests.ts#L14C14-L14C52

while other are just in a constant.ts as here:
https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/4e840b9de043f8ddb03352897c5ef2a575ca8776/src/packages/user/user/workspace/constants.ts

or  `index.ts`:
https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/4e840b9de043f8ddb03352897c5ef2a575ca8776/src/packages/block/block/workspace/index.ts#L5

It would be great if it could be more consistency and easier to work with codebase.

Some places I noticed we have  workspace under `workspace/entity` and `entity/workspace`.

I also noticed the fallback language picker seems broken at language and under user section.
It set the value, but somehow `items` always seems to be an empty array.

![image](https://github.com/user-attachments/assets/5051398b-38e5-4b03-b7ec-f8c338afad56)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
