### PR TITLE
Feature: Readonly mode for Member Picker Property Editor UI

### DIFF
--- a/src/packages/members/member/components/input-member/input-member.element.ts
+++ b/src/packages/members/member/components/input-member/input-member.element.ts
@@ -209,10 +209,8 @@ export class UmbInputMemberElement extends UmbFormControlMixin<string | undefine
 	#renderItem(item: UmbMemberItemModel) {
 		if (!item.unique) return nothing;
 		return html`
-			<uui-ref-node name=${item.name} id=${item.unique}>
+			<uui-ref-node name=${item.name} id=${item.unique} ?readonly=${this.readonly}>
 				<uui-action-bar slot="actions">
-					${this.#renderOpenButton(item)}
-					<uui-button @click=${() => this.#onRemove(item)} label=${this.localize.term('general_remove')}></uui-button>
 					${this.#renderOpenButton(item)} ${this.#renderRemoveButton(item)}
 				</uui-action-bar>
 			</uui-ref-node>

--- a/src/packages/members/member/components/input-member/input-member.element.ts
+++ b/src/packages/members/member/components/input-member/input-member.element.ts
@@ -209,11 +209,11 @@ export class UmbInputMemberElement extends UmbFormControlMixin<string | undefine
 	#renderItem(item: UmbMemberItemModel) {
 		if (!item.unique) return nothing;
 		return html`
-			<uui-ref-node name=${item.name} id=${item.unique} ?readonly=${this.readonly}>
+			<uui-ref-node-member name=${item.name} id=${item.unique} ?readonly=${this.readonly}>
 				<uui-action-bar slot="actions">
 					${this.#renderOpenButton(item)} ${this.#renderRemoveButton(item)}
 				</uui-action-bar>
-			</uui-ref-node>
+			</uui-ref-node-member>
 		`;
 	}
 

--- a/src/packages/members/member/components/input-member/input-member.element.ts
+++ b/src/packages/members/member/components/input-member/input-member.element.ts
@@ -102,6 +102,27 @@ export class UmbInputMemberElement extends UmbFormControlMixin<string | undefine
 	@property({ type: Object, attribute: false })
 	public filter: (member: UmbMemberItemModel) => boolean = () => true;
 
+	/**
+	 * Sets the input to readonly mode, meaning value cannot be changed but still able to read and select its content.
+	 * @type {boolean}
+	 * @attr
+	 * @default false
+	 */
+	@property({ type: Boolean, reflect: true })
+	public get readonly() {
+		return this.#readonly;
+	}
+	public set readonly(value) {
+		this.#readonly = value;
+
+		if (this.#readonly) {
+			this.#sorter.disable();
+		} else {
+			this.#sorter.enable();
+		}
+	}
+	#readonly = false;
+
 	@state()
 	private _editMemberPath = '';
 

--- a/src/packages/members/member/components/input-member/input-member.element.ts
+++ b/src/packages/members/member/components/input-member/input-member.element.ts
@@ -201,7 +201,8 @@ export class UmbInputMemberElement extends UmbFormControlMixin<string | undefine
 				id="btn-add"
 				look="placeholder"
 				@click=${this.#openPicker}
-				label=${this.localize.term('general_choose')}></uui-button>
+				label=${this.localize.term('general_choose')}
+				?disabled=${this.readonly}></uui-button>
 		`;
 	}
 

--- a/src/packages/members/member/components/input-member/input-member.element.ts
+++ b/src/packages/members/member/components/input-member/input-member.element.ts
@@ -213,6 +213,7 @@ export class UmbInputMemberElement extends UmbFormControlMixin<string | undefine
 				<uui-action-bar slot="actions">
 					${this.#renderOpenButton(item)}
 					<uui-button @click=${() => this.#onRemove(item)} label=${this.localize.term('general_remove')}></uui-button>
+					${this.#renderOpenButton(item)} ${this.#renderRemoveButton(item)}
 				</uui-action-bar>
 			</uui-ref-node>
 		`;
@@ -226,6 +227,13 @@ export class UmbInputMemberElement extends UmbFormControlMixin<string | undefine
 				label="${this.localize.term('general_open')} ${item.name}">
 				${this.localize.term('general_open')}
 			</uui-button>
+		`;
+	}
+
+	#renderRemoveButton(item: UmbMemberItemModel) {
+		if (this.readonly) return nothing;
+		return html`
+			<uui-button @click=${() => this.#onRemove(item)} label=${this.localize.term('general_remove')}></uui-button>
 		`;
 	}
 

--- a/src/packages/members/member/property-editor/member-picker/manifests.ts
+++ b/src/packages/members/member/property-editor/member-picker/manifests.ts
@@ -12,6 +12,7 @@ export const manifests: Array<ManifestTypes> = [
 			propertyEditorSchemaAlias: 'Umbraco.MemberPicker',
 			icon: 'icon-user',
 			group: 'people',
+			supportsReadOnly: true,
 		},
 	},
 	memberPickerSchemaManifest,

--- a/src/packages/members/member/property-editor/member-picker/property-editor-ui-member-picker.element.ts
+++ b/src/packages/members/member/property-editor/member-picker/property-editor-ui-member-picker.element.ts
@@ -16,13 +16,27 @@ export class UmbPropertyEditorUIMemberPickerElement extends UmbLitElement implem
 	@property({ attribute: false })
 	public config?: UmbPropertyEditorConfigCollection;
 
+	/**
+	 * Sets the input to readonly mode, meaning value cannot be changed but still able to read and select its content.
+	 * @type {boolean}
+	 * @attr
+	 * @default false
+	 */
+	@property({ type: Boolean, reflect: true })
+	readonly = false;
+
 	#onChange(event: CustomEvent & { target: UmbInputMemberElement }) {
 		this.value = event.target.value;
 		this.dispatchEvent(new UmbPropertyValueChangeEvent());
 	}
 
 	override render() {
-		return html`<umb-input-member min="0" max="1" .value=${this.value} @change=${this.#onChange}></umb-input-member>`;
+		return html`<umb-input-member
+			min="0"
+			max="1"
+			.value=${this.value}
+			@change=${this.#onChange}
+			?readonly=${this.readonly}></umb-input-member>`;
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds `readonly` mode to the Member Picker Property Editor UI

## How to test

* Add the `readonly` attribute to the element through developer tools

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)