### PR TITLE
Feature: Readonly mode for Rich Media Picker Property Editor UI

### DIFF
--- a/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
+++ b/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
@@ -117,6 +117,15 @@ export class UmbInputRichMediaElement extends UUIFormControlMixin(UmbLitElement,
 	@property({ type: Boolean })
 	multiple = false;
 
+	/**
+	 * Sets the input to readonly mode, meaning value cannot be changed but still able to read and select its content.
+	 * @type {boolean}
+	 * @attr
+	 * @default false
+	 */
+	@property({ type: Boolean, reflect: true })
+	readonly = false;
+
 	@property()
 	public override get value() {
 		return this.items?.map((item) => item.mediaKey).join(',');

--- a/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
+++ b/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
@@ -372,16 +372,19 @@ export class UmbInputRichMediaElement extends UUIFormControlMixin(UmbLitElement,
 					unique=${item.media}
 					alt=${item.name}
 					icon=${item.icon ?? 'icon-picture'}></umb-imaging-thumbnail>
-				${this.#renderIsTrashed(item)}
-				<uui-action-bar slot="actions">
-					<uui-button
-						label=${this.localize.term('general_remove')}
-						look="secondary"
-						@click=${() => this.#onRemove(item)}>
-						<uui-icon name="icon-trash"></uui-icon>
-					</uui-button>
-				</uui-action-bar>
+				${this.#renderIsTrashed(item)} ${this.#renderActions(item)}
 			</uui-card-media>
+		`;
+	}
+
+	#renderActions(item: UmbRichMediaCardModel) {
+		if (this.readonly) return nothing;
+		return html`
+			<uui-action-bar slot="actions">
+				<uui-button label=${this.localize.term('general_remove')} look="secondary" @click=${() => this.#onRemove(item)}>
+					<uui-icon name="icon-trash"></uui-icon>
+				</uui-button>
+			</uui-action-bar>
 		`;
 	}
 

--- a/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
+++ b/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
@@ -355,7 +355,8 @@ export class UmbInputRichMediaElement extends UUIFormControlMixin(UmbLitElement,
 				id="btn-add"
 				look="placeholder"
 				@click=${this.#openPicker}
-				label=${this.localize.term('general_choose')}>
+				label=${this.localize.term('general_choose')}
+				?disabled=${this.readonly}>
 				<uui-icon name="icon-add"></uui-icon>
 				${this.localize.term('general_choose')}
 			</uui-button>

--- a/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
+++ b/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
@@ -117,15 +117,6 @@ export class UmbInputRichMediaElement extends UUIFormControlMixin(UmbLitElement,
 	@property({ type: Boolean })
 	multiple = false;
 
-	/**
-	 * Sets the input to readonly mode, meaning value cannot be changed but still able to read and select its content.
-	 * @type {boolean}
-	 * @attr
-	 * @default false
-	 */
-	@property({ type: Boolean, reflect: true })
-	readonly = false;
-
 	@property()
 	public override get value() {
 		return this.items?.map((item) => item.mediaKey).join(',');
@@ -158,6 +149,27 @@ export class UmbInputRichMediaElement extends UUIFormControlMixin(UmbLitElement,
 	public get variantId(): string | undefined {
 		return this.#modalRouter.getUniquePathValue('variantId');
 	}
+
+	/**
+	 * Sets the input to readonly mode, meaning value cannot be changed but still able to read and select its content.
+	 * @type {boolean}
+	 * @attr
+	 * @default false
+	 */
+	@property({ type: Boolean, reflect: true })
+	public get readonly() {
+		return this.#readonly;
+	}
+	public set readonly(value) {
+		this.#readonly = value;
+
+		if (this.#readonly) {
+			this.#sorter.disable();
+		} else {
+			this.#sorter.enable();
+		}
+	}
+	#readonly = false;
 
 	@state()
 	private _cards: Array<UmbRichMediaCardModel> = [];

--- a/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
+++ b/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
@@ -332,6 +332,7 @@ export class UmbInputRichMediaElement extends UUIFormControlMixin(UmbLitElement,
 	}
 
 	#renderDropzone() {
+		if (this.readonly) return nothing;
 		if (this._cards && this._cards.length >= this.max) return;
 		return html`<umb-dropzone @change=${this.#onUploadCompleted}></umb-dropzone>`;
 	}

--- a/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
+++ b/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
@@ -377,9 +377,9 @@ export class UmbInputRichMediaElement extends UUIFormControlMixin(UmbLitElement,
 
 	#renderItem(item: UmbRichMediaCardModel) {
 		if (!item.unique) return nothing;
-		const href = this._routeBuilder?.({ key: item.unique });
+		const href = this.readonly ? undefined : this._routeBuilder?.({ key: item.unique });
 		return html`
-			<uui-card-media id=${item.unique} name=${item.name} .href=${href}>
+			<uui-card-media id=${item.unique} name=${item.name} .href=${href} ?readonly=${this.readonly}>
 				<umb-imaging-thumbnail
 					unique=${item.media}
 					alt=${item.name}

--- a/src/packages/media/media/property-editors/media-picker/manifests.ts
+++ b/src/packages/media/media/property-editors/media-picker/manifests.ts
@@ -11,6 +11,7 @@ const manifest: ManifestPropertyEditorUi = {
 		propertyEditorSchemaAlias: 'Umbraco.MediaPicker3',
 		icon: 'icon-picture',
 		group: 'media',
+		supportsReadOnly: true,
 	},
 };
 

--- a/src/packages/media/media/property-editors/media-picker/property-editor-ui-media-picker.element.ts
+++ b/src/packages/media/media/property-editors/media-picker/property-editor-ui-media-picker.element.ts
@@ -34,6 +34,15 @@ export class UmbPropertyEditorUIMediaPickerElement extends UmbLitElement impleme
 		this._max = minMax?.max ?? Infinity;
 	}
 
+	/**
+	 * Sets the input to readonly mode, meaning value cannot be changed but still able to read and select its content.
+	 * @type {boolean}
+	 * @attr
+	 * @default false
+	 */
+	@property({ type: Boolean, reflect: true })
+	readonly = false;
+
 	@state()
 	private _startNode: string = '';
 
@@ -88,7 +97,8 @@ export class UmbPropertyEditorUIMediaPickerElement extends UmbLitElement impleme
 				.startNode=${this._startNode}
 				.variantId=${this._variantId}
 				?multiple=${this._multiple}
-				@change=${this.#onChange}>
+				@change=${this.#onChange}
+				?readonly=${this.readonly}>
 			</umb-input-rich-media>
 		`;
 	}

--- a/src/packages/property-editors/toggle/manifests.ts
+++ b/src/packages/property-editors/toggle/manifests.ts
@@ -12,6 +12,7 @@ export const manifests: Array<ManifestTypes> = [
 			propertyEditorSchemaAlias: 'Umbraco.TrueFalse',
 			icon: 'icon-checkbox',
 			group: 'common',
+			supportsReadOnly: true,
 			settings: {
 				properties: [
 					{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds `readonly` mode to the Rich Media Picker Property Editor UI

## How to test

* Add the `readonly` attribute to the element through developer tools

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)