### PR TITLE
Fix: Update dictionary's name fallback value when using it as a placeholder in `dictionaryItem_description` localization term

### DIFF
--- a/src/packages/dictionary/workspace/views/workspace-view-dictionary-editor.element.ts
+++ b/src/packages/dictionary/workspace/views/workspace-view-dictionary-editor.element.ts
@@ -84,7 +84,7 @@ export class UmbWorkspaceViewDictionaryEditorElement extends UmbLitElement {
 	override render() {
 		return html`
 			<uui-box>
-				${unsafeHTML(this.localize.term('dictionaryItem_description', this._dictionary?.name || 'unnamed'))}
+				${unsafeHTML(this.localize.term('dictionaryItem_description', this._dictionary?.name || '&#8203;'))}
 				${repeat(
 					this._languages,
 					(item) => item.unique,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Used `zero-width space` character instead of `unnamed` instead for dictionary item name fallback in `dictionaryItem_description`.

## Description

As noted in umbraco/Umbraco-CMS#16385, using `unnamed` as a fallback for empty dictionary item names can be confusing, potentially being thought as an existing item. Displaying a quoted empty string is clearer and directly reflects the empty value.

In the code, placeholders in the format `%index%` and `{index}` are replaced with values from `args`. If an empty string is passed, it is treated as falsy, so placeholders are not replaced:

```javascript
if (typeof term === 'string') {
    if (args.length > 0) {
        term = term.replace(/(%(\d+)%|\{(\d+)\})/g, (match, _p1, p2, p3): string => {
            const index = p2 || p3;
            return String(args[index] || match);
        });
    }
}
```

Thus I used a zero-width space (HTML entity) because it is a truthy value and ensures placeholders are replaced correctly. I intentionally used the html entity value because if i copied the Unicode char it would cause more chaos for developers unless the text editor highlights it. Alternatively, using a visible space (` `) could be a simple solution and is barely noticeable in the UI. Another option might be to remove the placeholder completely or update it only when the item is saved. Either way the impact is small.

resolves  umbraco/Umbraco-CMS#16385

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

I have been interested in contributing to Umbraco and saw this issue as a good opportunity to get involved with the project. Usually, I pay attention to details and try to ensure a smooth experience. This issue seemed like a perfect starting point for me.

<!--- Why is this change required? What problem does it solve? -->

## How to test?

1. Follow the [installation instructions](https://github.com/umbraco/Umbraco.CMS.Backoffice?tab=readme-ov-file#installation-instructions) to set up `Bellisima` locally.
2. Open `Bellisima` in your web browser.
3. Go to the `Dictionary` section from the top navigation bar.
4. Create new dictionary items with various values to observe their behavior.

## Screenshots (if appropriate)

### Using empty string for fallback
![image](https://github.com/user-attachments/assets/b34798fc-2315-4455-9e0e-836740238afa)

### Using single space as the fallback value
![image](https://github.com/user-attachments/assets/daf74d35-b39d-4850-bce1-3b749e5f7718)


### Before the Fix
![no-fix](https://github.com/user-attachments/assets/84bf931d-78ef-4dac-8988-15ab4c894bd6)

### After the fix (using zero-width char)
![fix](https://github.com/user-attachments/assets/b442d319-54fd-4d47-a0ec-f4c2b4bba24d)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
