### PR TITLE
Bugfix: Exports `UmbUfmComponentBase` type

### DIFF
--- a/examples/ufm-custom-component/README.md
+++ b/examples/ufm-custom-component/README.md
@@ -1,0 +1,5 @@
+# UFM Custom Component
+
+This example demonstrates how to write a custom Umbraco-Flavored Markdown (UFM) component.
+
+https://docs.umbraco.com/umbraco-cms/reference/umbraco-flavored-markdown#custom-ufm-components

--- a/examples/ufm-custom-component/custom-ufm-component.ts
+++ b/examples/ufm-custom-component/custom-ufm-component.ts
@@ -1,0 +1,26 @@
+import { customElement, html, property } from '@umbraco-cms/backoffice/external/lit';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { UmbUfmComponentBase } from '@umbraco-cms/backoffice/ufm';
+import type { UfmToken } from '@umbraco-cms/backoffice/ufm';
+
+export class UmbCustomUfmComponent extends UmbUfmComponentBase {
+	render(token: UfmToken) {
+		// You could do further regular expression/text processing,
+		// then output your custom HTML markup.
+		return `<ufm-custom-component text="${token.text}"></ufm-custom-component>`;
+	}
+}
+
+// eslint-disable-next-line local-rules/enforce-umb-prefix-on-element-name
+@customElement('ufm-custom-component')
+export class UmbCustomUfmComponentElement extends UmbLitElement {
+	@property()
+	text?: string;
+
+	override render() {
+		return html`<marquee>${this.text}</marquee>`;
+	}
+}
+
+export { UmbCustomUfmComponent as api };
+export { UmbCustomUfmComponentElement as element };

--- a/examples/ufm-custom-component/index.ts
+++ b/examples/ufm-custom-component/index.ts
@@ -1,0 +1,13 @@
+import type { ManifestUfmComponent } from '@umbraco-cms/backoffice/extension-registry';
+
+export const manifests: Array<ManifestUfmComponent> = [
+	{
+		type: 'ufmComponent',
+		alias: 'Umb.CustomUfmComponent',
+		name: 'Custom UFM Component',
+		api: () => import('./custom-ufm-component.js'),
+		meta: {
+			marker: '%',
+		},
+	},
+];

--- a/src/packages/ufm/index.ts
+++ b/src/packages/ufm/index.ts
@@ -1,2 +1,3 @@
 export * from './components/ufm-render/index.js';
 export * from './plugins/marked-ufm.plugin.js';
+export * from './ufm-components/ufm-component-base.js';


### PR DESCRIPTION
## Description

Raised on the docs repo, https://github.com/umbraco/UmbracoDocs/issues/6374, the `UmbUfmComponentBase` class wasn't being exported.

This PR...

- Exports `UmbUfmComponentBase` type
- Adds custom UFM component example


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

