### PR TITLE
Fix: Determine when to create Blocks directly or via Block Workspace

### DIFF
--- a/src/packages/block/block-grid/context/block-grid-entries.context.ts
+++ b/src/packages/block/block-grid/context/block-grid-entries.context.ts
@@ -137,6 +137,26 @@ export class UmbBlockGridEntriesContext
 					},
 				};
 			})
+			.onSubmit(async (value, data) => {
+				if (value?.create && data) {
+					const created = await this.create(
+						value.create.contentElementTypeKey,
+						// We can parse an empty object, cause the rest will be filled in by others.
+						{} as any,
+						data.originData as UmbBlockGridWorkspaceOriginData,
+					);
+					if (created) {
+						this.insert(
+							created.layout,
+							created.content,
+							created.settings,
+							data.originData as UmbBlockGridWorkspaceOriginData,
+						);
+					} else {
+						throw new Error('Failed to create block');
+					}
+				}
+			})
 			.observeRouteBuilder((routeBuilder) => {
 				// TODO: Does it make any sense that this is a state? Check usage and confirm. [NL]
 				this._catalogueRouteBuilderState.setValue(routeBuilder);

--- a/src/packages/block/block-grid/context/block-grid-entries.context.ts
+++ b/src/packages/block/block-grid/context/block-grid-entries.context.ts
@@ -133,6 +133,7 @@ export class UmbBlockGridEntriesContext
 						blockGroups: this._manager?.getBlockGroups() ?? [],
 						openClipboard: routingInfo.view === 'clipboard',
 						originData: { index: index, areaKey: this.#areaKey, parentUnique: this.#parentUnique },
+						createBlockInWorkspace: true,
 					},
 				};
 			})

--- a/src/packages/block/block-rte/context/block-rte-entries.context.ts
+++ b/src/packages/block/block-rte/context/block-rte-entries.context.ts
@@ -4,7 +4,6 @@ import type { UmbBlockRteLayoutModel, UmbBlockRteTypeModel } from '../types.js';
 import {
 	UMB_BLOCK_RTE_WORKSPACE_MODAL,
 	type UmbBlockRteWorkspaceOriginData,
-	type UmbBlockRteWorkspaceData,
 } from '../workspace/block-rte-workspace.modal-token.js';
 import { UMB_BLOCK_RTE_MANAGER_CONTEXT } from './block-rte-manager.context-token.js';
 import { UmbBooleanState } from '@umbraco-cms/backoffice/observable-api';
@@ -44,6 +43,26 @@ export class UmbBlockRteEntriesContext extends UmbBlockEntriesContext<
 						createBlockInWorkspace: true,
 					},
 				};
+			})
+			.onSubmit(async (value, data) => {
+				if (value?.create && data) {
+					const created = await this.create(
+						value.create.contentElementTypeKey,
+						// We can parse an empty object, cause the rest will be filled in by others.
+						{} as any,
+						data.originData as UmbBlockRteWorkspaceOriginData,
+					);
+					if (created) {
+						this.insert(
+							created.layout,
+							created.content,
+							created.settings,
+							data.originData as UmbBlockRteWorkspaceOriginData,
+						);
+					} else {
+						throw new Error('Failed to create block');
+					}
+				}
 			})
 			.observeRouteBuilder((routeBuilder) => {
 				this._catalogueRouteBuilderState.setValue(routeBuilder);
@@ -115,10 +134,10 @@ export class UmbBlockRteEntriesContext extends UmbBlockEntriesContext<
 	async create(
 		contentElementTypeKey: string,
 		partialLayoutEntry?: Omit<UmbBlockRteLayoutModel, 'contentUdi'>,
-		modalData?: UmbBlockRteWorkspaceData,
+		originData?: UmbBlockRteWorkspaceOriginData,
 	) {
 		await this._retrieveManager;
-		return this._manager?.create(contentElementTypeKey, partialLayoutEntry, modalData);
+		return this._manager?.create(contentElementTypeKey, partialLayoutEntry, originData);
 	}
 
 	// insert Block?
@@ -127,10 +146,10 @@ export class UmbBlockRteEntriesContext extends UmbBlockEntriesContext<
 		layoutEntry: UmbBlockRteLayoutModel,
 		content: UmbBlockDataType,
 		settings: UmbBlockDataType | undefined,
-		modalData: UmbBlockRteWorkspaceData,
+		originData: UmbBlockRteWorkspaceOriginData,
 	) {
 		await this._retrieveManager;
-		return this._manager?.insert(layoutEntry, content, settings, modalData) ?? false;
+		return this._manager?.insert(layoutEntry, content, settings, originData) ?? false;
 	}
 
 	// create Block?

--- a/src/packages/block/block-rte/context/block-rte-entries.context.ts
+++ b/src/packages/block/block-rte/context/block-rte-entries.context.ts
@@ -41,6 +41,7 @@ export class UmbBlockRteEntriesContext extends UmbBlockEntriesContext<
 						blockGroups: [],
 						openClipboard: routingInfo.view === 'clipboard',
 						originData: {},
+						createBlockInWorkspace: true,
 					},
 				};
 			})

--- a/src/packages/block/block-rte/context/block-rte-manager.context.ts
+++ b/src/packages/block/block-rte/context/block-rte-manager.context.ts
@@ -1,5 +1,5 @@
 import type { UmbBlockRteLayoutModel, UmbBlockRteTypeModel } from '../types.js';
-import type { UmbBlockRteWorkspaceData } from '../index.js';
+import type { UmbBlockRteWorkspaceOriginData } from '../index.js';
 import type { UmbBlockDataType } from '../../block/types.js';
 import type { Editor } from '@umbraco-cms/backoffice/external/tinymce';
 import { UmbBlockManagerContext } from '@umbraco-cms/backoffice/block';
@@ -36,7 +36,7 @@ export class UmbBlockRteManagerContext<
 		partialLayoutEntry?: Omit<BlockLayoutType, 'contentUdi'>,
 		// This property is used by some implementations, but not used in this.
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		originData?: UmbBlockRteWorkspaceData,
+		originData?: UmbBlockRteWorkspaceOriginData,
 	) {
 		const data = super.createBlockData(contentElementTypeKey, partialLayoutEntry);
 
@@ -57,13 +57,13 @@ export class UmbBlockRteManagerContext<
 		layoutEntry: BlockLayoutType,
 		content: UmbBlockDataType,
 		settings: UmbBlockDataType | undefined,
-		modalData: UmbBlockRteWorkspaceData,
+		originData: UmbBlockRteWorkspaceOriginData,
 	) {
 		if (!this.#editor) return false;
 
 		this._layouts.appendOne(layoutEntry);
 
-		this.insertBlockData(layoutEntry, content, settings, modalData);
+		this.insertBlockData(layoutEntry, content, settings, originData);
 
 		if (layoutEntry.displayInline) {
 			this.#editor.selection.setContent(

--- a/src/packages/block/block-type/components/block-type-card/block-type-card.element.ts
+++ b/src/packages/block/block-type/components/block-type-card/block-type-card.element.ts
@@ -21,7 +21,7 @@ export class UmbBlockTypeCardElement extends UmbLitElement {
 		(x) => x.unique,
 	);
 
-	@property({ type: String, attribute: false })
+	@property({ type: String })
 	href?: string;
 
 	@property({ type: String, attribute: false })

--- a/src/packages/block/block/context/block-manager.context.ts
+++ b/src/packages/block/block/context/block-manager.context.ts
@@ -148,6 +148,10 @@ export abstract class UmbBlockManagerContext<
 	getContentTypeNameOf(contentTypeKey: string) {
 		return this.#contentTypes.getValue().find((x) => x.unique === contentTypeKey)?.name;
 	}
+	getContentTypeHasProperties(contentTypeKey: string) {
+		const properties = this.#contentTypes.getValue().find((x) => x.unique === contentTypeKey)?.properties;
+		return properties ? properties.length > 0 : false;
+	}
 	blockTypeOf(contentTypeKey: string) {
 		return this.#blockTypes.asObservablePart((source) =>
 			source.find((x) => x.contentElementTypeKey === contentTypeKey),

--- a/src/packages/block/block/modals/block-catalogue/block-catalogue-modal.element.ts
+++ b/src/packages/block/block/modals/block-catalogue/block-catalogue-modal.element.ts
@@ -1,6 +1,10 @@
 import { UMB_BLOCK_WORKSPACE_MODAL } from '../../workspace/index.js';
 import type { UmbBlockTypeGroup, UmbBlockTypeWithGroupKey } from '@umbraco-cms/backoffice/block-type';
-import type { UmbBlockCatalogueModalData, UmbBlockCatalogueModalValue } from '@umbraco-cms/backoffice/block';
+import {
+	UMB_BLOCK_MANAGER_CONTEXT,
+	type UmbBlockCatalogueModalData,
+	type UmbBlockCatalogueModalValue,
+} from '@umbraco-cms/backoffice/block';
 import { css, html, customElement, state, repeat, nothing } from '@umbraco-cms/backoffice/external/lit';
 import type { UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
 import { UMB_MODAL_CONTEXT, UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
@@ -14,8 +18,7 @@ export class UmbBlockCatalogueModalElement extends UmbModalBaseElement<
 	UmbBlockCatalogueModalData,
 	UmbBlockCatalogueModalValue
 > {
-	//
-	private _search = '';
+	#search = '';
 
 	private _groupedBlocks: Array<{ name?: string; blocks: Array<UmbBlockTypeWithGroupKey> }> = [];
 
@@ -27,6 +30,9 @@ export class UmbBlockCatalogueModalElement extends UmbModalBaseElement<
 
 	@state()
 	private _filtered: Array<{ name?: string; blocks: Array<UmbBlockTypeWithGroupKey> }> = [];
+
+	@state()
+	_manager?: typeof UMB_BLOCK_MANAGER_CONTEXT.TYPE;
 
 	constructor() {
 		super();
@@ -48,6 +54,10 @@ export class UmbBlockCatalogueModalElement extends UmbModalBaseElement<
 						this._workspacePath = routeBuilder({});
 					});
 			}
+		});
+
+		this.consumeContext(UMB_BLOCK_MANAGER_CONTEXT, (manager) => {
+			this._manager = manager;
 		});
 	}
 
@@ -71,10 +81,10 @@ export class UmbBlockCatalogueModalElement extends UmbModalBaseElement<
 	}
 
 	#updateFiltered() {
-		if (this._search.length === 0) {
+		if (this.#search.length === 0) {
 			this._filtered = this._groupedBlocks;
 		} else {
-			const search = this._search.toLowerCase();
+			const search = this.#search.toLowerCase();
 			this._filtered = this._groupedBlocks.map((group) => {
 				return { ...group, blocks: group.blocks.filter((block) => block.label?.toLocaleLowerCase().includes(search)) };
 			});
@@ -82,7 +92,7 @@ export class UmbBlockCatalogueModalElement extends UmbModalBaseElement<
 	}
 
 	#onSearch(e: UUIInputEvent) {
-		this._search = e.target.value as string;
+		this.#search = e.target.value as string;
 		this.#updateFiltered();
 	}
 
@@ -98,7 +108,7 @@ export class UmbBlockCatalogueModalElement extends UmbModalBaseElement<
 	override render() {
 		return html`
 			<umb-body-layout headline="${this.localize.term('blockEditor_addBlock')}">
-				${this.#renderViews()} ${this._openClipboard ? this.#renderClipboard() : this.#renderCreateEmpty()}
+				${this.#renderViews()}${this.#renderMain()}
 				<div slot="actions">
 					<uui-button label=${this.localize.term('general_close')} @click=${this._rejectModal}></uui-button>
 					<uui-button
@@ -109,6 +119,10 @@ export class UmbBlockCatalogueModalElement extends UmbModalBaseElement<
 				</div>
 			</umb-body-layout>
 		`;
+	}
+
+	#renderMain() {
+		return this._manager ? (this._openClipboard ? this.#renderClipboard() : this.#renderCreateEmpty()) : nothing;
 	}
 
 	#renderClipboard() {
@@ -140,7 +154,7 @@ export class UmbBlockCatalogueModalElement extends UmbModalBaseElement<
 									.backgroundColor=${block.backgroundColor}
 									.contentElementTypeKey=${block.contentElementTypeKey}
 									@open=${() => this.#chooseBlock(block.contentElementTypeKey)}
-									.href=${this._workspacePath
+									.href=${this._workspacePath && this._manager!.getContentTypeHasProperties(block.contentElementTypeKey)
 										? `${this._workspacePath}create/${block.contentElementTypeKey}`
 										: undefined}>
 								</umb-block-type-card>

--- a/src/packages/block/block/modals/block-catalogue/block-catalogue-modal.element.ts
+++ b/src/packages/block/block/modals/block-catalogue/block-catalogue-modal.element.ts
@@ -140,7 +140,7 @@ export class UmbBlockCatalogueModalElement extends UmbModalBaseElement<
 									.backgroundColor=${block.backgroundColor}
 									.contentElementTypeKey=${block.contentElementTypeKey}
 									@open=${() => this.#chooseBlock(block.contentElementTypeKey)}
-									?href=${this._workspacePath
+									.href=${this._workspacePath
 										? `${this._workspacePath}create/${block.contentElementTypeKey}`
 										: undefined}>
 								</umb-block-type-card>

--- a/src/packages/core/property/property/property.element.ts
+++ b/src/packages/core/property/property/property.element.ts
@@ -332,7 +332,7 @@ export class UmbPropertyElement extends UmbLitElement {
 				if ('checkValidity' in this._element) {
 					const dataPath = this.dataPath;
 					this.#controlValidator = new UmbFormControlValidator(this, this._element as any, dataPath);
-					// We trust blindly that the dataPath is available at this stage. [NL]
+					// We trust blindly that the dataPath will be present at this stage and not arrive later than this moment. [NL]
 					if (dataPath) {
 						this.#validationMessageBinder = new UmbBindServerValidationToFormControl(
 							this,


### PR DESCRIPTION
Fixes so Blocks are created via a modal Workspace, unless its Block List Editor in Inline Editing Mode.
There was a few missing parts of the current source that this PR corrects.

This now also considers if a Block has any content properties, if not it will not be created via the Workspace, instead directly.
Meaning we do not open Blocks in a Workspace if they dont have any Content Properties.

## Description

<!--- Describe the changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
