### PR TITLE
Tiptap: Fixes internal link bug

### DIFF
--- a/src/external/tiptap/extensions/tiptap-umb-link.extension.ts
+++ b/src/external/tiptap/extensions/tiptap-umb-link.extension.ts
@@ -17,6 +17,7 @@ export const UmbLink = Link.extend({
 			...this.parent?.(),
 			HTMLAttributes: {
 				target: '',
+				'data-router-slot': 'disabled',
 			},
 		};
 	},


### PR DESCRIPTION
## Description

When using internal links (document, media) within the Tiptap RTE, the links would be navigable (external links would be fine). This was due to the backoffice router listening to click events of all anchor links. I have add disabled this within the Tiptap editor by adding the `data-router-slot=disabled` attribute (for rendering, not in the property value).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## How to test?

Add a link that points to either a document or media item. Try to click on the link within the Tiptap editor, it should not navigate elsewhere.