### PR TITLE
Bugfix: No document type allowed at root message

### DIFF
--- a/src/packages/documents/documents/entity-actions/create/document-create-options-modal.element.ts
+++ b/src/packages/documents/documents/entity-actions/create/document-create-options-modal.element.ts
@@ -132,24 +132,39 @@ export class UmbDocumentCreateOptionsModalElement extends UmbModalBaseElement<
 		`;
 	}
 
+	#renderNoDocumentTypes() {
+		if (this.data?.documentType?.unique) {
+			return html`
+				<umb-localize key="create_noDocumentTypes">
+					There are no allowed Document Types available for creating content here. You must enable these in
+					<strong>Document Types</strong> within the <strong>Settings</strong> section, by editing the
+					<strong>Allowed child node types</strong> under <strong>Structure</strong>.
+				</umb-localize>
+				<br />
+				<uui-button
+					id="edit-permissions"
+					look="secondary"
+					href=${`/section/settings/workspace/document-type/edit/${this.data?.documentType?.unique}/view/structure`}
+					label=${this.localize.term('create_noDocumentTypesEditPermissions')}
+					@click=${() => this._rejectModal()}></uui-button>
+			`;
+		} else {
+			return html`
+				<umb-localize key="create_noDocumentTypesAllowedAtRoot">
+					There are no allowed Document Types available for creating content here. You must enable these in
+					<strong>Document Types</strong> within the <strong>Settings</strong> section, by changing the
+					<strong>Allow as root</strong> option under <strong>Structure</strong>.
+				</umb-localize>
+			`;
+		}
+	}
+
 	#renderDocumentTypes() {
 		return html`
 			<uui-box .headline=${this._headline}>
 				${when(
 					this._allowedDocumentTypes.length === 0,
-					() => html`
-						<umb-localize key="create_noDocumentTypes">
-							There are no allowed Document Types available for creating content here. You must enable these in
-							<strong>Document Types</strong> within the <strong>Settings</strong> section, by editing the
-							<strong>Allowed child node types</strong> under <strong>Permissions</strong>.<br />
-						</umb-localize>
-						<uui-button
-							id="edit-permissions"
-							look="secondary"
-							href=${`/section/settings/workspace/document-type/edit/${this.data?.documentType?.unique}/view/structure`}
-							label=${this.localize.term('create_noDocumentTypesEditPermissions')}
-							@click=${() => this._rejectModal()}></uui-button>
-					`,
+					() => this.#renderNoDocumentTypes(),
 					() =>
 						repeat(
 							this._allowedDocumentTypes,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When trying to create a new document type under content (at the root), and there is no allowed document types available, show the correct message and remove the edit button.
The button has been removed as there are multiple options when creating a document type (it was not there in v13 either)

Fixes https://github.com/umbraco/Umbraco-CMS/issues/17107

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
