### PR TITLE
Feature: Readonly mode for Multi URL Picker Property Editor UI

### DIFF
--- a/src/packages/multi-url-picker/components/input-multi-url/input-multi-url.element.ts
+++ b/src/packages/multi-url-picker/components/input-multi-url/input-multi-url.element.ts
@@ -124,6 +124,15 @@ export class UmbInputMultiUrlElement extends UUIFormControlMixin(UmbLitElement, 
 
 	#urls: Array<UmbLinkPickerLink> = [];
 
+	/**
+	 * Sets the input to readonly mode, meaning value cannot be changed but still able to read and select its content.
+	 * @type {boolean}
+	 * @attr
+	 * @default false
+	 */
+	@property({ type: Boolean, reflect: true })
+	readonly = false;
+
 	@state()
 	private _modalRoute?: UmbModalRouteBuilder;
 

--- a/src/packages/multi-url-picker/link-picker-modal/link-picker-modal.element.ts
+++ b/src/packages/multi-url-picker/link-picker-modal/link-picker-modal.element.ts
@@ -181,11 +181,6 @@ export class UmbLinkPickerModalElement extends UmbModalBaseElement<UmbLinkPicker
 				.open=${!this.documentExpand}></uui-symbol-expand>
 			<uui-label for="document-expand">${this.localize.term('defaultdialogs_linkToPage')}</uui-label>
 			<div style="${styleMap({ display: !this.documentExpand ? 'block' : 'none' })}">
-				<uui-input
-					disabled
-					id="search-input"
-					placeholder=${this.localize.term('placeholders_search')}
-					label=${this.localize.term('placeholders_search')}></uui-input>
 				<umb-tree
 					alias=${UMB_DOCUMENT_TREE_ALIAS}
 					.props=${{

--- a/src/packages/multi-url-picker/property-editor/manifests.ts
+++ b/src/packages/multi-url-picker/property-editor/manifests.ts
@@ -11,6 +11,7 @@ export const manifests = [
 			propertyEditorSchemaAlias: 'Umbraco.MultiUrlPicker',
 			icon: 'icon-link',
 			group: 'pickers',
+			supportsReadOnly: true,
 			settings: {
 				properties: [
 					{

--- a/src/packages/multi-url-picker/property-editor/property-editor-ui-multi-url-picker.element.ts
+++ b/src/packages/multi-url-picker/property-editor/property-editor-ui-multi-url-picker.element.ts
@@ -27,6 +27,15 @@ export class UmbPropertyEditorUIMultiUrlPickerElement extends UmbLitElement impl
 		this._overlaySize = config.getValueByAlias<UUIModalSidebarSize>('overlaySize') ?? 'small';
 	}
 
+	/**
+	 * Sets the input to readonly mode, meaning value cannot be changed but still able to read and select its content.
+	 * @type {boolean}
+	 * @attr
+	 * @default false
+	 */
+	@property({ type: Boolean, reflect: true })
+	readonly = false;
+
 	#parseInt(value: unknown, fallback: number): number {
 		const num = Number(value);
 		return !isNaN(num) && num > 0 ? num : fallback;
@@ -74,6 +83,7 @@ export class UmbPropertyEditorUIMultiUrlPickerElement extends UmbLitElement impl
 				.urls=${this.value ?? []}
 				.variantId=${this._variantId}
 				?hide-anchor=${this._hideAnchor}
+				?readonly=${this.readonly}
 				@change=${this.#onChange}>
 			</umb-input-multi-url>
 		`;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds `readonly` mode to the Multi URL Picker Property Editor UI

## How to test

* Add the `readonly` attribute to the element through developer tools

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)