### PR TITLE
Bugfix: Blocks in RTE redirects to the frontpage

### DIFF
--- a/src/packages/block/block-rte/tiny-mce-plugin/tiny-mce-block-picker.plugin.ts
+++ b/src/packages/block/block-rte/tiny-mce-plugin/tiny-mce-block-picker.plugin.ts
@@ -59,14 +59,19 @@ export default class UmbTinyMceMultiUrlPickerPlugin extends UmbTinyMcePluginBase
 	}
 
 	#createBlock() {
+		if (!this.#entriesContext) {
+			console.error('[Block Picker] No entries context available.');
+			return;
+		}
+
 		// TODO: Missing solution to skip catalogue if only one type available. [NL]
 		let createPath: string | undefined = undefined;
 
 		if (this._blocks?.length === 1) {
 			const elementKey = this._blocks[0].contentElementTypeKey;
-			createPath = this.#entriesContext?.getPathForCreateBlock() + 'modal/umb-modal-workspace/create/' + elementKey;
+			createPath = this.#entriesContext.getPathForCreateBlock() + 'modal/umb-modal-workspace/create/' + elementKey;
 		} else {
-			createPath = this.#entriesContext?.getPathForCreateBlock();
+			createPath = this.#entriesContext.getPathForCreateBlock();
 		}
 
 		if (createPath) {

--- a/src/packages/tiny-mce/property-editors/tiny-mce/property-editor-ui-tiny-mce.element.ts
+++ b/src/packages/tiny-mce/property-editors/tiny-mce/property-editor-ui-tiny-mce.element.ts
@@ -3,8 +3,6 @@ import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbPropertyValueChangeEvent } from '@umbraco-cms/backoffice/property-editor';
 import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
 import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extension-registry';
-
-import '../../components/input-tiny-mce/input-tiny-mce.element.js';
 import {
 	UmbBlockRteEntriesContext,
 	type UmbBlockRteLayoutModel,
@@ -12,6 +10,8 @@ import {
 	type UmbBlockRteTypeModel,
 } from '@umbraco-cms/backoffice/block-rte';
 import type { UmbBlockValueType } from '@umbraco-cms/backoffice/block';
+
+import '../../components/input-tiny-mce/input-tiny-mce.element.js';
 
 export interface UmbRichTextEditorValueType {
 	markup: string;

--- a/src/packages/tiny-mce/property-editors/tiny-mce/property-editor-ui-tiny-mce.element.ts
+++ b/src/packages/tiny-mce/property-editors/tiny-mce/property-editor-ui-tiny-mce.element.ts
@@ -89,6 +89,11 @@ export class UmbPropertyEditorUITinyMceElement extends UmbLitElement implements 
 	constructor() {
 		super();
 
+		this.observe(this.#entriesContext.layoutEntries, (layouts) => {
+			// Update manager:
+			this.#managerContext.setLayouts(layouts);
+		});
+
 		this.observe(this.#managerContext.layouts, (layouts) => {
 			this._value = {
 				...this._value,

--- a/src/packages/tiny-mce/property-editors/tiny-mce/property-editor-ui-tiny-mce.element.ts
+++ b/src/packages/tiny-mce/property-editors/tiny-mce/property-editor-ui-tiny-mce.element.ts
@@ -6,6 +6,7 @@ import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/extensi
 
 import '../../components/input-tiny-mce/input-tiny-mce.element.js';
 import {
+	UmbBlockRteEntriesContext,
 	type UmbBlockRteLayoutModel,
 	UmbBlockRteManagerContext,
 	type UmbBlockRteTypeModel,
@@ -83,6 +84,7 @@ export class UmbPropertyEditorUITinyMceElement extends UmbLitElement implements 
 	private _latestMarkup = ''; // The latest value gotten from the TinyMCE editor.
 
 	#managerContext = new UmbBlockRteManagerContext(this);
+	#entriesContext = new UmbBlockRteEntriesContext(this);
 
 	constructor() {
 		super();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds the `UmbBlockRteEntriesContext` to the tinymce property editor UI so that the blocks plugin can calculate the path to the block picker modal. This is modeled after the block-list itself and is the missing piece to make the block picker work again following a regression between 14.1 and 14.2.

Fixes https://github.com/umbraco/Umbraco-CMS/issues/17003

Fixes https://github.com/umbraco/Umbraco-CMS/issues/16949

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How to test?

1. Add an RTE to a page
2. Add blocks to the RTE and enable the "Insert blocks" button
3. Verify that the block picker opens when you click the button
4. Verify that a block is inserted into the editor (click the view source button) of the rich text editor
