### PR TITLE
V15: Move menu conditions

### DIFF
--- a/src/packages/core/collection/action/collection-action-button.element.ts
+++ b/src/packages/core/collection/action/collection-action-button.element.ts
@@ -4,11 +4,11 @@ import { html, customElement, property, state, ifDefined } from '@umbraco-cms/ba
 import type { UUIButtonState } from '@umbraco-cms/backoffice/external/uui';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
-import type { UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 import type { ManifestCollectionAction } from '@umbraco-cms/backoffice/collection';
 import { createExtensionApi } from '@umbraco-cms/backoffice/extension-api';
 
-const manifest: UmbBackofficeManifestKind = {
+const manifest: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.CollectionAction.Button',
 	matchKind: 'button',

--- a/src/packages/core/collection/default/collection-default.element.ts
+++ b/src/packages/core/collection/default/collection-default.element.ts
@@ -4,10 +4,10 @@ import { css, html, customElement, state } from '@umbraco-cms/backoffice/externa
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
-import type { UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 import type { UmbRoute } from '@umbraco-cms/backoffice/router';
 
-const manifest: UmbBackofficeManifestKind = {
+const manifest: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.Collection.Default',
 	matchKind: 'default',

--- a/src/packages/core/components/header-app/header-app-button.element.ts
+++ b/src/packages/core/components/header-app/header-app-button.element.ts
@@ -1,14 +1,11 @@
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import type { CSSResultGroup } from '@umbraco-cms/backoffice/external/lit';
 import { css, html, customElement, ifDefined } from '@umbraco-cms/backoffice/external/lit';
-import type {
-	ManifestHeaderAppButtonKind,
-	UmbBackofficeManifestKind,
-} from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestHeaderAppButtonKind, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 
-const manifest: UmbBackofficeManifestKind = {
+const manifest: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.Button',
 	matchKind: 'button',

--- a/src/packages/core/content-type/workspace/views/design/manifest.ts
+++ b/src/packages/core/content-type/workspace/views/design/manifest.ts
@@ -1,6 +1,6 @@
-import type { UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const contentTypeDesignEditorManifest: UmbBackofficeManifestKind = {
+export const contentTypeDesignEditorManifest: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.WorkspaceView.ContentTypeDesignEditor',
 	matchKind: 'contentTypeDesignEditor',

--- a/src/packages/core/content/workspace/views/edit/manifests.ts
+++ b/src/packages/core/content/workspace/views/edit/manifests.ts
@@ -1,7 +1,7 @@
 import { manifests as conditionsManifests } from './conditions/manifests.js';
-import type { UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-const contentEditorManifest: UmbBackofficeManifestKind = {
+const contentEditorManifest: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.WorkspaceView.ContentEditor',
 	matchKind: 'contentEditor',

--- a/src/packages/core/entity-action/common/delete/delete.action.kind.ts
+++ b/src/packages/core/entity-action/common/delete/delete.action.kind.ts
@@ -1,7 +1,7 @@
 import { UMB_ENTITY_ACTION_DEFAULT_KIND_MANIFEST } from '../../default/default.action.kind.js';
-import type { UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: UmbBackofficeManifestKind = {
+export const manifest: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.EntityAction.Delete',
 	matchKind: 'delete',

--- a/src/packages/core/entity-action/common/duplicate/duplicate.action.kind.ts
+++ b/src/packages/core/entity-action/common/duplicate/duplicate.action.kind.ts
@@ -1,7 +1,7 @@
 import { UMB_ENTITY_ACTION_DEFAULT_KIND_MANIFEST } from '../../default/default.action.kind.js';
-import type { UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: UmbBackofficeManifestKind = {
+export const manifest: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.EntityAction.Duplicate',
 	matchKind: 'duplicate',

--- a/src/packages/core/entity-action/common/duplicate/manifests.ts
+++ b/src/packages/core/entity-action/common/duplicate/manifests.ts
@@ -1,4 +1,4 @@
 import { manifest as duplicateKindManifest } from './duplicate.action.kind.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [duplicateKindManifest];
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [duplicateKindManifest];

--- a/src/packages/core/entity-action/default/default.action.kind.ts
+++ b/src/packages/core/entity-action/default/default.action.kind.ts
@@ -1,6 +1,6 @@
-import type { UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const UMB_ENTITY_ACTION_DEFAULT_KIND_MANIFEST: UmbBackofficeManifestKind = {
+export const UMB_ENTITY_ACTION_DEFAULT_KIND_MANIFEST: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.EntityAction.Default',
 	matchKind: 'default',

--- a/src/packages/core/entity-action/default/manifests.ts
+++ b/src/packages/core/entity-action/default/manifests.ts
@@ -1,4 +1,4 @@
 import { manifest as defaultKindManifest } from './default.action.kind.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [defaultKindManifest];
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [defaultKindManifest];

--- a/src/packages/core/entity-action/manifests.ts
+++ b/src/packages/core/entity-action/manifests.ts
@@ -1,9 +1,9 @@
 import { manifests as defaultEntityActionManifests } from './default/manifests.js';
 import { manifests as deleteEntityActionManifests } from './common/delete/manifests.js';
 import { manifests as duplicateEntityActionManifests } from './common/duplicate/manifests.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	...defaultEntityActionManifests,
 	...deleteEntityActionManifests,
 	...duplicateEntityActionManifests,

--- a/src/packages/core/entity-bulk-action/common/duplicate-to/duplicate-to.action.kind.ts
+++ b/src/packages/core/entity-bulk-action/common/duplicate-to/duplicate-to.action.kind.ts
@@ -1,7 +1,7 @@
 import { UMB_ENTITY_BULK_ACTION_DEFAULT_KIND_MANIFEST } from '../../default/default.action.kind.js';
-import type { UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: UmbBackofficeManifestKind = {
+export const manifest: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.EntityBulkAction.DuplicateTo',
 	matchKind: 'duplicateTo',

--- a/src/packages/core/entity-bulk-action/common/duplicate-to/manifests.ts
+++ b/src/packages/core/entity-bulk-action/common/duplicate-to/manifests.ts
@@ -1,4 +1,4 @@
 import { manifest as duplicateToKindManifest } from './duplicate-to.action.kind.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [duplicateToKindManifest];
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [duplicateToKindManifest];

--- a/src/packages/core/entity-bulk-action/common/move-to/manifests.ts
+++ b/src/packages/core/entity-bulk-action/common/move-to/manifests.ts
@@ -1,4 +1,4 @@
 import { manifest as moveToKindManifest } from './move-to.action.kind.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [moveToKindManifest];
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [moveToKindManifest];

--- a/src/packages/core/entity-bulk-action/common/move-to/move-to.action.kind.ts
+++ b/src/packages/core/entity-bulk-action/common/move-to/move-to.action.kind.ts
@@ -1,7 +1,7 @@
 import { UMB_ENTITY_BULK_ACTION_DEFAULT_KIND_MANIFEST } from '../../default/default.action.kind.js';
-import type { UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: UmbBackofficeManifestKind = {
+export const manifest: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.EntityBulkAction.MoveTo',
 	matchKind: 'moveTo',

--- a/src/packages/core/entity-bulk-action/common/trash/manifests.ts
+++ b/src/packages/core/entity-bulk-action/common/trash/manifests.ts
@@ -1,4 +1,4 @@
 import { manifest as trashKindManifest } from './trash.action.kind.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [trashKindManifest];
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [trashKindManifest];

--- a/src/packages/core/entity-bulk-action/common/trash/trash.action.kind.ts
+++ b/src/packages/core/entity-bulk-action/common/trash/trash.action.kind.ts
@@ -1,7 +1,7 @@
 import { UMB_ENTITY_BULK_ACTION_DEFAULT_KIND_MANIFEST } from '../../default/default.action.kind.js';
-import type { UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: UmbBackofficeManifestKind = {
+export const manifest: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.EntityBulkAction.Trash',
 	matchKind: 'trash',

--- a/src/packages/core/entity-bulk-action/default/default.action.kind.ts
+++ b/src/packages/core/entity-bulk-action/default/default.action.kind.ts
@@ -1,6 +1,6 @@
-import type { UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const UMB_ENTITY_BULK_ACTION_DEFAULT_KIND_MANIFEST: UmbBackofficeManifestKind = {
+export const UMB_ENTITY_BULK_ACTION_DEFAULT_KIND_MANIFEST: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.EntityBulkAction.Default',
 	matchKind: 'default',

--- a/src/packages/core/entity-bulk-action/default/manifests.ts
+++ b/src/packages/core/entity-bulk-action/default/manifests.ts
@@ -1,4 +1,4 @@
 import { manifest as defaultKindManifest } from './default.action.kind.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [defaultKindManifest];
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [defaultKindManifest];

--- a/src/packages/core/entity-bulk-action/manifests.ts
+++ b/src/packages/core/entity-bulk-action/manifests.ts
@@ -2,9 +2,9 @@ import { manifests as defaultEntityBulkActionManifests } from './default/manifes
 import { manifests as duplicateEntityBulkActionManifests } from './common/duplicate-to/manifests.js';
 import { manifests as moveToEntityBulkActionManifests } from './common/move-to/manifests.js';
 import { manifests as trashEntityBulkActionManifests } from './common/trash/manifests.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	...defaultEntityBulkActionManifests,
 	...duplicateEntityBulkActionManifests,
 	...moveToEntityBulkActionManifests,

--- a/src/packages/core/extension-registry/conditions/manifests.ts
+++ b/src/packages/core/extension-registry/conditions/manifests.ts
@@ -1,11 +1,9 @@
 import type { ManifestTypes } from '../models/index.js';
-import { manifest as menuAliasConditionManifest } from './menu-alias.condition.js';
 import { manifest as multipleAppLanguagesConditionManifest } from './multiple-app-languages.condition.js';
 import { manifest as sectionAliasConditionManifest } from './section-alias.condition.js';
 import { manifest as switchConditionManifest } from './switch.condition.js';
 
 export const manifests: Array<ManifestTypes> = [
-	menuAliasConditionManifest,
 	multipleAppLanguagesConditionManifest,
 	sectionAliasConditionManifest,
 	switchConditionManifest,

--- a/src/packages/core/extension-registry/registry.ts
+++ b/src/packages/core/extension-registry/registry.ts
@@ -1,7 +1,12 @@
 import type { ManifestKind } from '@umbraco-cms/backoffice/extension-api';
 import { UmbExtensionRegistry } from '@umbraco-cms/backoffice/extension-api';
 
-export type UmbBackofficeManifestKind = ManifestKind<UmbExtensionManifest>;
+export type UmbExtensionManifestKind = ManifestKind<UmbExtensionManifest>;
 export type UmbBackofficeExtensionRegistry = UmbExtensionRegistry<UmbExtensionManifest>;
 
 export const umbExtensionsRegistry = new UmbExtensionRegistry<UmbExtensionManifest>() as UmbBackofficeExtensionRegistry;
+
+/**
+ * @deprecated Use `UmbExtensionManifestKind` instead.
+ */
+export type UmbBackofficeManifestKind = ManifestKind<UmbExtensionManifest>;

--- a/src/packages/core/localization/components/ui-culture-input/ui-culture-input.element.ts
+++ b/src/packages/core/localization/components/ui-culture-input/ui-culture-input.element.ts
@@ -65,16 +65,16 @@ export class UmbUiCultureInputElement extends UUIFormControlMixin(UmbLitElement,
 	}
 
 	override render() {
-		return html` 
-		<uui-select
+		return html`
+			<uui-select
 				style="margin-top: var(--uui-size-space-1)"
 				@change=${this.#onCustomValidationChange}
-				.options=${this._options.map(e => ({
+				.options=${this._options.map((e) => ({
 					name: e.name,
 					value: e.value,
-					selected: e.value == this.value
+					selected: e.value == this.value,
 				}))}></uui-select>
-			`;
+		`;
 	}
 
 	static override styles = [

--- a/src/packages/core/manifests.ts
+++ b/src/packages/core/manifests.ts
@@ -22,9 +22,9 @@ import { manifests as themeManifests } from './themes/manifests.js';
 import { manifests as treeManifests } from './tree/manifests.js';
 import { manifests as workspaceManifests } from './workspace/manifests.js';
 
-import type { ManifestTypes, UmbBackofficeManifestKind } from './extension-registry/index.js';
+import type { ManifestTypes, UmbExtensionManifestKind } from './extension-registry/index.js';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	...authManifests,
 	...collectionManifests,
 	...contentManifests,

--- a/src/packages/core/menu/components/menu-item/link/manifests.ts
+++ b/src/packages/core/menu/components/menu-item/link/manifests.ts
@@ -1,6 +1,4 @@
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
-
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<UmbExtensionManifest> = [
 	{
 		type: 'kind',
 		alias: 'Umb.Kind.MenuItem.Link',

--- a/src/packages/core/menu/components/menu-item/link/manifests.ts
+++ b/src/packages/core/menu/components/menu-item/link/manifests.ts
@@ -1,4 +1,6 @@
-export const manifests: Array<UmbExtensionManifest> = [
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+
+export const manifests: Array<UmbExtensionManifest | UmbExtensionManifestKind> = [
 	{
 		type: 'kind',
 		alias: 'Umb.Kind.MenuItem.Link',

--- a/src/packages/core/menu/components/menu-item/manifests.ts
+++ b/src/packages/core/menu/components/menu-item/manifests.ts
@@ -1,4 +1,3 @@
 import { manifests as linkManifests } from './link/manifests.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [...linkManifests];
+export const manifests: Array<UmbExtensionManifest> = [...linkManifests];

--- a/src/packages/core/menu/components/menu-item/manifests.ts
+++ b/src/packages/core/menu/components/menu-item/manifests.ts
@@ -1,3 +1,4 @@
 import { manifests as linkManifests } from './link/manifests.js';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<UmbExtensionManifest> = [...linkManifests];
+export const manifests: Array<UmbExtensionManifest | UmbExtensionManifestKind> = [...linkManifests];

--- a/src/packages/core/menu/conditions/menu-alias.condition.ts
+++ b/src/packages/core/menu/conditions/menu-alias.condition.ts
@@ -1,16 +1,12 @@
-import { UMB_MENU_CONTEXT } from '../../menu/components/menu/menu.context.js';
-import { UmbConditionBase } from './condition-base.controller.js';
+import { UMB_MENU_CONTEXT } from '../components/menu/menu.context.js';
+import { UmbConditionBase } from '../../extension-registry/conditions/condition-base.controller.js';
+import type { MenuAliasConditionConfig } from './types.js';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import type {
 	ManifestCondition,
-	UmbConditionConfigBase,
 	UmbConditionControllerArguments,
 	UmbExtensionCondition,
 } from '@umbraco-cms/backoffice/extension-api';
-
-export type MenuAliasConditionConfig = UmbConditionConfigBase & {
-	match: string;
-};
 
 export class UmbMenuAliasCondition extends UmbConditionBase<MenuAliasConditionConfig> implements UmbExtensionCondition {
 	constructor(host: UmbControllerHost, args: UmbConditionControllerArguments<MenuAliasConditionConfig>) {

--- a/src/packages/core/menu/conditions/types.ts
+++ b/src/packages/core/menu/conditions/types.ts
@@ -1,0 +1,5 @@
+import type { UmbConditionConfigBase } from '@umbraco-cms/backoffice/extension-api';
+
+export type MenuAliasConditionConfig = UmbConditionConfigBase & {
+	match: string;
+};

--- a/src/packages/core/menu/manifests.ts
+++ b/src/packages/core/menu/manifests.ts
@@ -1,4 +1,4 @@
 import { manifests as menuItemManifests } from './components/menu-item/manifests.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import { manifest as menuAliasConditionManifest } from './conditions/menu-alias.condition.js';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [...menuItemManifests];
+export const manifests: Array<UmbExtensionManifest> = [...menuItemManifests, menuAliasConditionManifest];

--- a/src/packages/core/menu/manifests.ts
+++ b/src/packages/core/menu/manifests.ts
@@ -1,4 +1,8 @@
 import { manifests as menuItemManifests } from './components/menu-item/manifests.js';
 import { manifest as menuAliasConditionManifest } from './conditions/menu-alias.condition.js';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<UmbExtensionManifest> = [...menuItemManifests, menuAliasConditionManifest];
+export const manifests: Array<UmbExtensionManifest | UmbExtensionManifestKind> = [
+	...menuItemManifests,
+	menuAliasConditionManifest,
+];

--- a/src/packages/core/menu/types.ts
+++ b/src/packages/core/menu/types.ts
@@ -1,4 +1,5 @@
 import type { UmbEntityModel } from '@umbraco-cms/backoffice/entity';
+export type * from './conditions/types.js';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface UmbStructureItemModelBase extends UmbEntityModel {}

--- a/src/packages/core/picker/manifests.ts
+++ b/src/packages/core/picker/manifests.ts
@@ -1,4 +1,4 @@
 import { manifests as searchManifests } from './search/manifests.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [...searchManifests];
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [...searchManifests];

--- a/src/packages/core/picker/search/manifests.ts
+++ b/src/packages/core/picker/search/manifests.ts
@@ -1,4 +1,4 @@
 import { manifests as resultItemManifests } from './result-item/manifests.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [...resultItemManifests];
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [...resultItemManifests];

--- a/src/packages/core/picker/search/result-item/default/manifests.ts
+++ b/src/packages/core/picker/search/result-item/default/manifests.ts
@@ -1,6 +1,6 @@
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	{
 		type: 'kind',
 		alias: 'Umb.Kind.PickerSearchResultItem.Default',

--- a/src/packages/core/picker/search/result-item/manifests.ts
+++ b/src/packages/core/picker/search/result-item/manifests.ts
@@ -1,4 +1,4 @@
 import { manifests as defaultManifests } from './default/manifests.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [...defaultManifests];
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [...defaultManifests];

--- a/src/packages/core/property-action/components/property-action/default/default.action.kind.ts
+++ b/src/packages/core/property-action/components/property-action/default/default.action.kind.ts
@@ -1,6 +1,6 @@
-import type { UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: UmbBackofficeManifestKind = {
+export const manifest: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.PropertyAction.Default',
 	matchKind: 'default',

--- a/src/packages/core/property-action/components/property-action/default/manifests.ts
+++ b/src/packages/core/property-action/components/property-action/default/manifests.ts
@@ -1,4 +1,4 @@
 import { manifest as defaultKindManifest } from './default.action.kind.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [defaultKindManifest];
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [defaultKindManifest];

--- a/src/packages/core/property-action/components/property-action/manifests.ts
+++ b/src/packages/core/property-action/components/property-action/manifests.ts
@@ -1,4 +1,4 @@
 import { manifests as defaultWorkspaceActionManifests } from './default/manifests.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [...defaultWorkspaceActionManifests];
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [...defaultWorkspaceActionManifests];

--- a/src/packages/core/property-action/manifests.ts
+++ b/src/packages/core/property-action/manifests.ts
@@ -2,7 +2,7 @@ import { manifests as defaultManifests } from './components/property-action/mani
 import type {
 	ManifestPropertyActions,
 	ManifestTypes,
-	UmbBackofficeManifestKind,
+	UmbExtensionManifestKind,
 } from '@umbraco-cms/backoffice/extension-registry';
 
 import { UMB_WRITABLE_PROPERTY_CONDITION_ALIAS } from '@umbraco-cms/backoffice/property';
@@ -44,7 +44,7 @@ export const propertyActionManifests: Array<ManifestPropertyActions> = [
 	},
 ];
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	...defaultManifests,
 	...propertyActionManifests,
 ];

--- a/src/packages/core/recycle-bin/entity-action/empty-recycle-bin/empty-recycle-bin.action.kind.ts
+++ b/src/packages/core/recycle-bin/entity-action/empty-recycle-bin/empty-recycle-bin.action.kind.ts
@@ -1,7 +1,7 @@
 import { UMB_ENTITY_ACTION_DEFAULT_KIND_MANIFEST } from '../../../entity-action/default/default.action.kind.js';
-import type { UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: UmbBackofficeManifestKind = {
+export const manifest: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.EntityAction.RecycleBin.Empty',
 	matchKind: 'emptyRecycleBin',

--- a/src/packages/core/recycle-bin/entity-action/empty-recycle-bin/manifests.ts
+++ b/src/packages/core/recycle-bin/entity-action/empty-recycle-bin/manifests.ts
@@ -1,4 +1,4 @@
 import { manifest as emptyRecycleBinKindManifest } from './empty-recycle-bin.action.kind.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [emptyRecycleBinKindManifest];
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [emptyRecycleBinKindManifest];

--- a/src/packages/core/recycle-bin/entity-action/restore-from-recycle-bin/manifests.ts
+++ b/src/packages/core/recycle-bin/entity-action/restore-from-recycle-bin/manifests.ts
@@ -1,7 +1,7 @@
 import { manifest as kindManifest } from './restore-from-recycle-bin.action.kind.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	kindManifest,
 	{
 		type: 'modal',

--- a/src/packages/core/recycle-bin/entity-action/restore-from-recycle-bin/restore-from-recycle-bin.action.kind.ts
+++ b/src/packages/core/recycle-bin/entity-action/restore-from-recycle-bin/restore-from-recycle-bin.action.kind.ts
@@ -1,7 +1,7 @@
 import { UMB_ENTITY_ACTION_DEFAULT_KIND_MANIFEST } from '../../../entity-action/default/default.action.kind.js';
-import type { UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: UmbBackofficeManifestKind = {
+export const manifest: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.EntityAction.RecycleBin.Restore',
 	matchKind: 'restoreFromRecycleBin',

--- a/src/packages/core/recycle-bin/entity-action/trash/manifests.ts
+++ b/src/packages/core/recycle-bin/entity-action/trash/manifests.ts
@@ -1,4 +1,4 @@
 import { manifest as trashKindManifest } from './trash.action.kind.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [trashKindManifest];
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [trashKindManifest];

--- a/src/packages/core/recycle-bin/entity-action/trash/trash.action.kind.ts
+++ b/src/packages/core/recycle-bin/entity-action/trash/trash.action.kind.ts
@@ -1,7 +1,7 @@
 import { UMB_ENTITY_ACTION_DEFAULT_KIND_MANIFEST } from '../../../entity-action/default/default.action.kind.js';
-import type { UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: UmbBackofficeManifestKind = {
+export const manifest: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.EntityAction.Trash',
 	matchKind: 'trash',

--- a/src/packages/core/recycle-bin/manifests.ts
+++ b/src/packages/core/recycle-bin/manifests.ts
@@ -2,9 +2,9 @@ import { manifests as trashEntityActionManifests } from './entity-action/trash/m
 import { manifests as restoreFromRecycleBinEntityActionManifests } from './entity-action/restore-from-recycle-bin/manifests.js';
 import { manifests as emptyRecycleBinEntityActionManifests } from './entity-action/empty-recycle-bin/manifests.js';
 import { manifests as conditionManifests } from './conditions/manifests.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	...conditionManifests,
 	...emptyRecycleBinEntityActionManifests,
 	...restoreFromRecycleBinEntityActionManifests,

--- a/src/packages/core/section/section-main-views/section-main-views.element.ts
+++ b/src/packages/core/section/section-main-views/section-main-views.element.ts
@@ -12,7 +12,6 @@ import { UmbExtensionsManifestInitializer, createExtensionElement } from '@umbra
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { pathFolderName } from '@umbraco-cms/backoffice/utils';
 
-// TODO: this might need a new name, since it's both views and dashboards
 @customElement('umb-section-main-views')
 export class UmbSectionMainViewElement extends UmbLitElement {
 	@property({ type: String, attribute: 'section-alias' })
@@ -48,12 +47,12 @@ export class UmbSectionMainViewElement extends UmbLitElement {
 	}
 
 	#constructDashboardPath(manifest: ManifestDashboard) {
-		const dashboardName = manifest.meta.label ?? manifest.name;
+		const dashboardName = manifest.meta.label ?? manifest.name ?? manifest.alias;
 		return 'dashboard/' + (manifest.meta.pathname ? manifest.meta.pathname : pathFolderName(dashboardName));
 	}
 
 	#constructViewPath(manifest: ManifestSectionView) {
-		const viewName = manifest.meta.label ?? manifest.name;
+		const viewName = manifest.meta.label ?? manifest.name ?? manifest.alias;
 		return 'view/' + (manifest.meta.pathname ? manifest.meta.pathname : pathFolderName(viewName));
 	}
 
@@ -119,7 +118,9 @@ export class UmbSectionMainViewElement extends UmbLitElement {
 							return html`
 								<uui-tab
 									href="${this._routerPath}/${dashboardPath}"
-									label="${dashboard.meta.label ? this.localize.string(dashboard.meta.label) : dashboard.name}"
+									label="${dashboard.meta.label
+										? this.localize.string(dashboard.meta.label)
+										: (dashboard.name ?? dashboard.alias)}"
 									?active="${this._activePath === dashboardPath}"></uui-tab>
 							`;
 						})}
@@ -134,7 +135,7 @@ export class UmbSectionMainViewElement extends UmbLitElement {
 			? html`
 					<uui-tab-group slot="navigation" id="views">
 						${this._views.map((view) => {
-							const viewName = view.meta.label ? this.localize.string(view.meta.label) : view.name;
+							const viewName = view.meta.label ? this.localize.string(view.meta.label) : (view.name ?? view.alias);
 							const viewPath = this.#constructViewPath(view);
 							return html`
 								<uui-tab

--- a/src/packages/core/section/section-sidebar-menu-with-entity-actions/section-sidebar-menu-with-entity-actions.element.ts
+++ b/src/packages/core/section/section-sidebar-menu-with-entity-actions/section-sidebar-menu-with-entity-actions.element.ts
@@ -2,11 +2,11 @@ import { UmbSectionSidebarMenuElement } from '../section-sidebar-menu/section-si
 import { css, html, customElement } from '@umbraco-cms/backoffice/external/lit';
 import type {
 	ManifestSectionSidebarAppMenuWithEntityActionsKind,
-	UmbBackofficeManifestKind,
+	UmbExtensionManifestKind,
 } from '@umbraco-cms/backoffice/extension-registry';
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 
-const manifestWithEntityActions: UmbBackofficeManifestKind = {
+const manifestWithEntityActions: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.SectionSidebarAppMenuWithEntityActions',
 	matchKind: 'menuWithEntityActions',

--- a/src/packages/core/section/section-sidebar-menu/section-sidebar-menu.element.ts
+++ b/src/packages/core/section/section-sidebar-menu/section-sidebar-menu.element.ts
@@ -4,13 +4,13 @@ import type {
 	ManifestMenu,
 	ManifestSectionSidebarAppBaseMenu,
 	ManifestSectionSidebarAppMenuKind,
-	UmbBackofficeManifestKind,
+	UmbExtensionManifestKind,
 } from '@umbraco-cms/backoffice/extension-registry';
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 
 // TODO: Move to separate file:
-const manifest: UmbBackofficeManifestKind = {
+const manifest: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.SectionSidebarAppMenu',
 	matchKind: 'menu',

--- a/src/packages/core/server-file-system/manifests.ts
+++ b/src/packages/core/server-file-system/manifests.ts
@@ -1,4 +1,4 @@
 import { manifests as renameEntityActionManifests } from '../server-file-system/rename/manifests.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [...renameEntityActionManifests];
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [...renameEntityActionManifests];

--- a/src/packages/core/server-file-system/rename/manifests.ts
+++ b/src/packages/core/server-file-system/rename/manifests.ts
@@ -1,8 +1,5 @@
 import { manifests as renameModalManifests } from './modal/manifests.js';
 import { manifest as renameKindManifest } from './rename-server-file.action.kind.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
-	...renameModalManifests,
-	renameKindManifest,
-];
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [...renameModalManifests, renameKindManifest];

--- a/src/packages/core/server-file-system/rename/rename-server-file.action.kind.ts
+++ b/src/packages/core/server-file-system/rename/rename-server-file.action.kind.ts
@@ -1,7 +1,7 @@
 import { UMB_ENTITY_ACTION_DEFAULT_KIND_MANIFEST } from '../../entity-action/default/default.action.kind.js';
-import type { UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: UmbBackofficeManifestKind = {
+export const manifest: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.EntityAction.ServerFile.Rename',
 	matchKind: 'renameServerFile',

--- a/src/packages/core/tree/default/manifests.ts
+++ b/src/packages/core/tree/default/manifests.ts
@@ -1,6 +1,6 @@
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-const defaultTreeKind: UmbBackofficeManifestKind = {
+const defaultTreeKind: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.Tree.Default',
 	matchKind: 'default',
@@ -12,4 +12,4 @@ const defaultTreeKind: UmbBackofficeManifestKind = {
 	},
 };
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [defaultTreeKind];
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [defaultTreeKind];

--- a/src/packages/core/tree/entity-actions/duplicate-to/duplicate-to.action.kind.ts
+++ b/src/packages/core/tree/entity-actions/duplicate-to/duplicate-to.action.kind.ts
@@ -1,7 +1,7 @@
 import { UMB_ENTITY_ACTION_DEFAULT_KIND_MANIFEST } from '@umbraco-cms/backoffice/entity-action';
-import type { UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: UmbBackofficeManifestKind = {
+export const manifest: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.EntityAction.DuplicateTo',
 	matchKind: 'duplicateTo',

--- a/src/packages/core/tree/entity-actions/move/move-to.action.kind.ts
+++ b/src/packages/core/tree/entity-actions/move/move-to.action.kind.ts
@@ -1,7 +1,7 @@
 import { UMB_ENTITY_ACTION_DEFAULT_KIND_MANIFEST } from '@umbraco-cms/backoffice/entity-action';
-import type { UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: UmbBackofficeManifestKind = {
+export const manifest: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.EntityAction.MoveTo',
 	matchKind: 'moveTo',

--- a/src/packages/core/tree/entity-actions/reload-tree-item-children/manifests.ts
+++ b/src/packages/core/tree/entity-actions/reload-tree-item-children/manifests.ts
@@ -1,4 +1,4 @@
 import { manifest as reloadTreeItemChildrenKind } from './reload-tree-item-children.action.kind.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [reloadTreeItemChildrenKind];
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [reloadTreeItemChildrenKind];

--- a/src/packages/core/tree/entity-actions/reload-tree-item-children/reload-tree-item-children.action.kind.ts
+++ b/src/packages/core/tree/entity-actions/reload-tree-item-children/reload-tree-item-children.action.kind.ts
@@ -1,7 +1,7 @@
-import type { UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 import { UMB_ENTITY_ACTION_DEFAULT_KIND_MANIFEST } from '@umbraco-cms/backoffice/entity-action';
 
-export const manifest: UmbBackofficeManifestKind = {
+export const manifest: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.EntityAction.Tree.ReloadChildrenOf',
 	matchKind: 'reloadTreeItemChildren',

--- a/src/packages/core/tree/entity-actions/sort-children-of/sort-children-of.action.kind.ts
+++ b/src/packages/core/tree/entity-actions/sort-children-of/sort-children-of.action.kind.ts
@@ -1,7 +1,7 @@
 import { UMB_ENTITY_ACTION_DEFAULT_KIND_MANIFEST } from '@umbraco-cms/backoffice/entity-action';
-import type { UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: UmbBackofficeManifestKind = {
+export const manifest: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.EntityAction.SortChildrenOf',
 	matchKind: 'sortChildrenOf',

--- a/src/packages/core/tree/folder/entity-action/create-folder/create-folder.action.kind.ts
+++ b/src/packages/core/tree/folder/entity-action/create-folder/create-folder.action.kind.ts
@@ -1,8 +1,8 @@
 import { UmbCreateFolderEntityAction } from './create-folder.action.js';
-import type { UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 import { UMB_ENTITY_ACTION_DEFAULT_KIND_MANIFEST } from '@umbraco-cms/backoffice/entity-action';
 
-export const manifest: UmbBackofficeManifestKind = {
+export const manifest: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.EntityAction.Folder.Create',
 	matchKind: 'folderCreate',

--- a/src/packages/core/tree/folder/entity-action/delete-folder/delete-folder.action.kind.ts
+++ b/src/packages/core/tree/folder/entity-action/delete-folder/delete-folder.action.kind.ts
@@ -1,8 +1,8 @@
 import { UmbDeleteFolderEntityAction } from './delete-folder.action.js';
-import type { UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 import { UMB_ENTITY_ACTION_DEFAULT_KIND_MANIFEST } from '@umbraco-cms/backoffice/entity-action';
 
-export const manifest: UmbBackofficeManifestKind = {
+export const manifest: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.EntityAction.Folder.Delete',
 	matchKind: 'folderDelete',

--- a/src/packages/core/tree/folder/entity-action/manifests.ts
+++ b/src/packages/core/tree/folder/entity-action/manifests.ts
@@ -1,9 +1,9 @@
 import { manifest as createKindManifest } from './create-folder/create-folder.action.kind.js';
 import { manifest as deleteKindManifest } from './delete-folder/delete-folder.action.kind.js';
 import { manifest as updateKindManifest } from './update-folder/update-folder.action.kind.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	createKindManifest,
 	deleteKindManifest,
 	updateKindManifest,

--- a/src/packages/core/tree/folder/entity-action/update-folder/update-folder.action.kind.ts
+++ b/src/packages/core/tree/folder/entity-action/update-folder/update-folder.action.kind.ts
@@ -1,8 +1,8 @@
 import { UmbUpdateFolderEntityAction } from './update-folder.action.js';
-import type { UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 import { UMB_ENTITY_ACTION_DEFAULT_KIND_MANIFEST } from '@umbraco-cms/backoffice/entity-action';
 
-export const manifest: UmbBackofficeManifestKind = {
+export const manifest: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.EntityAction.Folder.Update',
 	matchKind: 'folderUpdate',

--- a/src/packages/core/tree/folder/manifests.ts
+++ b/src/packages/core/tree/folder/manifests.ts
@@ -1,8 +1,5 @@
 import { manifests as modalManifests } from './modal/manifests.js';
 import { manifests as entityActionManifests } from './entity-action/manifests.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
-	...modalManifests,
-	...entityActionManifests,
-];
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [...modalManifests, ...entityActionManifests];

--- a/src/packages/core/tree/manifests.ts
+++ b/src/packages/core/tree/manifests.ts
@@ -3,9 +3,9 @@ import { manifests as defaultTreeItemManifests } from './tree-item/tree-item-def
 import { manifests as defaultTreeManifests } from './default/manifests.js';
 import { manifests as treePickerManifests } from './tree-picker-modal/manifests.js';
 import { manifests as entityActionManifests } from './entity-actions/manifests.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	...defaultTreeItemManifests,
 	...defaultTreeManifests,
 	...entityActionManifests,

--- a/src/packages/core/tree/tree-item/tree-item-default/manifests.ts
+++ b/src/packages/core/tree/tree-item/tree-item-default/manifests.ts
@@ -1,6 +1,6 @@
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-const kind: UmbBackofficeManifestKind = {
+const kind: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.TreeItem.Default',
 	matchKind: 'default',
@@ -12,4 +12,4 @@ const kind: UmbBackofficeManifestKind = {
 	},
 };
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [kind];
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [kind];

--- a/src/packages/core/tree/tree-menu-item-default/tree-menu-item-default.element.ts
+++ b/src/packages/core/tree/tree-menu-item-default/tree-menu-item-default.element.ts
@@ -2,13 +2,13 @@ import { html, nothing, customElement, property } from '@umbraco-cms/backoffice/
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type {
 	ManifestMenuItemTreeKind,
-	UmbBackofficeManifestKind,
+	UmbExtensionManifestKind,
 	UmbMenuItemElement,
 } from '@umbraco-cms/backoffice/extension-registry';
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 
 // TODO: Move to separate file:
-const manifest: UmbBackofficeManifestKind = {
+const manifest: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.Tree',
 	matchKind: 'tree',

--- a/src/packages/core/workspace/components/manifests.ts
+++ b/src/packages/core/workspace/components/manifests.ts
@@ -2,9 +2,9 @@ import { manifests as workspaceActionManifests } from './workspace-action/manife
 import { manifests as workspaceActionMenuItemManifests } from './workspace-action-menu-item/manifests.js';
 import { manifests as workspaceBreadcrumbManifests } from './workspace-breadcrumb/manifests.js';
 import { manifests as workspaceViewManifests } from './workspace-collection/manifests.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	...workspaceActionManifests,
 	...workspaceActionMenuItemManifests,
 	...workspaceBreadcrumbManifests,

--- a/src/packages/core/workspace/components/workspace-action-menu-item/default/default.action.kind.ts
+++ b/src/packages/core/workspace/components/workspace-action-menu-item/default/default.action.kind.ts
@@ -1,6 +1,6 @@
-import type { UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: UmbBackofficeManifestKind = {
+export const manifest: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.WorkspaceActionMenuItem.Default',
 	matchKind: 'default',

--- a/src/packages/core/workspace/components/workspace-action-menu-item/default/manifests.ts
+++ b/src/packages/core/workspace/components/workspace-action-menu-item/default/manifests.ts
@@ -1,4 +1,4 @@
 import { manifest as defaultKindManifest } from './default.action.kind.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [defaultKindManifest];
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [defaultKindManifest];

--- a/src/packages/core/workspace/components/workspace-action-menu-item/manifests.ts
+++ b/src/packages/core/workspace/components/workspace-action-menu-item/manifests.ts
@@ -1,4 +1,4 @@
 import { manifests as defaultWorkspaceActionManifests } from './default/manifests.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [...defaultWorkspaceActionManifests];
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [...defaultWorkspaceActionManifests];

--- a/src/packages/core/workspace/components/workspace-action/default/default.action.kind.ts
+++ b/src/packages/core/workspace/components/workspace-action/default/default.action.kind.ts
@@ -1,6 +1,6 @@
-import type { UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: UmbBackofficeManifestKind = {
+export const manifest: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.WorkspaceAction.Default',
 	matchKind: 'default',

--- a/src/packages/core/workspace/components/workspace-action/default/manifests.ts
+++ b/src/packages/core/workspace/components/workspace-action/default/manifests.ts
@@ -1,4 +1,4 @@
 import { manifest as defaultKindManifest } from './default.action.kind.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [defaultKindManifest];
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [defaultKindManifest];

--- a/src/packages/core/workspace/components/workspace-action/manifests.ts
+++ b/src/packages/core/workspace/components/workspace-action/manifests.ts
@@ -1,4 +1,4 @@
 import { manifests as defaultWorkspaceActionManifests } from './default/manifests.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [...defaultWorkspaceActionManifests];
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [...defaultWorkspaceActionManifests];

--- a/src/packages/core/workspace/components/workspace-breadcrumb/manifests.ts
+++ b/src/packages/core/workspace/components/workspace-breadcrumb/manifests.ts
@@ -1,8 +1,8 @@
 import { manifest as workspaceBreadcrumbKind } from './workspace-menu-breadcrumb/workspace-menu-breadcrumb.kind.js';
 import { manifest as variantBreadcrumbKind } from './workspace-variant-menu-breadcrumb/workspace-variant-menu-breadcrumb.kind.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	workspaceBreadcrumbKind,
 	variantBreadcrumbKind,
 ];

--- a/src/packages/core/workspace/components/workspace-breadcrumb/workspace-menu-breadcrumb/workspace-menu-breadcrumb.kind.ts
+++ b/src/packages/core/workspace/components/workspace-breadcrumb/workspace-menu-breadcrumb/workspace-menu-breadcrumb.kind.ts
@@ -1,6 +1,6 @@
-import type { UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: UmbBackofficeManifestKind = {
+export const manifest: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.WorkspaceFooterApp.MenuBreadcrumb',
 	matchKind: 'menuBreadcrumb',

--- a/src/packages/core/workspace/components/workspace-breadcrumb/workspace-variant-menu-breadcrumb/workspace-variant-menu-breadcrumb.kind.ts
+++ b/src/packages/core/workspace/components/workspace-breadcrumb/workspace-variant-menu-breadcrumb/workspace-variant-menu-breadcrumb.kind.ts
@@ -1,6 +1,6 @@
-import type { UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: UmbBackofficeManifestKind = {
+export const manifest: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.WorkspaceFooterApp.VariantMenuBreadcrumb',
 	matchKind: 'variantMenuBreadcrumb',

--- a/src/packages/core/workspace/components/workspace-collection/manifests.ts
+++ b/src/packages/core/workspace/components/workspace-collection/manifests.ts
@@ -1,6 +1,6 @@
-import type { UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<UmbBackofficeManifestKind> = [
+export const manifests: Array<UmbExtensionManifestKind> = [
 	{
 		type: 'kind',
 		alias: 'Umb.Kind.WorkspaceView.Collection',

--- a/src/packages/core/workspace/kinds/manifests.ts
+++ b/src/packages/core/workspace/kinds/manifests.ts
@@ -1,4 +1,4 @@
 import { manifest as routableKindManifest } from './routable/routable-workspace.kind.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [routableKindManifest];
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [routableKindManifest];

--- a/src/packages/core/workspace/kinds/routable/routable-workspace.kind.ts
+++ b/src/packages/core/workspace/kinds/routable/routable-workspace.kind.ts
@@ -1,6 +1,6 @@
-import type { UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: UmbBackofficeManifestKind = {
+export const manifest: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.Workspace.Routable',
 	matchKind: 'routable',

--- a/src/packages/core/workspace/manifests.ts
+++ b/src/packages/core/workspace/manifests.ts
@@ -3,9 +3,9 @@ import { manifests as sectionRouteManifests } from './section-routes/manifests.j
 import { manifests as workspaceConditionManifests } from './conditions/manifests.js';
 import { manifests as workspaceKindManifest } from './kinds/manifests.js';
 import { manifests as workspaceModalManifest } from './modals/manifests.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	...componentManifests,
 	...sectionRouteManifests,
 	...workspaceConditionManifests,

--- a/src/packages/documents/documents/manifests.ts
+++ b/src/packages/documents/documents/manifests.ts
@@ -14,9 +14,9 @@ import { manifests as treeManifests } from './tree/manifests.js';
 import { manifests as userPermissionManifests } from './user-permissions/manifests.js';
 import { manifests as workspaceManifests } from './workspace/manifests.js';
 
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	...collectionManifests,
 	...entityActionManifests,
 	...entityBulkActionManifests,

--- a/src/packages/documents/documents/picker/manifests.ts
+++ b/src/packages/documents/documents/picker/manifests.ts
@@ -1,7 +1,7 @@
 import { UMB_DOCUMENT_ENTITY_TYPE } from '../entity.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	{
 		type: 'pickerSearchResultItem',
 		kind: 'default',

--- a/src/packages/documents/manifests.ts
+++ b/src/packages/documents/manifests.ts
@@ -3,9 +3,9 @@ import { manifests as documentBlueprintManifests } from './document-blueprints/m
 import { manifests as documentManifests } from './documents/manifests.js';
 import { manifests as documentTypeManifests } from './document-types/manifests.js';
 import { manifests as sectionManifests } from './section/manifests.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	...dashboardManifests,
 	...documentBlueprintManifests,
 	...documentManifests,

--- a/src/packages/help/header-app/manifests.ts
+++ b/src/packages/help/header-app/manifests.ts
@@ -1,6 +1,6 @@
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	{
 		type: 'headerApp',
 		alias: 'Umb.HeaderApp.Help',

--- a/src/packages/help/manifests.ts
+++ b/src/packages/help/manifests.ts
@@ -1,5 +1,5 @@
 import { manifests as headerAppManifests } from './header-app/manifests.js';
 import { manifests as menuManifests } from './menu/manifests.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [...menuManifests, ...headerAppManifests];
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [...menuManifests, ...headerAppManifests];

--- a/src/packages/help/menu/manifests.ts
+++ b/src/packages/help/menu/manifests.ts
@@ -1,8 +1,8 @@
 import { UMB_HELP_MENU_ALIAS } from './constants.js';
 import { UMB_CURRENT_USER_IS_ADMIN_CONDITION_ALIAS } from '@umbraco-cms/backoffice/current-user';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	{
 		type: 'menu',
 		alias: UMB_HELP_MENU_ALIAS,

--- a/src/packages/members/manifests.ts
+++ b/src/packages/members/manifests.ts
@@ -2,12 +2,12 @@ import { manifests as memberGroupManifests } from './member-group/manifests.js';
 import { manifests as memberManifests } from './member/manifests.js';
 import { manifests as memberSectionManifests } from './member-section/manifests.js';
 import { manifests as memberTypeManifests } from './member-type/manifests.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
 import './member/components/index.js';
 import './member-group/components/index.js';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	...memberGroupManifests,
 	...memberManifests,
 	...memberSectionManifests,

--- a/src/packages/members/member/manifests.ts
+++ b/src/packages/members/member/manifests.ts
@@ -8,9 +8,9 @@ import { manifests as searchManifests } from './search/manifests.js';
 import { manifests as sectionViewManifests } from './section-view/manifests.js';
 import { manifests as workspaceManifests } from './workspace/manifests.js';
 
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	...collectionManifests,
 	...entityActionManifests,
 	...memberPickerModalManifests,

--- a/src/packages/members/member/picker/manifests.ts
+++ b/src/packages/members/member/picker/manifests.ts
@@ -1,7 +1,7 @@
 import { UMB_MEMBER_ENTITY_TYPE } from '../entity.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	{
 		type: 'pickerSearchResultItem',
 		kind: 'default',

--- a/src/packages/settings/manifests.ts
+++ b/src/packages/settings/manifests.ts
@@ -2,9 +2,9 @@ import { manifests as advancedManifests } from './advanced/manifests.js';
 import { manifests as sectionManifests } from './section/manifests.js';
 import { manifests as structureManifests } from './structure/manifests.js';
 import { manifests as welcomeDashboardManifests } from './welcome/manifests.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	...advancedManifests,
 	...sectionManifests,
 	...structureManifests,

--- a/src/packages/settings/section/manifests.ts
+++ b/src/packages/settings/section/manifests.ts
@@ -1,7 +1,7 @@
 import { UMB_SETTINGS_SECTION_ALIAS } from './constants.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	{
 		type: 'section',
 		alias: UMB_SETTINGS_SECTION_ALIAS,

--- a/src/packages/settings/structure/manifests.ts
+++ b/src/packages/settings/structure/manifests.ts
@@ -1,8 +1,8 @@
 import { UMB_SETTINGS_SECTION_ALIAS } from '../section/index.js';
 import { UMB_STRUCTURE_SETTINGS_MENU_ALIAS } from './constants.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	{
 		type: 'menu',
 		alias: UMB_STRUCTURE_SETTINGS_MENU_ALIAS,

--- a/src/packages/settings/welcome/manifests.ts
+++ b/src/packages/settings/welcome/manifests.ts
@@ -1,7 +1,7 @@
 import { UMB_SETTINGS_SECTION_ALIAS } from '../section/index.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	{
 		type: 'dashboard',
 		alias: 'Umb.Dashboard.SettingsWelcome',

--- a/src/packages/user/change-password/manifests.ts
+++ b/src/packages/user/change-password/manifests.ts
@@ -1,7 +1,7 @@
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 import { UMB_USER_ENTITY_TYPE } from '@umbraco-cms/backoffice/user';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	{
 		type: 'entityAction',
 		kind: 'default',

--- a/src/packages/user/current-user/action/default.kind.ts
+++ b/src/packages/user/current-user/action/default.kind.ts
@@ -1,6 +1,6 @@
-import type { UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifest: UmbBackofficeManifestKind = {
+export const manifest: UmbExtensionManifestKind = {
 	type: 'kind',
 	alias: 'Umb.Kind.CurrentUserAction.Default',
 	matchKind: 'default',

--- a/src/packages/user/section/manifests.ts
+++ b/src/packages/user/section/manifests.ts
@@ -4,7 +4,7 @@ import { manifests as menuManifests } from './menu/manifests.js';
 import type {
 	ManifestSection,
 	ManifestTypes,
-	UmbBackofficeManifestKind,
+	UmbExtensionManifestKind,
 } from '@umbraco-cms/backoffice/extension-registry';
 
 const section: ManifestSection = {
@@ -24,7 +24,7 @@ const section: ManifestSection = {
 	],
 };
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	section,
 	...sectionSidebarAppManifests,
 	...menuManifests,

--- a/src/packages/user/section/sidebar-app/manifests.ts
+++ b/src/packages/user/section/sidebar-app/manifests.ts
@@ -1,8 +1,8 @@
 import { UMB_USER_MANAGEMENT_SECTION_ALIAS } from '../constants.js';
 import { UMB_USER_MANAGEMENT_MENU_ALIAS } from '../menu/index.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	{
 		type: 'sectionSidebarApp',
 		kind: 'menu',

--- a/src/packages/user/user-group/manifests.ts
+++ b/src/packages/user/user-group/manifests.ts
@@ -7,9 +7,9 @@ import { manifests as repositoryManifests } from './repository/manifests.js';
 import { manifests as sectionViewManifests } from './workspace/user-group-root/manifests.js';
 import { manifests as workspaceManifests } from './workspace/manifests.js';
 
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	...collectionManifests,
 	...entityActionManifests,
 	...entityBulkActionManifests,

--- a/src/packages/user/user-group/workspace/manifests.ts
+++ b/src/packages/user/user-group/workspace/manifests.ts
@@ -1,4 +1,4 @@
 import { manifests as userGroupManifests } from './user-group/manifests.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [...userGroupManifests];
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [...userGroupManifests];

--- a/src/packages/user/user-group/workspace/user-group-root/manifests.ts
+++ b/src/packages/user/user-group/workspace/user-group-root/manifests.ts
@@ -1,7 +1,7 @@
 import { UMB_USER_GROUP_ROOT_ENTITY_TYPE } from '../../entity.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	{
 		type: 'workspace',
 		alias: 'Umb.Workspace.UserGroupRoot',

--- a/src/packages/user/user/client-credential/create/manifests.ts
+++ b/src/packages/user/user/client-credential/create/manifests.ts
@@ -1,5 +1,5 @@
 import { manifests as modalManifests } from './modal/manifests.js';
 
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [...modalManifests];
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [...modalManifests];

--- a/src/packages/user/user/client-credential/create/modal/manifests.ts
+++ b/src/packages/user/user/client-credential/create/modal/manifests.ts
@@ -1,7 +1,7 @@
 import { UMB_CREATE_USER_CLIENT_CREDENTIAL_MODAL_ALIAS } from './constants.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	{
 		type: 'modal',
 		alias: UMB_CREATE_USER_CLIENT_CREDENTIAL_MODAL_ALIAS,

--- a/src/packages/user/user/client-credential/manifests.ts
+++ b/src/packages/user/user/client-credential/manifests.ts
@@ -1,5 +1,5 @@
 import { manifests as createManifests } from './create/manifests.js';
 import { manifests as repositoryManifests } from './repository/manifests.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [...createManifests, ...repositoryManifests];
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [...createManifests, ...repositoryManifests];

--- a/src/packages/user/user/client-credential/repository/manifests.ts
+++ b/src/packages/user/user/client-credential/repository/manifests.ts
@@ -1,7 +1,7 @@
 import { UMB_USER_CLIENT_CREDENTIAL_REPOSITORY_ALIAS } from './constants.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	{
 		type: 'repository',
 		alias: UMB_USER_CLIENT_CREDENTIAL_REPOSITORY_ALIAS,

--- a/src/packages/user/user/entity-actions/create/manifests.ts
+++ b/src/packages/user/user/entity-actions/create/manifests.ts
@@ -2,9 +2,9 @@ import { UMB_USER_ROOT_ENTITY_TYPE } from '../../entity.js';
 
 import { manifests as modalManifests } from './modal/manifests.js';
 
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	{
 		type: 'entityAction',
 		kind: 'default',

--- a/src/packages/user/user/entity-actions/create/modal/manifests.ts
+++ b/src/packages/user/user/entity-actions/create/modal/manifests.ts
@@ -1,6 +1,6 @@
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	{
 		type: 'modal',
 		alias: 'Umb.Modal.User.CreateOptions',

--- a/src/packages/user/user/entity-actions/manifests.ts
+++ b/src/packages/user/user/entity-actions/manifests.ts
@@ -3,7 +3,7 @@ import { UMB_USER_ENTITY_TYPE } from '../entity.js';
 
 import { manifests as createManifests } from './create/manifests.js';
 
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
 const entityActions: Array<ManifestTypes> = [
 	{
@@ -96,4 +96,4 @@ const entityActions: Array<ManifestTypes> = [
 	},
 ];
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [...entityActions, ...createManifests];
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [...entityActions, ...createManifests];

--- a/src/packages/user/user/invite/entity-action/invite/manifests.ts
+++ b/src/packages/user/user/invite/entity-action/invite/manifests.ts
@@ -1,8 +1,8 @@
 import { UMB_USER_ROOT_ENTITY_TYPE } from '../../../entity.js';
 
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	{
 		type: 'entityAction',
 		kind: 'default',

--- a/src/packages/user/user/invite/entity-action/manifests.ts
+++ b/src/packages/user/user/invite/entity-action/manifests.ts
@@ -1,9 +1,9 @@
 import { manifests as inviteManifests } from './invite/manifests.js';
 import { manifests as resendInviteManifests } from './resend-invite/manifests.js';
 
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	...inviteManifests,
 	...resendInviteManifests,
 ];

--- a/src/packages/user/user/invite/manifests.ts
+++ b/src/packages/user/user/invite/manifests.ts
@@ -2,9 +2,9 @@ import { manifests as collectionActionManifests } from './collection-action/mani
 import { manifests as modalManifests } from './modal/manifests.js';
 import { manifests as repositoryManifests } from './repository/manifests.js';
 import { manifests as entityActionManifests } from './entity-action/manifests.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	...collectionActionManifests,
 	...modalManifests,
 	...repositoryManifests,

--- a/src/packages/user/user/manifests.ts
+++ b/src/packages/user/user/manifests.ts
@@ -9,9 +9,9 @@ import { manifests as propertyEditorManifests } from './property-editor/manifest
 import { manifests as repositoryManifests } from './repository/manifests.js';
 import { manifests as workspaceManifests } from './workspace/manifests.js';
 import { manifests as menuItemManifests } from './menu-item/manifests.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	...clientCredentialManifests,
 	...collectionManifests,
 	...conditionsManifests,

--- a/src/packages/user/user/workspace/manifests.ts
+++ b/src/packages/user/user/workspace/manifests.ts
@@ -1,5 +1,5 @@
 import { manifests as userManifests } from './user/manifests.js';
 import { manifests as userRootManifests } from './user-root/manifests.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [...userManifests, ...userRootManifests];
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [...userManifests, ...userRootManifests];

--- a/src/packages/user/user/workspace/user-root/manifests.ts
+++ b/src/packages/user/user/workspace/user-root/manifests.ts
@@ -1,7 +1,7 @@
 import { UMB_USER_ROOT_ENTITY_TYPE } from '../../entity.js';
-import type { ManifestTypes, UmbBackofficeManifestKind } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes | UmbBackofficeManifestKind> = [
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [
 	{
 		type: 'workspace',
 		alias: 'Umb.Workspace.UserRoot',


### PR DESCRIPTION
Renaming UmbBackofficeManifestKind to UmbExtensionManifestKind to be aligned with new Global Manifest Types.

also moves Menu Alias Condition to Manu package.


## Description

<!--- Describe the changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
