### PR TITLE
Fix null ref exception in Context Data

### DIFF
--- a/src/libs/context-api/debug/context-data.function.ts
+++ b/src/libs/context-api/debug/context-data.function.ts
@@ -48,7 +48,7 @@ function contextItemData(contextInstance: any): UmbDebugContextItemData {
 
 					case 'object':
 						// Check if the object is an observable (by checking if it has a subscribe method/function)
-						const isSubscribeLike = 'subscribe' in value && typeof value['subscribe'] === 'function';
+						const isSubscribeLike = value && 'subscribe' in value && typeof value['subscribe'] === 'function';
 						const isWebComponent = value instanceof HTMLElement;
 
 						let valueToDisplay = 'Complex Object';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes a simple nullcheck when the code determines a certain item in an array is an object but the value of the reference is null

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

I was testing out the debugElement inside a user profile app and noticed it wasn't showing the console error directed me to the line and showed the missing truthy check.

The routerContext router value was null and thus threw and error when the system tried to figure out if type was an observable