### PR TITLE
Bugfix: Document Type Picker - enable boolean properties

### DIFF
--- a/src/packages/documents/document-types/components/input-document-type/input-document-type.element.ts
+++ b/src/packages/documents/document-types/components/input-document-type/input-document-type.element.ts
@@ -37,7 +37,7 @@ export class UmbInputDocumentTypeElement extends UmbFormControlMixin<string | un
 	 * @attr
 	 * @default false
 	 */
-	@property({ type: Boolean })
+	@property({ attribute: false })
 	elementTypesOnly: boolean = false;
 
 	/**
@@ -46,7 +46,7 @@ export class UmbInputDocumentTypeElement extends UmbFormControlMixin<string | un
 	 * @attr
 	 * @default false
 	 */
-	@property({ type: Boolean })
+	@property({ attribute: false })
 	documentTypesOnly: boolean = false;
 
 	/**

--- a/src/packages/documents/document-types/components/input-document-type/input-document-type.element.ts
+++ b/src/packages/documents/document-types/components/input-document-type/input-document-type.element.ts
@@ -37,7 +37,7 @@ export class UmbInputDocumentTypeElement extends UmbFormControlMixin<string | un
 	 * @attr
 	 * @default false
 	 */
-	@property({ attribute: false })
+	@property({ type: Boolean })
 	elementTypesOnly: boolean = false;
 
 	/**
@@ -46,7 +46,7 @@ export class UmbInputDocumentTypeElement extends UmbFormControlMixin<string | un
 	 * @attr
 	 * @default false
 	 */
-	@property({ attribute: false })
+	@property({ type: Boolean })
 	documentTypesOnly: boolean = false;
 
 	/**

--- a/src/packages/documents/document-types/property-editors/document-type-picker/property-editor-ui-document-type-picker.element.ts
+++ b/src/packages/documents/document-types/property-editors/document-type-picker/property-editor-ui-document-type-picker.element.ts
@@ -45,7 +45,7 @@ export class UmbPropertyEditorUIDocumentTypePickerElement extends UmbLitElement 
 				.min=${this.min}
 				.max=${this.max}
 				.value=${this.value}
-				?elementTypesOnly=${this.onlyElementTypes}
+				.elementTypesOnly=${this.onlyElementTypes ?? false}
 				?showOpenButton=${this.showOpenButton}
 				@change=${this.#onChange}>
 			</umb-input-document-type>

--- a/src/packages/webhook/workspace/webhook/views/webhook-details-workspace-view.element.ts
+++ b/src/packages/webhook/workspace/webhook/views/webhook-details-workspace-view.element.ts
@@ -90,7 +90,7 @@ export class UmbWebhookDetailsWorkspaceViewElement extends UmbLitElement impleme
 						slot="editor"
 						@change=${this.#onTypesChange}
 						.selection=${this._webhook?.contentTypes ?? []}
-						?documentTypesOnly=${true}></umb-input-document-type>
+						.documentTypesOnly=${true}></umb-input-document-type>
 				`;
 			case 'Media':
 				return html`


### PR DESCRIPTION
## Description

I'd noticed when configuring a Block type (in Block Grid, Block List or RTE Blocks), the Document Type picker UI was ignoring the `"onlyPickElementTypes"` configuration. It turns out that the `elementTypesOnly` property wasn't reading the attribute value.

Also, in a Webhook edit workspace, the "Content Type" option should only be enabled for `documentTypesOnly`, but element-types were selectable.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## How to test?

**Blocks**
Go to any of the Block editor data-type configurations, create a new or select an existing Block type, in the configuration modal panel, open the document-type picker modal for either "Content model" or "Settings model"... you should see that only element-types are selectable.

**Webhooks**
In the Webhooks section, create a new or select an existing webhook, open the document-type picker modal for "Content Type"... you should see that only document-types are selectable. 
