### PR TITLE
Feature: Tiptap toolbar elements

### DIFF
--- a/src/packages/rte/manifests.ts
+++ b/src/packages/rte/manifests.ts
@@ -1,4 +1,4 @@
 import { manifests as tiptapManifests } from './tiptap/manifests.js';
-import type { ManifestTypes } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes> = [...tiptapManifests];
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [...tiptapManifests];

--- a/src/packages/rte/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/packages/rte/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -75,7 +75,6 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 	}
 
 	async #loadEditor() {
-
 		const element = this.shadowRoot?.querySelector('#editor');
 		if (!element) return;
 
@@ -119,10 +118,7 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 				() => html`<uui-loader></uui-loader>`,
 				() => html`
 					<umb-tiptap-hover-menu .editor=${this._editor}></umb-tiptap-hover-menu>
-					<umb-tiptap-fixed-menu
-						.editor=${this._editor}
-						.extensions=${this._extensions}
-						?readonly=${this.readonly}></umb-tiptap-fixed-menu>
+					<umb-tiptap-fixed-menu .editor=${this._editor} ?readonly=${this.readonly}></umb-tiptap-fixed-menu>
 				`,
 			)}
 			<div id="editor"></div>

--- a/src/packages/rte/tiptap/components/input-tiptap/tiptap-fixed-menu.element.ts
+++ b/src/packages/rte/tiptap/components/input-tiptap/tiptap-fixed-menu.element.ts
@@ -1,4 +1,5 @@
-import type { UmbTiptapExtensionBase, UmbTiptapToolbarButton } from '../../extensions/types.js';
+import type { UmbTiptapToolbarButton } from '../../extensions/types.js';
+import type { ManifestTiptapExtension } from '../../extensions/tiptap-extension.js';
 import * as icons from './icons.js';
 import { css, customElement, html, property, state, when } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
@@ -153,17 +154,9 @@ export class UmbTiptapFixedMenuElement extends UmbLitElement {
 	}
 	#editor?: Editor;
 
-	@property({ attribute: false })
-	extensions: Array<UmbTiptapExtensionBase> = [];
-
 	#onUpdate = () => {
 		this.requestUpdate();
 	};
-
-	protected override firstUpdated() {
-		const buttons = this.extensions.flatMap((ext) => ext.getToolbarButtons());
-		this.actions.push(...buttons);
-	}
 
 	override render() {
 		return html`
@@ -181,6 +174,11 @@ export class UmbTiptapFixedMenuElement extends UmbLitElement {
 					</button>
 				`,
 			)}
+			<umb-extension-with-api-slot
+				type="tiptapExtension"
+				.filter=${(ext: ManifestTiptapExtension) => !!ext.kind || !!ext.element}
+				.elementProps=${{ editor: this.editor }}>
+			</umb-extension-with-api-slot>
 		`;
 	}
 

--- a/src/packages/rte/tiptap/extensions/manifests.ts
+++ b/src/packages/rte/tiptap/extensions/manifests.ts
@@ -1,18 +1,40 @@
 import type { ManifestTiptapExtension } from './tiptap-extension.js';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTiptapExtension> = [
+const kinds: Array<UmbExtensionManifestKind> = [
+	{
+		type: 'kind',
+		alias: 'Umb.Kind.Button',
+		matchKind: 'button',
+		matchType: 'tiptapExtension',
+		manifest: {
+			element: () => import('./tiptap-toolbar-button.element.js'),
+		},
+	},
+];
+
+const extensions: Array<ManifestTiptapExtension> = [
 	{
 		type: 'tiptapExtension',
 		alias: 'Umb.Tiptap.Image',
 		name: 'Image Tiptap Extension',
 		weight: 1000,
 		api: () => import('./tiptap-image.extension.js'),
+		meta: {},
 	},
 	{
 		type: 'tiptapExtension',
+		kind: 'button',
 		alias: 'Umb.Tiptap.MediaPicker',
 		name: 'Media Picker Tiptap Extension',
 		weight: 900,
 		api: () => import('./tiptap-mediapicker.extension.js'),
+		meta: {
+			alias: 'umb-media',
+			icon: 'icon-picture',
+			label: 'Media picker',
+		},
 	},
 ];
+
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [...kinds, ...extensions];

--- a/src/packages/rte/tiptap/extensions/tiptap-extension.ts
+++ b/src/packages/rte/tiptap/extensions/tiptap-extension.ts
@@ -1,8 +1,27 @@
-import type { UmbTiptapExtensionBase } from './types.js';
-import type { ManifestApi } from '@umbraco-cms/backoffice/extension-api';
+import type { UmbTiptapExtensionApi } from './types.js';
+import type { UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
+import type { ManifestElementAndApi } from '@umbraco-cms/backoffice/extension-api';
 
-export interface ManifestTiptapExtension extends ManifestApi<UmbTiptapExtensionBase> {
+export interface ManifestTiptapExtension<MetaType extends MetaTiptapExtension = MetaTiptapExtension>
+	extends ManifestElementAndApi<UmbControllerHostElement, UmbTiptapExtensionApi> {
 	type: 'tiptapExtension';
+	meta: MetaType;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface MetaTiptapExtension {}
+
+export interface ManifestTiptapExtensionButtonKind<
+	MetaType extends MetaTiptapExtensionButtonKind = MetaTiptapExtensionButtonKind,
+> extends ManifestTiptapExtension<MetaType> {
+	type: 'tiptapExtension';
+	kind: 'button';
+}
+
+export interface MetaTiptapExtensionButtonKind extends MetaTiptapExtension {
+	alias: string;
+	icon: string;
+	label: string;
 }
 
 declare global {

--- a/src/packages/rte/tiptap/extensions/tiptap-image.extension.ts
+++ b/src/packages/rte/tiptap/extensions/tiptap-image.extension.ts
@@ -1,12 +1,8 @@
-import { UmbTiptapExtensionBase } from './types.js';
+import { UmbTiptapExtensionApi } from './types.js';
 import { UmbImage } from '@umbraco-cms/backoffice/external/tiptap';
 
-export default class UmbTiptapImageExtension extends UmbTiptapExtensionBase {
-	getExtensions() {
+export default class UmbTiptapImageExtension extends UmbTiptapExtensionApi {
+	getTiptapExtensions() {
 		return [UmbImage.configure({ inline: true })];
-	}
-
-	getToolbarButtons() {
-		return [];
 	}
 }

--- a/src/packages/rte/tiptap/extensions/tiptap-mediapicker.extension.ts
+++ b/src/packages/rte/tiptap/extensions/tiptap-mediapicker.extension.ts
@@ -1,23 +1,23 @@
-import { UmbTiptapExtensionBase } from './types.js';
+import { UmbTiptapExtensionApi } from './types.js';
 import { mergeAttributes, Node } from '@umbraco-cms/backoffice/external/tiptap';
+import { UMB_MEDIA_PICKER_MODAL } from '@umbraco-cms/backoffice/media';
 import { UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
 import type { Editor } from '@umbraco-cms/backoffice/external/tiptap';
-import { UMB_MEDIA_PICKER_MODAL } from '@umbraco-cms/backoffice/media';
 
-export default class UmbTiptapMediaPickerPlugin extends UmbTiptapExtensionBase {
-	getExtensions() {
+export default class UmbTiptapMediaPickerPlugin extends UmbTiptapExtensionApi {
+	getTiptapExtensions() {
 		return [
 			Node.create({
 				name: 'umbMediaPicker',
+				priority: 1000,
 				group: 'block',
 				marks: '',
 				draggable: true,
 				addNodeView() {
 					return () => {
 						//console.log('umb-media.addNodeView');
-						const dom = document.createElement('umb-debug');
-						dom.attributes.setNamedItem(document.createAttribute('visible'));
-						dom.attributes.setNamedItem(document.createAttribute('dialog'));
+						const dom = document.createElement('span');
+						dom.innerText = '🖼️';
 						return { dom };
 					};
 				},
@@ -33,22 +33,15 @@ export default class UmbTiptapMediaPickerPlugin extends UmbTiptapExtensionBase {
 		];
 	}
 
-	getToolbarButtons() {
-		return [
-			{
-				name: 'umb-media',
-				icon: 'icon-picture',
-				isActive: (editor?: Editor) => editor?.isActive('umbMediaPicker'),
-				command: async (editor?: Editor) => {
-					//console.log('umb-media.command', editor);
+	//isActive: (editor?: Editor) => editor?.isActive('umbMediaPicker') || editor?.isActive('image'),
 
-					const selection = await this.#openMediaPicker();
-					if (!selection || !selection.length) return;
+	override async execute(editor?: Editor) {
+		console.log('umb-media.execute', editor);
 
-					editor?.chain().focus().insertContent(`<umb-media>${selection}</umb-media>`).run();
-				},
-			},
-		];
+		const selection = await this.#openMediaPicker();
+		if (!selection || !selection.length) return;
+
+		editor?.chain().focus().insertContent(`<umb-media>${selection}</umb-media>`).run();
 	}
 
 	async #openMediaPicker() {

--- a/src/packages/rte/tiptap/extensions/tiptap-toolbar-button.element.ts
+++ b/src/packages/rte/tiptap/extensions/tiptap-toolbar-button.element.ts
@@ -1,0 +1,34 @@
+import type { ManifestTiptapExtensionButtonKind } from './tiptap-extension.js';
+import type { UmbTiptapExtensionApi } from './types.js';
+import type { Editor } from '@umbraco-cms/backoffice/external/tiptap';
+import { customElement, html, ifDefined, when } from '@umbraco-cms/backoffice/external/lit';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+
+const elementName = 'umb-tiptap-toolbar-button';
+
+@customElement(elementName)
+export class UmbTiptapToolbarButtonElement extends UmbLitElement {
+	public api?: UmbTiptapExtensionApi;
+	public editor?: Editor;
+	public manifest?: ManifestTiptapExtensionButtonKind;
+
+	override render() {
+		return html`
+			<uui-button compact label=${ifDefined(this.manifest?.meta.label)} @click=${() => this.api?.execute(this.editor)}>
+				${when(
+					this.manifest?.meta.icon,
+					() => html`<umb-icon name=${this.manifest!.meta.icon}></umb-icon>`,
+					() => html`<span>${this.manifest?.meta.label}</span>`,
+				)}
+			</uui-button>
+		`;
+	}
+}
+
+export { UmbTiptapToolbarButtonElement as element };
+
+declare global {
+	interface HTMLElementTagNameMap {
+		[elementName]: UmbTiptapToolbarButtonElement;
+	}
+}

--- a/src/packages/rte/tiptap/extensions/types.ts
+++ b/src/packages/rte/tiptap/extensions/types.ts
@@ -4,14 +4,15 @@ import type { TemplateResult } from '@umbraco-cms/backoffice/external/lit';
 import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
-export abstract class UmbTiptapExtensionBase extends UmbControllerBase implements UmbApi {
+export abstract class UmbTiptapExtensionApi extends UmbControllerBase implements UmbApi {
 	constructor(host: UmbControllerHost) {
 		super(host);
 	}
 
-	abstract getExtensions(): Array<Extension | Mark | Node>;
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	execute(editor?: Editor) {}
 
-	abstract getToolbarButtons(): Array<UmbTiptapToolbarButton>;
+	abstract getTiptapExtensions(): Array<Extension | Mark | Node>;
 }
 
 export interface UmbTiptapToolbarButton {

--- a/src/packages/rte/tiptap/manifests.ts
+++ b/src/packages/rte/tiptap/manifests.ts
@@ -1,5 +1,5 @@
 import { manifests as extensions } from './extensions/manifests.js';
 import { manifests as propertyEditors } from './property-editors/manifests.js';
-import type { ManifestTypes } from '@umbraco-cms/backoffice/extension-registry';
+import type { ManifestTypes, UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<ManifestTypes> = [...extensions, ...propertyEditors];
+export const manifests: Array<ManifestTypes | UmbExtensionManifestKind> = [...extensions, ...propertyEditors];

--- a/src/packages/rte/tiptap/property-editors/tiptap/property-editor-ui-tiptap.element.ts
+++ b/src/packages/rte/tiptap/property-editors/tiptap/property-editor-ui-tiptap.element.ts
@@ -138,11 +138,13 @@ export class UmbPropertyEditorUITiptapElement extends UmbLitElement implements U
 	}
 
 	override render() {
-		return html`<umb-input-tiptap
-			.value=${this._markup}
-			@change=${this.#onChange}
-			.configuration=${this._config}
-			?readonly=${this.readonly}></umb-input-tiptap>`;
+		return html`
+			<umb-input-tiptap
+				.configuration=${this._config}
+				.value=${this._markup}
+				?readonly=${this.readonly}
+				@change=${this.#onChange}></umb-input-tiptap>
+		`;
 	}
 }
 


### PR DESCRIPTION
## Description

- Adds support for custom elements in the toolbar
- Adds a `button` kind for `tiptapExtension` for default toolbar buttons
- Amends how the toolbar extensions are loaded in/rendered

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## How to test?

If the Media Picker button is rendered on the toolbar, then it's working.

_**Note**: I've noticed a re-rendering when editing content, which is causing the toolbar to glitch... I expect that we'll revisit that particular code when we do the data-type configuration plumbing._
