### PR TITLE
Chore: Remove property-actions for textbox property-editor

### DIFF
--- a/src/packages/core/property-action/manifests.ts
+++ b/src/packages/core/property-action/manifests.ts
@@ -12,7 +12,7 @@ export const propertyActionManifests: Array<ManifestPropertyActions> = [
 		alias: 'Umb.PropertyAction.Copy',
 		name: 'Copy Property Action',
 		api: () => import('./common/copy/property-action-copy.controller.js'),
-		forPropertyEditorUis: ['Umb.PropertyEditorUi.TextBox'],
+		forPropertyEditorUis: [],
 		meta: {
 			icon: 'icon-paste-in',
 			label: 'Copy',
@@ -24,7 +24,7 @@ export const propertyActionManifests: Array<ManifestPropertyActions> = [
 		alias: 'Umb.PropertyAction.Clear',
 		name: 'Clear Property Action',
 		api: () => import('./common/clear/property-action-clear.controller.js'),
-		forPropertyEditorUis: ['Umb.PropertyEditorUi.TextBox'],
+		forPropertyEditorUis: [],
 		meta: {
 			icon: 'icon-trash',
 			label: 'Clear',


### PR DESCRIPTION
## Description

The initial property-actions (Clear and Copy) were a proof-of-concept and should not have been released with 14.0.

## Types of changes

- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
