### PR TITLE
Align table icons centrally

### DIFF
--- a/src/packages/core/components/table/table.element.ts
+++ b/src/packages/core/components/table/table.element.ts
@@ -204,7 +204,7 @@ export class UmbTableElement extends LitElement {
 		if (this.config.hideIcon && !this.config.allowSelection) return;
 
 		return html`
-			<uui-table-head-cell style="--uui-table-cell-padding: 0">
+			<uui-table-head-cell style="--uui-table-cell-padding: 0; text-align: center;">
 				${when(
 					this.config.allowSelection,
 					() =>
@@ -236,7 +236,7 @@ export class UmbTableElement extends LitElement {
 		if (this.config.hideIcon && !this.config.allowSelection) return;
 
 		return html`
-			<uui-table-cell>
+			<uui-table-cell style="text-align: center;">
 				${when(!this.config.hideIcon, () => html`<umb-icon name="${ifDefined(item.icon ?? undefined)}"></umb-icon>`)}
 				${when(
 					this.config.allowSelection,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The PR aligns the icons columns of collection views centrally to prevent miss-alignment issues when alternating between the column icon and the checkbox

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

There is unnecessary movement when rolling over the table rows and switching between the checkbox and icon. This fix ensures prop alignment of both preventing this movement.

## How to test?

Roll over any collection view

## Screenshots (if appropriate)

Before
![image](https://github.com/user-attachments/assets/1023c875-3b27-4b6f-81e6-c02869cf5c82)

After
![image](https://github.com/user-attachments/assets/94ff7250-eb3e-4d14-866d-be3e394e10e8)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
