### PR TITLE
Bugfix: Content Picker, gets dynamic root value from menu context

### DIFF
--- a/src/packages/property-editors/content-picker/property-editor-ui-content-picker.element.ts
+++ b/src/packages/property-editors/content-picker/property-editor-ui-content-picker.element.ts
@@ -6,7 +6,6 @@ import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 import { UmbPropertyValueChangeEvent } from '@umbraco-cms/backoffice/property-editor';
 import { UMB_DOCUMENT_ENTITY_TYPE } from '@umbraco-cms/backoffice/document';
-import { UMB_ENTITY_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/workspace';
 import { UMB_MEDIA_ENTITY_TYPE } from '@umbraco-cms/backoffice/media';
 import { UMB_MEMBER_ENTITY_TYPE } from '@umbraco-cms/backoffice/member';
 import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
@@ -114,13 +113,11 @@ export class UmbPropertyEditorUIContentPickerElement
 		if (this._rootUnique) return;
 		if (!this.#dynamicRoot) return;
 
-		const workspaceContext = await this.getContext(UMB_ENTITY_WORKSPACE_CONTEXT);
-		const unique = workspaceContext.getUnique();
-		if (!unique) return;
-
 		const menuStructureWorkspaceContext = (await this.getContext('UmbMenuStructureWorkspaceContext')) as any;
-		const parent = (await this.observe(menuStructureWorkspaceContext.parent, () => {})?.asPromise()) as any;
-		const parentUnique = parent?.unique;
+		const structure = (await this.observe(menuStructureWorkspaceContext.structure, () => {})?.asPromise()) as any[];
+		const [parentUnique, unique] = structure?.slice(-2).map((x) => x.unique) ?? [];
+
+		if (!unique) return;
 
 		const result = await this.#dynamicRootRepository.requestRoot(this.#dynamicRoot, unique, parentUnique);
 		if (result && result.length > 0) {


### PR DESCRIPTION
## Description

In the Content Picker, _(formerly Multinode Treepicker)_, to set the start node of the picker (using Dynamic Root), the `UMB_ENTITY_WORKSPACE_CONTEXT` was used to get the unique ID of the entity. However, when using the Content Picker within a Block Grid/List, the workspace context was for the Block, not the top-most entity, e.g. a document.

Rather than attempt to query the Block's modal context (for the parent entity workspace context), I have opted to use the `UmbMenuStructureWorkspaceContext.structure` to get the top-most entity workspace's unique and parent unique values.

(We were already using this to get the `parent` unique)

Fixes https://github.com/umbraco/Umbraco-CMS/issues/16632.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## How to test?

- Configure a Content Picker property-editor with a "Node type" of "Content" and "Specify root node". (The exact configuration doesn't matter).
- Add to a property on an element-type, then configure a Block List property-editor to use that element-type.
- Add both the Content Picker and Block List data-types to a document-type.
- Create a new document (of that type); try opening the Content Picker modal, do you get the expected results? and no error?
