### PR TITLE
make z-index relative to the editor

### DIFF
--- a/src/packages/rte/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/packages/rte/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -152,6 +152,8 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 		css`
 			:host {
 				display: block;
+				position: relative;
+				z-index: 0;
 			}
 			:host([readonly]) {
 				pointer-events: none;
@@ -191,7 +193,6 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 				width: 100%;
 				min-height: 400px;
 				display: grid; /* Don't ask me why this is needed, but it is. */
-
 				pre {
 					background-color: var(--uui-color-surface-alt);
 					padding: var(--uui-size-space-2) var(--uui-size-space-4);

--- a/src/packages/rte/tiptap/components/input-tiptap/tiptap-fixed-menu.element.ts
+++ b/src/packages/rte/tiptap/components/input-tiptap/tiptap-fixed-menu.element.ts
@@ -51,7 +51,7 @@ export class UmbTiptapFixedMenuElement extends UmbLitElement {
 			right: 0px;
 			padding: var(--uui-size-space-3);
 			align-items: center;
-			z-index: 100;
+			z-index: 9999999;
 		}
 
 		:host([readonly]) {


### PR DESCRIPTION
Fixes the toolbar overlapping elements outside the editor by giving the editor a stacking context (z-index: 0)