### PR TITLE
Feature: Unsupported properties

### DIFF
--- a/src/packages/block/block/workspace/views/edit/block-workspace-view-edit-properties.element.ts
+++ b/src/packages/block/block/workspace/views/edit/block-workspace-view-edit-properties.element.ts
@@ -35,11 +35,15 @@ export class UmbBlockWorkspaceViewEditPropertiesElement extends UmbLitElement {
 	@state()
 	_dataPaths?: Array<string>;
 
+	@state()
+	private _ownerEntityType?: string;
+
 	constructor() {
 		super();
 
 		this.consumeContext(UMB_BLOCK_WORKSPACE_CONTEXT, (workspaceContext) => {
 			this.#blockWorkspace = workspaceContext;
+			this._ownerEntityType = this.#blockWorkspace.getEntityType();
 			this.#setStructureManager();
 		});
 	}
@@ -70,6 +74,7 @@ export class UmbBlockWorkspaceViewEditPropertiesElement extends UmbLitElement {
 				html`<umb-property-type-based-property
 					class="property"
 					data-path=${this._dataPaths![index]}
+					.ownerEntityType=${this._ownerEntityType}
 					.property=${property}
 					${umbDestroyOnDisconnect()}></umb-property-type-based-property>`,
 		);

--- a/src/packages/core/property/index.ts
+++ b/src/packages/core/property/index.ts
@@ -3,3 +3,4 @@ export * from './property-dataset/index.js';
 export * from './property-layout/index.js';
 export * from './property/index.js';
 export * from './types/index.js';
+export * from './unsupported-property/index.js';

--- a/src/packages/core/property/types/index.ts
+++ b/src/packages/core/property/types/index.ts
@@ -1,1 +1,2 @@
 export * from './property-value-data.type.js';
+export * from './unsupported-properties.type.js';

--- a/src/packages/core/property/types/unsupported-properties.type.ts
+++ b/src/packages/core/property/types/unsupported-properties.type.ts
@@ -1,0 +1,1 @@
+export type UmbUnsupportedEditorSchemaAliases = Record<string, Array<string>>;

--- a/src/packages/core/property/unsupported-property/index.ts
+++ b/src/packages/core/property/unsupported-property/index.ts
@@ -1,0 +1,2 @@
+export * from './utils.js';
+export * from './unsupported-property.element.js';

--- a/src/packages/core/property/unsupported-property/unsupported-property.element.ts
+++ b/src/packages/core/property/unsupported-property/unsupported-property.element.ts
@@ -1,0 +1,45 @@
+import { css, customElement, html, property } from '@umbraco-cms/backoffice/external/lit';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
+
+/**
+ *  @description Component for displaying an unsupported property
+ */
+
+@customElement('umb-unsupported-property')
+export class UmbUnsupportedPropertyElement extends UmbLitElement {
+	@property({ type: String })
+	public alias = '';
+
+	@property({ type: String })
+	public schema = '';
+
+	override render() {
+		return html`<div id="not-supported">
+			<umb-localize key="blockEditor_propertyEditorNotSupported" .args=${[this.alias, this.schema]}></umb-localize>
+		</div>`;
+	}
+
+	static override styles = [
+		UmbTextStyles,
+		css`
+			:host {
+				display: block;
+				padding: var(--uui-size-layout-1) 0;
+			}
+
+			#not-supported {
+				background-color: var(--uui-color-danger);
+				color: var(--uui-color-surface);
+				padding: var(--uui-size-space-4);
+				border-radius: var(--uui-border-radius);
+			}
+		`,
+	];
+}
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-unsupported-property': UmbUnsupportedPropertyElement;
+	}
+}

--- a/src/packages/core/property/unsupported-property/utils.ts
+++ b/src/packages/core/property/unsupported-property/utils.ts
@@ -1,0 +1,5 @@
+import type { UmbUnsupportedEditorSchemaAliases } from '../types/index.js';
+
+export const UMB_UNSUPPORTED_EDITOR_SCHEMA_ALIASES: UmbUnsupportedEditorSchemaAliases = {
+	block: ['Umbraco.ImageCropper', 'Umbraco.UploadField'],
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

A fresh PR for the adding logic to unsupported properties based on the comments from the previous PR: https://github.com/umbraco/Umbraco.CMS.Backoffice/pull/2102

Added `UMB_UNSUPPORTED_EDITOR_SCHEMA_ALIASES` which contains all unsupported schemas.
Added element `umb-unsupported-property` to be used for any property that are unsupported.

Fixes https://github.com/umbraco/Umbraco-CMS/issues/16664

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
