### PR TITLE
Chore: Property Type manifest name correction

### DIFF
--- a/src/packages/core/property-type/workspace/manifests.ts
+++ b/src/packages/core/property-type/workspace/manifests.ts
@@ -6,7 +6,7 @@ export const manifests: Array<ManifestTypes> = [
 	{
 		type: 'workspace',
 		kind: 'routable',
-		name: 'Block Workspace',
+		name: 'Property Type Workspace',
 		alias: UMB_PROPERTY_TYPE_WORKSPACE_ALIAS,
 		api: () => import('./property-type-workspace.context.js'),
 		meta: {
@@ -16,7 +16,7 @@ export const manifests: Array<ManifestTypes> = [
 	{
 		type: 'workspaceView',
 		alias: 'Umb.WorkspaceView.PropertyType.Settings',
-		name: 'Block Workspace Content View',
+		name: 'Property Type Settings Workspace View',
 		js: () => import('./views/settings/property-workspace-view-settings.element.js'),
 		weight: 1000,
 		meta: {


### PR DESCRIPTION
## Description

I've noticed that the Property Type workspace manifests had "Block" in their names.

## Types of changes

- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
