### PR TITLE
Feature: Readonly mode for Date Picker Property Editor UI

### DIFF
--- a/src/packages/core/components/input-date/input-date.element.ts
+++ b/src/packages/core/components/input-date/input-date.element.ts
@@ -18,6 +18,15 @@ export class UmbInputDateElement extends UUIFormControlMixin(UmbLitElement, '') 
 	}
 
 	/**
+	 * Sets the input to readonly mode, meaning value cannot be changed but still able to read and select its content.
+	 * @type {boolean}
+	 * @attr
+	 * @default false
+	 */
+	@property({ type: Boolean, reflect: true })
+	readonly: boolean = false;
+
+	/**
 	 * Specifies the type of input that will be rendered.
 	 * @type {'date'| 'time'| 'datetime-local'}
 	 * @attr
@@ -49,7 +58,8 @@ export class UmbInputDateElement extends UUIFormControlMixin(UmbLitElement, '') 
 			.step=${this.step}
 			.type=${this.type}
 			value=${ifDefined(this.value)}
-			@change=${this.#onChange}>
+			@change=${this.#onChange}
+			?readonly=${this.readonly}>
 		</uui-input>`;
 	}
 }

--- a/src/packages/property-editors/date-picker/manifests.ts
+++ b/src/packages/property-editors/date-picker/manifests.ts
@@ -12,6 +12,7 @@ export const manifests: Array<ManifestTypes> = [
 			propertyEditorSchemaAlias: 'Umbraco.DateTime',
 			icon: 'icon-time',
 			group: 'pickers',
+			supportsReadOnly: true,
 			settings: {
 				properties: [
 					{

--- a/src/packages/property-editors/date-picker/property-editor-ui-date-picker.element.ts
+++ b/src/packages/property-editors/date-picker/property-editor-ui-date-picker.element.ts
@@ -26,6 +26,15 @@ import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extensi
  */
 @customElement('umb-property-editor-ui-date-picker')
 export class UmbPropertyEditorUIDatePickerElement extends UmbLitElement implements UmbPropertyEditorUiElement {
+	/**
+	 * Sets the input to readonly mode, meaning value cannot be changed but still able to read and select its content.
+	 * @type {boolean}
+	 * @attr
+	 * @default false
+	 */
+	@property({ type: Boolean, reflect: true })
+	readonly: boolean = false;
+
 	@state()
 	private _inputType: UmbInputDateElement['type'] = 'datetime-local';
 
@@ -141,7 +150,8 @@ export class UmbPropertyEditorUIDatePickerElement extends UmbLitElement implemen
 				.max=${this._max}
 				.step=${this._step}
 				.type=${this._inputType}
-				@change=${this.#onChange}>
+				@change=${this.#onChange}
+				?readonly=${this.readonly}>
 			</umb-input-date>
 		`;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds `readonly` mode to the Date Picker Property Editor UI

## How to test

* Add the `readonly` attribute to the element through developer tools

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)