### PR TITLE
Bugfix: Reexport `UmbBlockTypeBaseModel` from `@umbraco-cms/backoffice/block-type`

### DIFF
--- a/src/packages/block/block-type/types.ts
+++ b/src/packages/block/block-type/types.ts
@@ -1,4 +1,5 @@
 import type { UmbBlockTypeBaseModel } from '@umbraco-cms/backoffice/extension-registry';
+export type { UmbBlockTypeBaseModel } from '@umbraco-cms/backoffice/extension-registry';
 
 export interface UmbBlockTypeGroup {
 	name?: string;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The PR fixes a breaking change.

Export of `UmbBlockTypeBaseModel` has been moved from `@umbraco-cms/backoffice/block-type` to `@umbraco-cms/backoffice/extension-registry`. This PR reexports the type from `@umbraco-cms/backoffice/block-type`again.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
