### PR TITLE
[v14.2.0-RC] Fix Block Grid `layoutStylesheet` not using correct URL

### DIFF
--- a/src/mocks/data/data-type/data-type.data.ts
+++ b/src/mocks/data/data-type/data-type.data.ts
@@ -702,6 +702,10 @@ export const data: Array<UmbMockDataTypeModel> = [
 				alias: 'blockGroups',
 				value: [{ key: 'demo-block-group-id', name: 'Demo Blocks' }],
 			},
+      {
+        alias: 'layoutStylesheet',
+        value: '/wwwroot/css/umbraco-blockgridlayout.css'
+      },
 			{
 				alias: 'blocks',
 				value: [

--- a/src/packages/block/block-grid/context/block-grid-manager.context.ts
+++ b/src/packages/block/block-grid/context/block-grid-manager.context.ts
@@ -1,7 +1,7 @@
 import type { UmbBlockGridLayoutModel, UmbBlockGridTypeModel } from '../types.js';
 import type { UmbBlockGridWorkspaceData } from '../index.js';
 import { UmbArrayState, appendToFrozenArray, pushAtToUniqueArray } from '@umbraco-cms/backoffice/observable-api';
-import { transformServerPathToClientPath } from '@umbraco-cms/backoffice/utils';
+import { removeLastSlashFromPath, transformServerPathToClientPath } from '@umbraco-cms/backoffice/utils';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UMB_APP_CONTEXT } from '@umbraco-cms/backoffice/app';
 import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
@@ -29,7 +29,7 @@ export class UmbBlockGridManagerContext<
 
 		if (layoutStylesheet) {
 			// Cause we await initAppUrl in setting the _editorConfiguration, we can trust the appUrl begin here.
-			return this.#appUrl! + transformServerPathToClientPath(layoutStylesheet);
+			return removeLastSlashFromPath(this.#appUrl!) + transformServerPathToClientPath(layoutStylesheet);
 		}
 		return undefined;
 	});

--- a/src/packages/block/block-grid/context/block-grid-manager.context.ts
+++ b/src/packages/block/block-grid/context/block-grid-manager.context.ts
@@ -29,7 +29,7 @@ export class UmbBlockGridManagerContext<
 
 		if (layoutStylesheet) {
 			// Cause we await initAppUrl in setting the _editorConfiguration, we can trust the appUrl begin here.
-			return this.#appUrl! + removeInitialSlashFromPath(transformServerPathToClientPath(layoutStylesheet));
+			return this.#appUrl! + transformServerPathToClientPath(layoutStylesheet);
 		}
 		return undefined;
 	});

--- a/src/packages/block/block-grid/context/block-grid-manager.context.ts
+++ b/src/packages/block/block-grid/context/block-grid-manager.context.ts
@@ -1,7 +1,7 @@
 import type { UmbBlockGridLayoutModel, UmbBlockGridTypeModel } from '../types.js';
 import type { UmbBlockGridWorkspaceData } from '../index.js';
 import { UmbArrayState, appendToFrozenArray, pushAtToUniqueArray } from '@umbraco-cms/backoffice/observable-api';
-import { removeInitialSlashFromPath, transformServerPathToClientPath } from '@umbraco-cms/backoffice/utils';
+import { transformServerPathToClientPath } from '@umbraco-cms/backoffice/utils';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UMB_APP_CONTEXT } from '@umbraco-cms/backoffice/app';
 import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';

--- a/src/packages/block/block-type/components/block-type-card/block-type-card.element.ts
+++ b/src/packages/block/block-type/components/block-type-card/block-type-card.element.ts
@@ -28,7 +28,7 @@ export class UmbBlockTypeCardElement extends UmbLitElement {
 		value = transformServerPathToClientPath(value);
 		if (value) {
 			this.#init.then(() => {
-				this._iconFile = this.#appUrl + removeInitialSlashFromPath(value);
+				this._iconFile = this.#appUrl + value;
 			});
 		} else {
 			this._iconFile = undefined;

--- a/src/packages/block/block-type/components/block-type-card/block-type-card.element.ts
+++ b/src/packages/block/block-type/components/block-type-card/block-type-card.element.ts
@@ -6,7 +6,7 @@ import { html, customElement, property, state, ifDefined } from '@umbraco-cms/ba
 import { UmbRepositoryItemsManager } from '@umbraco-cms/backoffice/repository';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UMB_APP_CONTEXT } from '@umbraco-cms/backoffice/app';
-import { removeInitialSlashFromPath, transformServerPathToClientPath } from '@umbraco-cms/backoffice/utils';
+import { transformServerPathToClientPath } from '@umbraco-cms/backoffice/utils';
 
 @customElement('umb-block-type-card')
 export class UmbBlockTypeCardElement extends UmbLitElement {

--- a/src/packages/block/block-type/components/block-type-card/block-type-card.element.ts
+++ b/src/packages/block/block-type/components/block-type-card/block-type-card.element.ts
@@ -6,13 +6,13 @@ import { html, customElement, property, state, ifDefined } from '@umbraco-cms/ba
 import { UmbRepositoryItemsManager } from '@umbraco-cms/backoffice/repository';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UMB_APP_CONTEXT } from '@umbraco-cms/backoffice/app';
-import { transformServerPathToClientPath } from '@umbraco-cms/backoffice/utils';
+import { removeLastSlashFromPath, transformServerPathToClientPath } from '@umbraco-cms/backoffice/utils';
 
 @customElement('umb-block-type-card')
 export class UmbBlockTypeCardElement extends UmbLitElement {
 	//
 	#init: Promise<void>;
-	#appUrl?: string;
+	#appUrl: string = '';
 
 	#itemManager = new UmbRepositoryItemsManager<UmbDocumentTypeItemModel>(
 		this,
@@ -28,7 +28,7 @@ export class UmbBlockTypeCardElement extends UmbLitElement {
 		value = transformServerPathToClientPath(value);
 		if (value) {
 			this.#init.then(() => {
-				this._iconFile = this.#appUrl + value;
+				this._iconFile = removeLastSlashFromPath(this.#appUrl) + value;
 			});
 		} else {
 			this._iconFile = undefined;

--- a/src/packages/core/utils/index.ts
+++ b/src/packages/core/utils/index.ts
@@ -12,6 +12,7 @@ export * from './path/path-decode.function.js';
 export * from './path/path-encode.function.js';
 export * from './path/path-folder-name.function.js';
 export * from './path/remove-initial-slash-from-path.function.js';
+export * from './path/remove-last-slash-from-path.function.js';
 export * from './path/stored-path.function.js';
 export * from './path/transform-server-path-to-client-path.function.js';
 export * from './path/umbraco-path.function.js';

--- a/src/packages/core/utils/path/remove-initial-slash-from-path.function.ts
+++ b/src/packages/core/utils/path/remove-initial-slash-from-path.function.ts
@@ -1,5 +1,5 @@
 /**
- *
+ * Removes the initial slash from a path, if the first character is a slash.
  * @param path
  */
 export function removeInitialSlashFromPath(path: string) {

--- a/src/packages/core/utils/path/remove-last-slash-from-path.function.ts
+++ b/src/packages/core/utils/path/remove-last-slash-from-path.function.ts
@@ -1,0 +1,7 @@
+/**
+ * Remove the last slash from a path, if the last character is a slash.
+ * @param path
+ */
+export function removeLastSlashFromPath(path: string) {
+	return path.endsWith('/') ? path.slice(undefined, -1) : path;
+}


### PR DESCRIPTION
## Description
When configuring a `layoutStylesheet` against a BlockGrid datatype, the path to the CSS isn't resolved correctly when the front end is built and included in the NuGet package for release. The URL it is trying to be loaded from includes the backoffice path as part of the URL.

When running the Backoffice project locally, `appUrl` will always resolve to `http://localhost:5173`, whereas when running within the context of a C# project, `appUrl` will resolve to the absolute backoffice path, e.g. `https://localhost:44338/umbraco`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context
See https://github.com/umbraco/Umbraco-CMS/issues/16897.

Fixes the above linked issue so that BlockGrid layouts can be rendered correctly in the backoffice, and in Custom Views, with applied CSS.

This also fixes the same issue with Block icons.

## How to test?
Will need to be tested against a built version of the backoffice running in a .NET project (unsure how to do this, sorry!)

## Screenshots (if appropriate)
Unable to show screenshots as this only affects the built project when running on a .NET project

## Checklist
- [x] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
