### PR TITLE
Add headline to block editor

### DIFF
--- a/src/packages/block/block/workspace/block-workspace-editor.element.ts
+++ b/src/packages/block/block/workspace/block-workspace-editor.element.ts
@@ -8,9 +8,12 @@ export class UmbBlockWorkspaceEditorElement extends UmbLitElement {
 	@property({ type: String, attribute: false })
 	workspaceAlias?: string;
 
+	@property({ type: String, attribute: false })
+	headline?: String;
+
 	override render() {
 		return this.workspaceAlias
-			? html` <umb-workspace-editor alias=${this.workspaceAlias} headline=${'BLOCK EDITOR'}> </umb-workspace-editor> `
+			? html` <umb-workspace-editor alias=${this.workspaceAlias} headline=${this.headline ?? 'BLOCK EDITOR'}> </umb-workspace-editor> `
 			: '';
 	}
 

--- a/src/packages/block/block/workspace/block-workspace.context.ts
+++ b/src/packages/block/block/workspace/block-workspace.context.ts
@@ -88,9 +88,11 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 				path: 'create/:elementTypeKey',
 				component: UmbBlockWorkspaceEditorElement,
 				setup: async (component, info) => {
-					(component as UmbBlockWorkspaceEditorElement).workspaceAlias = manifest.alias;
-
 					const elementTypeKey = info.match.params.elementTypeKey;
+					const blockType = this.#blockManager?.getBlockTypeOf(elementTypeKey);
+					(component as UmbBlockWorkspaceEditorElement).workspaceAlias = manifest.alias;
+					(component as UmbBlockWorkspaceEditorElement).headline = blockType?.label;
+					
 					this.create(elementTypeKey);
 
 					new UmbWorkspaceIsNewRedirectController(


### PR DESCRIPTION
Add headline to block editor

## Description

Add a headline to the block editor instead of the hardcoded 'BLOCK EDITOR'

## How to test?
Add a new block to a block editor

## Screenshots (if appropriate)
Before: 
![image](https://github.com/user-attachments/assets/6fd64a43-a5bf-40ba-9b11-959b649a3206)

After: 
![image](https://github.com/user-attachments/assets/79cd5882-7703-4eff-b101-e2facf3776b1)


