### PR TITLE
feat: adds readonly mode to the tiptap input element

### DIFF
--- a/src/packages/rte/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/packages/rte/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -35,12 +35,18 @@ import './tiptap-fixed-menu.element.js';
 import './tiptap-hover-menu.element.js';
 
 @customElement('umb-input-tiptap')
-export class UmbInputTiptapElement extends UmbFormControlMixin(UmbLitElement, '') {
-	@state()
-	private _extensions: Array<UmbTiptapExtensionBase> = [];
-
+export class UmbInputTiptapElement extends UmbFormControlMixin(UmbLitElement, undefined) {
 	@property({ attribute: false })
 	configuration?: UmbPropertyEditorConfigCollection;
+
+	/**
+	 * Sets the input to readonly mode, meaning value cannot be changed but still able to read and select its content.
+	 */
+	@property({ type: Boolean, reflect: true })
+	readonly = false;
+
+	@state()
+	private _extensions: Array<UmbTiptapExtensionBase> = [];
 
 	@state()
 	private _editor!: Editor;
@@ -78,6 +84,7 @@ export class UmbInputTiptapElement extends UmbFormControlMixin(UmbLitElement, ''
 
 		this._editor = new Editor({
 			element: element,
+			editable: !this.readonly,
 			extensions: [
 				// REQUIRED EXTENSIONS START
 				Document,
@@ -106,7 +113,7 @@ export class UmbInputTiptapElement extends UmbFormControlMixin(UmbLitElement, ''
 				Underline,
 				...extensions,
 			],
-			content: this.value.toString(),
+			content: this.value?.toString(),
 			onUpdate: ({ editor }) => {
 				this.value = editor.getHTML();
 				this.dispatchEvent(new UmbChangeEvent());
@@ -118,13 +125,24 @@ export class UmbInputTiptapElement extends UmbFormControlMixin(UmbLitElement, ''
 		if (!this._extensions?.length) return html`<uui-loader></uui-loader>`;
 		return html`
 			<umb-tiptap-hover-menu .editor=${this._editor}></umb-tiptap-hover-menu>
-			<umb-tiptap-fixed-menu .editor=${this._editor} .extensions=${this._extensions}></umb-tiptap-fixed-menu>
+			<umb-tiptap-fixed-menu
+				?readonly=${this.readonly}
+				.editor=${this._editor}
+				.extensions=${this._extensions}></umb-tiptap-fixed-menu>
 			<div id="editor"></div>
 		`;
 	}
 
-	static override styles = [
+	static override readonly styles = [
 		css`
+			:host([readonly]) {
+				pointer-events: none;
+
+				#editor {
+					background-color: var(--uui-color-surface-alt);
+				}
+			}
+
 			#editor {
 				border-radius: var(--uui-border-radius);
 				border: 1px solid var(--uui-color-border);

--- a/src/packages/rte/tiptap/components/input-tiptap/tiptap-fixed-menu.element.ts
+++ b/src/packages/rte/tiptap/components/input-tiptap/tiptap-fixed-menu.element.ts
@@ -184,7 +184,7 @@ export class UmbTiptapFixedMenuElement extends UmbLitElement {
 		`;
 	}
 
-	static override styles = css`
+	static override readonly styles = css`
 		:host {
 			border-radius: var(--uui-border-radius);
 			border: 1px solid var(--uui-color-border);

--- a/src/packages/rte/tiptap/components/input-tiptap/tiptap-fixed-menu.element.ts
+++ b/src/packages/rte/tiptap/components/input-tiptap/tiptap-fixed-menu.element.ts
@@ -6,6 +6,9 @@ import type { Editor } from '@umbraco-cms/backoffice/external/tiptap';
 
 @customElement('umb-tiptap-fixed-menu')
 export class UmbTiptapFixedMenuElement extends UmbLitElement {
+	@property({ type: Boolean, reflect: true })
+	readonly = false;
+
 	@state()
 	actions: Array<UmbTiptapToolbarButton> = [
 		// TODO: I don't think we need a paragraph button. It's the default state.
@@ -194,6 +197,11 @@ export class UmbTiptapFixedMenuElement extends UmbLitElement {
 			left: 0px;
 			right: 0px;
 			padding: 4px;
+		}
+
+		:host([readonly]) {
+			pointer-events: none;
+			background-color: var(--uui-color-surface-alt);
 		}
 
 		button {

--- a/src/packages/rte/tiptap/components/input-tiptap/tiptap-hover-menu.element.ts
+++ b/src/packages/rte/tiptap/components/input-tiptap/tiptap-hover-menu.element.ts
@@ -38,7 +38,7 @@ export class UmbTiptapHoverMenuElement extends LitElement {
 		return html`<uui-popover-container></uui-popover-container>`;
 	}
 
-	static override styles = css`
+	static override readonly styles = css`
 		:host {
 			position: fixed;
 			background-color: var(--uui-color-surface-alt);


### PR DESCRIPTION
## Description

Adds readonly mode to the Tiptap input element. It changes the background color and disables all controls and sets `editable` to false on the editor.

## Screenshots

<img width="827" alt="image" src="https://github.com/user-attachments/assets/3e37a07d-e70a-45a4-9cf9-30570b43ca08">
