### PR TITLE
MultipleTextString: Add new line on pressing enter

### DIFF
--- a/src/packages/core/components/multiple-text-string-input/input-multiple-text-string-item.element.ts
+++ b/src/packages/core/components/multiple-text-string-input/input-multiple-text-string-item.element.ts
@@ -49,6 +49,14 @@ export class UmbInputMultipleTextStringItemElement extends UUIFormControlMixin(U
 		this.dispatchEvent(new UmbInputEvent());
 	}
 
+	#onKeydown(event: KeyboardEvent) {
+		event.stopPropagation();
+		const target = event.currentTarget as UUIInputElement;
+		if (event.key === 'Enter' && target.value) {
+			this.dispatchEvent(new CustomEvent('enter'));
+		}
+	}
+
 	#onChange(event: UUIInputEvent) {
 		event.stopPropagation();
 		const target = event.currentTarget as UUIInputElement;
@@ -84,6 +92,7 @@ export class UmbInputMultipleTextStringItemElement extends UUIFormControlMixin(U
 					id="input"
 					label="Value"
 					value=${this.value}
+					@keydown=${this.#onKeydown}
 					@input=${this.#onInput}
 					@change=${this.#onChange}
 					?disabled=${this.disabled}

--- a/src/packages/core/components/multiple-text-string-input/input-multiple-text-string.element.ts
+++ b/src/packages/core/components/multiple-text-string-input/input-multiple-text-string.element.ts
@@ -209,6 +209,7 @@ export class UmbInputMultipleTextStringElement extends UmbFormControlMixin<undef
 						value=${item}
 						?disabled=${this.disabled}
 						?readonly=${this.readonly}
+						@enter=${this.#onAdd}
 						@delete=${(event: UmbDeleteEvent) => this.#deleteItem(event, index)}
 						@input=${(event: UmbInputEvent) => this.#onInput(event, index)}>
 					</umb-input-multiple-text-string-item>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
MultipleTextString property editor now adds a new line when pressing enter (similar to how it was in v13)

Fixes https://github.com/umbraco/Umbraco-CMS/issues/16162

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)