### PR TITLE
Chore: Remove postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,6 @@
 		"check": "npm run lint:errors && npm run compile && npm run build-storybook && npm run generate:jsonschema:dist",
 		"check:paths": "node ./devops/build/check-path-length.js dist-cms 120",
 		"compile": "tsc",
-		"postinstall": "npm run generate:tsconfig",
 		"dev": "vite",
 		"dev:server": "VITE_UMBRACO_USE_MSW=off vite",
 		"dev:mock": "VITE_UMBRACO_USE_MSW=on vite",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The 14.2-rc package can't be installed because the `generate:tsconfig` script can't run. The issue is caused by the `postinstall` script that runs when the package is installed from npm. We don't ship any of our `devops` files which makes the script fail.

## How to test

You can test a local version of the package to check that it installs correctly:

**In the backoffice repo**
1. `npm i` to ensure all dependencies are installed
2. `npm run build:for:npm` build the output files for npm
3. `npm pack` pack a local version of the npm package
4. Copy the package to a local Umbraco project where it should be installed

**In your Umbraco project**

1.  Point to the local version in your `package.json` file: `"@umbraco-cms/backoffice": "./umbraco-cms-backoffice-14.2.0.tgz"`
2.  Run `npm i` in your Umbraco project
3. 🤞 The package works

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
