### PR TITLE
Fix: Block Grid Editor — Specified Permissions Group Rules

### DIFF
--- a/src/packages/block/block-grid/context/block-grid-entries.context.ts
+++ b/src/packages/block/block-grid/context/block-grid-entries.context.ts
@@ -490,7 +490,7 @@ export class UmbBlockGridEntriesContext
 							.filter((blockType) => blockType.groupKey === rule.groupKey && blockType.allowInAreas === true)
 							.map((x) => x.contentElementTypeKey) ?? [];
 					const groupAmount = layoutEntries.filter((entry) => {
-						const contentTypeKey = this._manager!.getContentTypeKeyOf(entry.contentUdi);
+						const contentTypeKey = this._manager!.getContentTypeKeyOfContentUdi(entry.contentUdi);
 						return contentTypeKey ? groupElementTypeKeys.indexOf(contentTypeKey) !== -1 : false;
 					}).length;
 
@@ -503,6 +503,7 @@ export class UmbBlockGridEntriesContext
 							maxRequirement: maxAllowed,
 						};
 					}
+					return undefined;
 				}
 				// For specific elementTypes:
 				else if (rule.elementTypeKey) {
@@ -519,6 +520,7 @@ export class UmbBlockGridEntriesContext
 							maxRequirement: maxAllowed,
 						};
 					}
+					return undefined;
 				}
 
 				// Lets fail cause the rule was bad.

--- a/src/packages/block/block-grid/context/block-grid-entries.context.ts
+++ b/src/packages/block/block-grid/context/block-grid-entries.context.ts
@@ -20,6 +20,14 @@ import { UmbModalRouteRegistrationController } from '@umbraco-cms/backoffice/rou
 import { pathFolderName } from '@umbraco-cms/backoffice/utils';
 import type { UmbNumberRangeValueType } from '@umbraco-cms/backoffice/models';
 
+interface UmbBlockGridAreaTypeInvalidRuleType {
+	groupKey?: string;
+	key?: string;
+	name: string;
+	amount: number;
+	minRequirement: number;
+	maxRequirement: number;
+}
 export class UmbBlockGridEntriesContext
 	extends UmbBlockEntriesContext<
 		typeof UMB_BLOCK_GRID_MANAGER_CONTEXT,
@@ -455,14 +463,7 @@ export class UmbBlockGridEntriesContext
 		}
 	}
 
-	#invalidBlockTypeLimits?: Array<{
-		groupKey?: string;
-		key?: string;
-		name: string;
-		amount: number;
-		minRequirement: number;
-		maxRequirement: number;
-	}>;
+	#invalidBlockTypeLimits?: Array<UmbBlockGridAreaTypeInvalidRuleType>;
 
 	getInvalidBlockTypeLimits() {
 		return this.#invalidBlockTypeLimits ?? [];
@@ -476,57 +477,56 @@ export class UmbBlockGridEntriesContext
 
 		const layoutEntries = this._layoutEntries.getValue();
 
-		this.#invalidBlockTypeLimits = [];
+		this.#invalidBlockTypeLimits = this.#areaType.specifiedAllowance
+			.map((rule) => {
+				const minAllowed = rule.minAllowed || 0;
+				const maxAllowed = rule.maxAllowed || 0;
 
-		const hasInvalidRules = this.#areaType.specifiedAllowance.some((rule) => {
-			const minAllowed = rule.minAllowed || 0;
-			const maxAllowed = rule.maxAllowed || 0;
+				// For block groups:
+				if (rule.groupKey) {
+					const groupElementTypeKeys =
+						this._manager
+							?.getBlockTypes()
+							.filter((blockType) => blockType.groupKey === rule.groupKey && blockType.allowInAreas === true)
+							.map((x) => x.contentElementTypeKey) ?? [];
+					const groupAmount = layoutEntries.filter((entry) => {
+						const contentTypeKey = this._manager!.getContentTypeKeyOf(entry.contentUdi);
+						return contentTypeKey ? groupElementTypeKeys.indexOf(contentTypeKey) !== -1 : false;
+					}).length;
 
-			// For block groups:
-			if (rule.groupKey) {
-				const groupElementTypeKeys =
-					this._manager
-						?.getBlockTypes()
-						.filter((blockType) => blockType.groupKey === rule.groupKey && blockType.allowInAreas === true)
-						.map((x) => x.contentElementTypeKey) ?? [];
-				const groupAmount = layoutEntries.filter((entry) => {
-					const contentTypeKey = this._manager!.getContentTypeKeyOf(entry.contentUdi);
-					return contentTypeKey ? groupElementTypeKeys.indexOf(contentTypeKey) !== -1 : false;
-				}).length;
-
-				if (groupAmount < minAllowed || (maxAllowed > 0 && groupAmount > maxAllowed)) {
-					this.#invalidBlockTypeLimits!.push({
-						groupKey: rule.groupKey,
-						name: this._manager!.getBlockGroupName(rule.groupKey) ?? '?',
-						amount: groupAmount,
-						minRequirement: minAllowed,
-						maxRequirement: maxAllowed,
-					});
-					return true;
+					if (groupAmount < minAllowed || (maxAllowed > 0 && groupAmount > maxAllowed)) {
+						return {
+							groupKey: rule.groupKey,
+							name: this._manager!.getBlockGroupName(rule.groupKey) ?? '?',
+							amount: groupAmount,
+							minRequirement: minAllowed,
+							maxRequirement: maxAllowed,
+						};
+					}
 				}
-			}
-			// For specific elementTypes:
-			else if (rule.elementTypeKey) {
-				const amount = layoutEntries.filter((entry) => {
-					const contentTypeKey = this._manager!.getContentOf(entry.contentUdi)?.contentTypeKey;
-					return contentTypeKey === rule.elementTypeKey;
-				}).length;
-				if (amount < minAllowed || (maxAllowed > 0 ? amount > maxAllowed : false)) {
-					this.#invalidBlockTypeLimits!.push({
-						key: rule.elementTypeKey,
-						name: this._manager!.getContentTypeNameOf(rule.elementTypeKey) ?? '?',
-						amount: amount,
-						minRequirement: minAllowed,
-						maxRequirement: maxAllowed,
-					});
-					return true;
+				// For specific elementTypes:
+				else if (rule.elementTypeKey) {
+					const amount = layoutEntries.filter((entry) => {
+						const contentTypeKey = this._manager!.getContentOf(entry.contentUdi)?.contentTypeKey;
+						return contentTypeKey === rule.elementTypeKey;
+					}).length;
+					if (amount < minAllowed || (maxAllowed > 0 ? amount > maxAllowed : false)) {
+						return {
+							key: rule.elementTypeKey,
+							name: this._manager!.getContentTypeNameOf(rule.elementTypeKey) ?? '?',
+							amount: amount,
+							minRequirement: minAllowed,
+							maxRequirement: maxAllowed,
+						};
+					}
 				}
-			}
 
-			// Lets fail cause the rule was bad.
-			console.error('Invalid block type limit rule.', rule);
-			return false;
-		});
+				// Lets fail cause the rule was bad.
+				console.error('Invalid block type limit rule.', rule);
+				return undefined;
+			})
+			.filter((x) => x !== undefined) as Array<UmbBlockGridAreaTypeInvalidRuleType>;
+		const hasInvalidRules = this.#invalidBlockTypeLimits.length > 0;
 		return hasInvalidRules === false;
 	}
 

--- a/src/packages/block/block-grid/workspace/block-grid-type-workspace.modal-token.ts
+++ b/src/packages/block/block-grid/workspace/block-grid-type-workspace.modal-token.ts
@@ -14,7 +14,7 @@ export const UMB_BLOCK_GRID_TYPE_WORKSPACE_MODAL = new UmbModalToken<
 			type: 'sidebar',
 			size: 'large',
 		},
-		data: { entityType: UMB_BLOCK_GRID_TYPE, preset: { allowAtRoot: true } },
+		data: { entityType: UMB_BLOCK_GRID_TYPE, preset: { allowAtRoot: true, allowInAreas: true } },
 	},
 	// Recast the type, so the entityType data prop is not required:
 ) as UmbModalToken<Omit<UmbWorkspaceModalData, 'entityType' | 'preset'>, UmbWorkspaceModalValue>;

--- a/src/packages/block/block/context/block-manager.context.ts
+++ b/src/packages/block/block/context/block-manager.context.ts
@@ -139,6 +139,9 @@ export abstract class UmbBlockManagerContext<
 		this.#contentTypes.appendOne(data);
 	}
 
+	getContentTypeKeyOfContentUdi(contentUdi: string) {
+		return this.getContentOf(contentUdi)?.contentTypeKey;
+	}
 	contentTypeOf(contentTypeKey: string) {
 		return this.#contentTypes.asObservablePart((source) => source.find((x) => x.unique === contentTypeKey));
 	}
@@ -147,9 +150,6 @@ export abstract class UmbBlockManagerContext<
 	}
 	getContentTypeNameOf(contentTypeKey: string) {
 		return this.#contentTypes.getValue().find((x) => x.unique === contentTypeKey)?.name;
-	}
-	getContentTypeKeyOf(contentTypeKey: string) {
-		return this.#contentTypes.getValue().find((x) => x.unique === contentTypeKey)?.unique;
 	}
 	getContentTypeHasProperties(contentTypeKey: string) {
 		const properties = this.#contentTypes.getValue().find((x) => x.unique === contentTypeKey)?.properties;

--- a/src/packages/core/validation/mixins/form-control.mixin.ts
+++ b/src/packages/core/validation/mixins/form-control.mixin.ts
@@ -164,7 +164,7 @@ export function UmbFormControlMixin<
 			super(...args);
 			this._internals = this.attachInternals();
 
-			this.addEventListener('blur', (e) => {
+			this.addEventListener('blur', () => {
 				/*if (e.composedPath().some((x) => x === this)) {
 					return;
 				}*/

--- a/src/packages/core/validation/mixins/form-control.mixin.ts
+++ b/src/packages/core/validation/mixins/form-control.mixin.ts
@@ -164,7 +164,10 @@ export function UmbFormControlMixin<
 			super(...args);
 			this._internals = this.attachInternals();
 
-			this.addEventListener('blur', () => {
+			this.addEventListener('blur', (e) => {
+				/*if (e.composedPath().some((x) => x === this)) {
+					return;
+				}*/
 				this.pristine = false;
 				this.checkValidity();
 			});

--- a/src/packages/data-type/components/data-type-flow-input/data-type-flow-input.element.ts
+++ b/src/packages/data-type/components/data-type-flow-input/data-type-flow-input.element.ts
@@ -101,7 +101,7 @@ export class UmbInputDataTypeElement extends UmbFormControlMixin(UmbLitElement, 
 						label="Select Property Editor"
 						look="placeholder"
 						color="default"
-						@focus=${() => {
+						@blur=${() => {
 							this.pristine = false;
 						}}
 						.href=${this._createRoute}></uui-button>


### PR DESCRIPTION
Fixes Group rules + Combination of rules

So now you can have a single element rule and a group rule (specified permissions for Areas) Where those two now play well together.

For this PR I tested with a requirement of the headline to be present at least once, and maximum once.
And the group of Elements should be present twice.

![image](https://github.com/user-attachments/assets/9235f092-e926-4435-a9e6-85cc9cc25471)
![image](https://github.com/user-attachments/assets/8a5743c2-fa40-49e4-a95c-7aee03d739b2)

Every things is good in this case:
![image](https://github.com/user-attachments/assets/ebc5ef8d-690e-4f40-8dba-21cf4940f06f)

A few screenshots of bad cases:
![image](https://github.com/user-attachments/assets/61934401-f014-4869-9d87-02b3adb06227)
![image](https://github.com/user-attachments/assets/868f29d2-6dd3-4c18-9ee3-83430a90e179)
![image](https://github.com/user-attachments/assets/7c9f2ae6-66f3-47aa-b2cf-f584bc9b702e)

You may do another test to ensure the system works intuitively.

Notice, when picking a group, its only the Blocks of the group that is set for Allow in Areas that is considered.
But for Element Rules that settings does not matter.

So this PR also changes to Allow In Areas are ticked pr. default. which is similar to v.13.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
