### PR TITLE
MultipleColorPicker: Tab behaviour and new line on enter

### DIFF
--- a/src/packages/core/components/multiple-color-picker-input/multiple-color-picker-input.element.ts
+++ b/src/packages/core/components/multiple-color-picker-input/multiple-color-picker-input.element.ts
@@ -175,7 +175,7 @@ export class UmbMultipleColorPickerInputElement extends UUIFormControlMixin(UmbL
 			<div id="sorter-wrapper">
 				${repeat(
 					this._items,
-					(item) => item.value,
+					(item, index) => index,
 					(item, index) => html`
 						<umb-multiple-color-picker-item-input
 							label=${item.label}
@@ -185,6 +185,7 @@ export class UmbMultipleColorPickerInputElement extends UUIFormControlMixin(UmbL
 							?disabled=${this.disabled}
 							?readonly=${this.readonly}
 							?showLabels=${this.showLabels}
+							@enter=${this.#onAdd}
 							@change=${(event: UmbChangeEvent) => this.#onChange(event, index)}
 							@delete=${(event: UmbDeleteEvent) => this.#deleteItem(event, index)}>
 						</umb-multiple-color-picker-item-input>

--- a/src/packages/core/components/multiple-color-picker-input/multiple-color-picker-item-input.element.ts
+++ b/src/packages/core/components/multiple-color-picker-input/multiple-color-picker-item-input.element.ts
@@ -84,10 +84,23 @@ export class UmbMultipleColorPickerItemInputElement extends UUIFormControlMixin(
 		this.dispatchEvent(new UmbInputEvent());
 	}
 
+	#onLabelKeydown(event: KeyboardEvent) {
+		event.stopPropagation();
+		const target = event.currentTarget as UUIInputElement;
+		if (event.key === 'Enter' && target.value) {
+			this.dispatchEvent(new CustomEvent('enter'));
+		}
+	}
+
 	#onLabelChange(event: UUIInputEvent) {
 		event.stopPropagation();
 		this.label = event.target.value as string;
 		this.dispatchEvent(new UmbChangeEvent());
+	}
+
+	#onValueKeydown(event: KeyboardEvent) {
+		event.stopPropagation();
+		if (event.key === 'Enter') this.#onColorClick();
 	}
 
 	#onValueChange(event: UUIInputEvent) {
@@ -145,6 +158,7 @@ export class UmbMultipleColorPickerItemInputElement extends UUIFormControlMixin(
 							placeholder=${this.localize.term('general_value')}
 							required=${this.required}
 							required-message="Value is missing"
+							@keydown=${this.#onValueKeydown}
 							@input=${this.#onValueInput}
 							@change=${this.#onValueChange}>
 							<uui-color-swatch
@@ -162,6 +176,7 @@ export class UmbMultipleColorPickerItemInputElement extends UUIFormControlMixin(
 								label=${this.localize.term('placeholders_label')}
 								placeholder=${this.localize.term('placeholders_label')}
 								value=${ifDefined(this.label)}
+								@keydown=${this.#onLabelKeydown}
 								@input="${this.#onLabelInput}"
 								@change="${this.#onLabelChange}"
 								?disabled=${this.disabled}
@@ -208,6 +223,12 @@ export class UmbMultipleColorPickerItemInputElement extends UUIFormControlMixin(
 
 			uui-color-swatch {
 				padding: var(--uui-size-1);
+			}
+
+			uui-color-swatch:focus-within {
+				outline: 2px solid var(--uui-color-selected);
+				outline-offset: 0;
+				border-radius: var(--uui-border-radius);
 			}
 
 			.color-wrapper {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed an issue where the the user would lose tab focus when changing color values
Add new row when pressing enter if a label is filled out.
Automatically opens the color picker window when pressing enter in the color input field

Fixes https://github.com/umbraco/Umbraco-CMS/issues/16158

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

