### PR TITLE
Bugfix: Use `<uui-input-lock>` for workspace aliases

### DIFF
--- a/src/packages/core/components/input-with-alias/input-with-alias.element.ts
+++ b/src/packages/core/components/input-with-alias/input-with-alias.element.ts
@@ -1,9 +1,10 @@
-import { css, customElement, html, nothing, property, state } from '@umbraco-cms/backoffice/external/lit';
+import { css, customElement, html, property, state } from '@umbraco-cms/backoffice/external/lit';
+import { generateAlias } from '@umbraco-cms/backoffice/utils';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import { type UUIInputElement, UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
-import { generateAlias } from '@umbraco-cms/backoffice/utils';
+import { UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
+import type { UUIInputElement } from '@umbraco-cms/backoffice/external/uui';
 
 @customElement('umb-input-with-alias')
 export class UmbInputWithAliasElement extends UmbFormControlMixin<string, typeof UmbLitElement>(UmbLitElement) {
@@ -64,8 +65,11 @@ export class UmbInputWithAliasElement extends UmbFormControlMixin<string, typeof
 		}
 	}
 
-	#onToggleAliasLock() {
+	#onToggleAliasLock(event: CustomEvent) {
 		this._aliasLocked = !this._aliasLocked;
+		if (!this._aliasLocked) {
+			(event.target as UUIInputElement)?.focus();
+		}
 	}
 
 	override render() {
@@ -79,26 +83,18 @@ export class UmbInputWithAliasElement extends UmbFormControlMixin<string, typeof
 				label=${nameLabel}
 				.value=${this.value}
 				@input=${this.#onNameChange}>
-				<!-- TODO: should use UUI-LOCK-INPUT, but that does not fire an event when its locked/unlocked -->
-				<uui-input
+				<uui-input-lock
 					auto-width
 					name="alias"
 					slot="append"
 					label=${aliasLabel}
-					.value=${this.alias}
 					placeholder=${aliasLabel}
-					?disabled=${this._aliasLocked && !this.aliasReadonly}
+					.value=${this.alias}
+					?locked=${this._aliasLocked && !this.aliasReadonly}
 					?readonly=${this.aliasReadonly}
-					@input=${this.#onAliasChange}>
-					<!-- TODO: validation for bad characters -->
-					${this.aliasReadonly
-						? nothing
-						: html`
-								<div @click=${this.#onToggleAliasLock} @keydown=${() => ''} id="alias-lock" slot="prepend">
-									<uui-icon name=${this._aliasLocked ? 'icon-lock' : 'icon-unlocked'}></uui-icon>
-								</div>
-							`}
-				</uui-input>
+					@input=${this.#onAliasChange}
+					@lock-change=${this.#onToggleAliasLock}>
+				</uui-input-lock>
 			</uui-input>
 		`;
 	}
@@ -120,21 +116,10 @@ export class UmbInputWithAliasElement extends UmbFormControlMixin<string, typeof
 		:host(:invalid:not([pristine])) > uui-input {
 			border-color: var(--uui-color-danger);
 		}
-
-		#alias-lock {
-			display: flex;
-			align-items: center;
-			justify-content: center;
-			cursor: pointer;
-		}
-
-		#alias-lock uui-icon {
-			margin-bottom: 2px;
-		}
 	`;
 }
 
-export default UmbInputWithAliasElement;
+export { UmbInputWithAliasElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {

--- a/src/packages/core/content-type/workspace/views/design/content-type-design-editor-property.element.ts
+++ b/src/packages/core/content-type/workspace/views/design/content-type-design-editor-property.element.ts
@@ -1,19 +1,18 @@
 import { UmbPropertyTypeContext } from './content-type-design-editor-property.context.js';
-import { UmbDataTypeDetailRepository } from '@umbraco-cms/backoffice/data-type';
-import type { UUIInputElement } from '@umbraco-cms/backoffice/external/uui';
-import { UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
 import { css, html, customElement, property, state, nothing } from '@umbraco-cms/backoffice/external/lit';
-import { umbConfirmModal } from '@umbraco-cms/backoffice/modal';
-import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { generateAlias } from '@umbraco-cms/backoffice/utils';
+import { umbConfirmModal } from '@umbraco-cms/backoffice/modal';
+import { UmbDataTypeDetailRepository } from '@umbraco-cms/backoffice/data-type';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
+import { UMB_EDIT_PROPERTY_TYPE_WORKSPACE_PATH_PATTERN } from '@umbraco-cms/backoffice/property-type';
 import type {
 	UmbContentTypeModel,
 	UmbContentTypePropertyStructureHelper,
 	UmbPropertyTypeModel,
 	UmbPropertyTypeScaffoldModel,
 } from '@umbraco-cms/backoffice/content-type';
-import { UMB_EDIT_PROPERTY_TYPE_WORKSPACE_PATH_PATTERN } from '@umbraco-cms/backoffice/property-type';
+import type { UUIInputElement, UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
 
 /**
  *  @element umb-content-type-design-editor-property
@@ -22,10 +21,9 @@ import { UMB_EDIT_PROPERTY_TYPE_WORKSPACE_PATH_PATTERN } from '@umbraco-cms/back
  */
 @customElement('umb-content-type-design-editor-property')
 export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
-	//
+	#context = new UmbPropertyTypeContext(this);
 	#dataTypeDetailRepository = new UmbDataTypeDetailRepository(this);
 	#dataTypeUnique?: string;
-	#context = new UmbPropertyTypeContext(this);
 
 	@property({ attribute: false })
 	public set propertyStructureHelper(value: UmbContentTypePropertyStructureHelper<UmbContentTypeModel> | undefined) {
@@ -115,8 +113,11 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 		this._propertyStructureHelper.partialUpdateProperty(this._property.id, partialObject);
 	}
 
-	#onToggleAliasLock() {
+	#onToggleAliasLock(event: CustomEvent) {
 		this._aliasLocked = !this._aliasLocked;
+		if (!this._aliasLocked) {
+			(event.target as UUIInputElement)?.focus();
+		}
 	}
 
 	async #setDataType(dataTypeUnique: string | undefined) {
@@ -138,12 +139,7 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 		// TODO: Do proper localization here: [NL]
 		await umbConfirmModal(this, {
 			headline: `${this.localize.term('actions_delete')} property`,
-			content: html`<umb-localize key="contentTypeEditor_confirmDeletePropertyMessage" .args=${[
-				this._property.name ?? this._property.id,
-			]}>
-					Are you sure you want to delete the property <strong>${this._property.name ?? this._property.id}</strong>
-				</umb-localize>
-				</div>`,
+			content: html`<umb-localize key="contentTypeEditor_confirmDeletePropertyMessage" .args=${[this._property.name ?? this._property.id]}>Are you sure you want to delete the property <strong>${this._property.name ?? this._property.id}</strong></umb-localize></div>`,
 			confirmLabel: this.localize.term('actions_delete'),
 			color: 'danger',
 		});
@@ -151,24 +147,22 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 		this._propertyStructureHelper?.removeProperty(this._property.id);
 	}
 
-	#onNameChanged(event: UUIInputEvent) {
-		if (event instanceof UUIInputEvent) {
-			const target = event.composedPath()[0] as UUIInputElement;
+	#onAliasChanged(event: UUIInputEvent) {
+		this.#singleValueUpdate('alias', event.target.value.toString());
+	}
 
-			if (typeof target?.value === 'string') {
-				const oldName = this.property?.name ?? '';
-				const oldAlias = this.property?.alias ?? '';
-				const newName = event.target.value.toString();
-				if (this._aliasLocked) {
-					const expectedOldAlias = generateAlias(oldName ?? '');
-					// Only update the alias if the alias matches a generated alias of the old name (otherwise the alias is considered one written by the user.)
-					if (expectedOldAlias === oldAlias) {
-						this.#singleValueUpdate('alias', generateAlias(newName ?? ''));
-					}
-				}
-				this.#singleValueUpdate('name', newName);
+	#onNameChanged(event: UUIInputEvent) {
+		const oldName = this.property?.name ?? '';
+		const oldAlias = this.property?.alias ?? '';
+		const newName = event.target.value.toString();
+		if (this._aliasLocked) {
+			const expectedOldAlias = generateAlias(oldName ?? '');
+			// Only update the alias if the alias matches a generated alias of the old name (otherwise the alias is considered one written by the user.)
+			if (expectedOldAlias === oldAlias) {
+				this.#singleValueUpdate('alias', generateAlias(newName ?? ''));
 			}
 		}
+		this.#singleValueUpdate('name', newName);
 	}
 
 	override render() {
@@ -271,24 +265,19 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 	}
 
 	renderPropertyAlias() {
-		return this.property
-			? html`<uui-input
-					name="alias"
-					id="alias-input"
-					label="alias"
-					placeholder=${this.localize.term('placeholders_alias')}
-					.value=${this.property.alias}
-					?disabled=${this._aliasLocked}
-					@input=${(e: CustomEvent) => {
-						if (e.target) this.#singleValueUpdate('alias', (e.target as HTMLInputElement).value);
-					}}>
-					<!-- TODO: should use UUI-LOCK-INPUT, but that does not fire an event when its locked/unlocked -->
-					<!-- TODO: validation for bad characters -->
-					<div @click=${this.#onToggleAliasLock} @keydown=${() => ''} id="alias-lock" slot="prepend">
-						<uui-icon name=${this._aliasLocked ? 'icon-lock' : 'icon-unlocked'}></uui-icon>
-					</div>
-				</uui-input>`
-			: '';
+		if (!this.property) return;
+		return html`
+			<uui-input-lock
+				name="alias"
+				id="alias-input"
+				label=${this.localize.term('placeholders_enterAlias')}
+				placeholder=${this.localize.term('placeholders_enterAlias')}
+				.value=${this.property.alias}
+				?locked=${this._aliasLocked}
+				@input=${this.#onAliasChanged}
+				@lock-change=${this.#onToggleAliasLock}>
+			</uui-input-lock>
+		`;
 	}
 
 	renderPropertyTags() {
@@ -423,16 +412,6 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 				--uui-input-border-color: transparent;
 			}
 
-			#alias-lock {
-				display: flex;
-				align-items: center;
-				justify-content: center;
-				cursor: pointer;
-			}
-			#alias-lock uui-icon {
-				margin-bottom: 2px;
-				/* margin: 0; */
-			}
 			#description-input {
 				--uui-textarea-border-color: transparent;
 				font-weight: 0.5rem; /* TODO: Cant change font size of UUI textarea yet */

--- a/src/packages/core/property-type/workspace/views/settings/property-workspace-view-settings.element.ts
+++ b/src/packages/core/property-type/workspace/views/settings/property-workspace-view-settings.element.ts
@@ -1,18 +1,19 @@
 import { UMB_PROPERTY_TYPE_WORKSPACE_CONTEXT } from '../../../index.js';
 import { css, html, customElement, state, nothing } from '@umbraco-cms/backoffice/external/lit';
-import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
-import { UmbLitElement, umbFocus } from '@umbraco-cms/backoffice/lit-element';
-import type { UmbWorkspaceViewElement } from '@umbraco-cms/backoffice/extension-registry';
-import type { UmbPropertyTypeModel } from '@umbraco-cms/backoffice/content-type';
-import { UMB_CONTENT_TYPE_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/content-type';
-import type { UUIBooleanInputEvent, UUIInputEvent, UUISelectEvent } from '@umbraco-cms/backoffice/external/uui';
 import { generateAlias } from '@umbraco-cms/backoffice/utils';
+import { UmbLitElement, umbFocus } from '@umbraco-cms/backoffice/lit-element';
+import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
+import { UMB_CONTENT_TYPE_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/content-type';
+import type { UmbPropertyTypeModel } from '@umbraco-cms/backoffice/content-type';
+import type { UmbWorkspaceViewElement } from '@umbraco-cms/backoffice/extension-registry';
+import type { UUIBooleanInputEvent, UUIInputEvent, UUISelectEvent } from '@umbraco-cms/backoffice/external/uui';
 
 @customElement('umb-property-type-workspace-view-settings')
 export class UmbPropertyTypeWorkspaceViewSettingsElement extends UmbLitElement implements UmbWorkspaceViewElement {
 	#context?: typeof UMB_PROPERTY_TYPE_WORKSPACE_CONTEXT.TYPE;
 
-	@state() private _customValidationOptions: Array<Option> = [
+	@state()
+	private _customValidationOptions: Array<Option> = [
 		{
 			name: this.localize.term('validation_validateNothing'),
 			value: '!NOVALIDATION!',
@@ -171,65 +172,61 @@ export class UmbPropertyTypeWorkspaceViewSettingsElement extends UmbLitElement i
 	}
 
 	override render() {
-		return this._data
-			? html`
-					<uui-box class="uui-text">
-						<div class="container">
-							<!-- TODO: Align styling across this and the property of document type workspace editor, or consider if this can go away for a different UX flow -->
-							<uui-input
-								id="name-input"
-								name="name"
-								label=${this.localize.term('placeholders_entername')}
-								@input=${this.#onNameChange}
-								.value=${this._data?.name}
-								placeholder=${this.localize.term('placeholders_entername')}
-								${umbFocus()}>
-								<!-- TODO: validation for bad characters -->
-							</uui-input>
-							<uui-input
-								id="alias-input"
-								name="alias"
-								@input=${this.#onAliasChange}
-								.value=${this._data?.alias}
-								label=${this.localize.term('placeholders_enterAlias')}
-								placeholder=${this.localize.term('placeholders_enterAlias')}
-								?disabled=${this._aliasLocked}>
-								<!-- TODO: validation for bad characters -->
-								<div @click=${this.#onToggleAliasLock} @keydown=${() => ''} id="alias-lock" slot="prepend">
-									<uui-icon name=${this._aliasLocked ? 'icon-lock' : 'icon-unlocked'}></uui-icon>
-								</div>
-							</uui-input>
-							<uui-textarea
-								id="description-input"
-								name="description"
-								@input=${this.#onDescriptionChange}
-								label=${this.localize.term('placeholders_enterDescription')}
-								placeholder=${this.localize.term('placeholders_enterDescription')}
-								.value=${this._data?.description}></uui-textarea>
-						</div>
-						<umb-data-type-flow-input
-							.value=${this._data?.dataType?.unique ?? ''}
-							@change=${this.#onDataTypeIdChange}></umb-data-type-flow-input>
-						<hr />
-						<div class="container">
-							<b><umb-localize key="validation_validation">Validation</umb-localize></b>
-							${this.#renderMandatory()}
-							<p style="margin-bottom: 0">
-								<umb-localize key="validation_customValidation">Custom validation</umb-localize>
-							</p>
-							${this.#renderCustomValidation()}
-						</div>
-						<hr />
-						${this.#renderVariationControls()}
-						<div class="container">
-							<b style="margin-bottom: var(--uui-size-space-3)">
-								<umb-localize key="contentTypeEditor_displaySettingsHeadline">Appearance</umb-localize>
-							</b>
-							<div id="appearances">${this.#renderAlignLeftIcon()} ${this.#renderAlignTopIcon()}</div>
-						</div>
-					</uui-box>
-				`
-			: '';
+		if (!this._data) return;
+		return html`
+			<uui-box class="uui-text">
+				<div class="container">
+					<!-- TODO: Align styling across this and the property of document type workspace editor, or consider if this can go away for a different UX flow -->
+					<uui-input
+						id="name-input"
+						name="name"
+						label=${this.localize.term('placeholders_entername')}
+						placeholder=${this.localize.term('placeholders_entername')}
+						.value=${this._data?.name}
+						@input=${this.#onNameChange}
+						${umbFocus()}>
+						<!-- TODO: validation for bad characters -->
+					</uui-input>
+					<uui-input-lock
+						id="alias-input"
+						name="alias"
+						label=${this.localize.term('placeholders_enterAlias')}
+						placeholder=${this.localize.term('placeholders_enterAlias')}
+						.value=${this._data?.alias}
+						?locked=${this._aliasLocked}
+						@input=${this.#onAliasChange}
+						@lock-change=${this.#onToggleAliasLock}>
+					</uui-input-lock>
+					<uui-textarea
+						id="description-input"
+						name="description"
+						@input=${this.#onDescriptionChange}
+						label=${this.localize.term('placeholders_enterDescription')}
+						placeholder=${this.localize.term('placeholders_enterDescription')}
+						.value=${this._data?.description}></uui-textarea>
+				</div>
+				<umb-data-type-flow-input
+					.value=${this._data?.dataType?.unique ?? ''}
+					@change=${this.#onDataTypeIdChange}></umb-data-type-flow-input>
+				<hr />
+				<div class="container">
+					<b><umb-localize key="validation_validation">Validation</umb-localize></b>
+					${this.#renderMandatory()}
+					<p style="margin-bottom: 0">
+						<umb-localize key="validation_customValidation">Custom validation</umb-localize>
+					</p>
+					${this.#renderCustomValidation()}
+				</div>
+				<hr />
+				${this.#renderVariationControls()}
+				<div class="container">
+					<b style="margin-bottom: var(--uui-size-space-3)">
+						<umb-localize key="contentTypeEditor_displaySettingsHeadline">Appearance</umb-localize>
+					</b>
+					<div id="appearances">${this.#renderAlignLeftIcon()} ${this.#renderAlignTopIcon()}</div>
+				</div>
+			</uui-box>
+		`;
 	}
 
 	#renderAlignLeftIcon() {
@@ -357,16 +354,6 @@ export class UmbPropertyTypeWorkspaceViewSettingsElement extends UmbLitElement i
 				--uui-input-border-color: transparent;
 			}
 
-			#alias-lock {
-				display: flex;
-				align-items: center;
-				justify-content: center;
-				cursor: pointer;
-			}
-			#alias-lock uui-icon {
-				margin-bottom: 2px;
-				/* margin: 0; */
-			}
 			#description-input {
 				--uui-textarea-border-color: transparent;
 				font-weight: 0.5rem; /* TODO: Cant change font size of UUI textarea yet */


### PR DESCRIPTION
## Description

Makes use of the `<uui-input-lock>` component for workspace name/alias combinations.

Fixes https://github.com/umbraco/Umbraco-CMS/issues/16246.

This PR separates out part of PR #2092, to focus on the `<uui-input-lock>` component, so to fix [the accessibility/tabbing issue](https://github.com/umbraco/Umbraco-CMS/issues/16246) (for v14.2.0-RC).

Auto-generating the alias is not part of this PR.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## How to test?

Test that the padlocked alias UI is accessible in the following areas:

- Document Type workspace header, name/alias field
- Media Type workspace header, name/alias field
- Member Type workspace header, name/alias field
- User Group workspace header, name/alias field
- Template workspace header, name/alias field
- Document Type > Property modal > label/alias field (inside the modal UI)
- Document Type >Property label/alias field
