### PR TITLE
Bugfix: Code Block is removing spaces

### DIFF
--- a/src/packages/core/components/code-block/code-block.element.ts
+++ b/src/packages/core/components/code-block/code-block.element.ts
@@ -86,7 +86,7 @@ export class UmbCodeBlockElement extends LitElement {
 			pre,
 			code {
 				word-wrap: normal;
-				white-space: pre-line;
+				white-space: pre;
 			}
 
 			#header {

--- a/src/packages/sysinfo/components/sysinfo.element.ts
+++ b/src/packages/sysinfo/components/sysinfo.element.ts
@@ -78,7 +78,7 @@ export class UmbSysinfoElement extends UmbModalBaseElement {
 					${when(
 						this._loading,
 						() => html`<uui-loader-bar></uui-loader-bar>`,
-						() => html` <umb-code-block id="codeblock"> ${this._systemInformation} </umb-code-block> `,
+						() => html` <umb-code-block id="codeblock">${this._systemInformation}</umb-code-block> `,
 					)}
 
 					<uui-button


### PR DESCRIPTION
## Description

Revert to `white-space: pre` and fix the underlying issue with sysinfo.

Fixes https://github.com/umbraco/Umbraco-CMS/issues/17152