### PR TITLE
Feature: Readonly mode for Radio Button List Property Editor UI

### DIFF
--- a/src/packages/core/components/input-radio-button-list/input-radio-button-list.element.ts
+++ b/src/packages/core/components/input-radio-button-list/input-radio-button-list.element.ts
@@ -21,6 +21,15 @@ export class UmbInputRadioButtonListElement extends UUIFormControlMixin(UmbLitEl
 	@property({ type: Array })
 	public list: Array<UmbRadioButtonItem> = [];
 
+	/**
+	 * Sets the input to readonly mode, meaning value cannot be changed but still able to read and select its content.
+	 * @type {boolean}
+	 * @attr
+	 * @default false
+	 */
+	@property({ type: Boolean, reflect: true })
+	readonly = false;
+
 	protected override getFormElement() {
 		return undefined;
 	}
@@ -36,7 +45,7 @@ export class UmbInputRadioButtonListElement extends UUIFormControlMixin(UmbLitEl
 		if (!this.list) return nothing;
 
 		return html`
-			<uui-radio-group .value=${this.value} @change=${this.#onChange}>
+			<uui-radio-group .value=${this.value} @change=${this.#onChange} ?readonly=${this.readonly}>
 				${repeat(
 					this.list,
 					(item) => item,

--- a/src/packages/property-editors/radio-button-list/manifests.ts
+++ b/src/packages/property-editors/radio-button-list/manifests.ts
@@ -12,6 +12,7 @@ export const manifests: Array<ManifestTypes> = [
 			propertyEditorSchemaAlias: 'Umbraco.RadioButtonList',
 			icon: 'icon-target',
 			group: 'lists',
+			supportsReadOnly: true,
 		},
 	},
 	radioButtonListSchemaManifest,

--- a/src/packages/property-editors/radio-button-list/property-editor-ui-radio-button-list.element.ts
+++ b/src/packages/property-editors/radio-button-list/property-editor-ui-radio-button-list.element.ts
@@ -13,6 +13,15 @@ export class UmbPropertyEditorUIRadioButtonListElement extends UmbLitElement imp
 	@property()
 	value?: string = '';
 
+	/**
+	 * Sets the input to readonly mode, meaning value cannot be changed but still able to read and select its content.
+	 * @type {boolean}
+	 * @attr
+	 * @default false
+	 */
+	@property({ type: Boolean, reflect: true })
+	readonly = false;
+
 	public set config(config: UmbPropertyEditorConfigCollection | undefined) {
 		if (!config) return;
 
@@ -39,7 +48,8 @@ export class UmbPropertyEditorUIRadioButtonListElement extends UmbLitElement imp
 			<umb-input-radio-button-list
 				.list=${this._list}
 				.value=${this.value ?? ''}
-				@change=${this.#onChange}></umb-input-radio-button-list>
+				@change=${this.#onChange}
+				?readonly=${this.readonly}></umb-input-radio-button-list>
 		`;
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds `readonly` mode to the Radio Button List Property Editor UI

## How to test

* Add the `readonly` attribute to the element through developer tools

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)