### PR TITLE
Tiptap: Fixes Table CSS rules

### DIFF
--- a/src/packages/rte/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/packages/rte/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -264,6 +264,8 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 
 				.umb-embed-holder.ProseMirror-selectednode::before {
 					background: rgba(0, 0, 0, 0.025);
+				}
+
 				/* Table-specific styling */
 				.tableWrapper {
 					margin: 1.5rem 0;
@@ -318,7 +320,6 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 							width: 3px;
 						}
 					}
-				}
 
 				.resize-cursor {
 					cursor: ew-resize;


### PR DESCRIPTION
## Description

I'd noticed that the CSS rules for the Tiptap Table extension was being nested in another rule, (probably from a bad merge conflict). This PR fixes this.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
