### PR TITLE
Tiptap: Combined Max Height/Width options into Dimensions

### DIFF
--- a/src/packages/rte/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/packages/rte/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -105,10 +105,9 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 		const element = this.shadowRoot?.querySelector('#editor');
 		if (!element) return;
 
-		const maxWidth = this.configuration?.getValueByAlias<number>('maxWidth');
-		const maxHeight = this.configuration?.getValueByAlias<number>('maxHeight');
-		if (maxWidth) this.setAttribute('style', `max-width: ${maxWidth}px;`);
-		if (maxHeight) element.setAttribute('style', `max-height: ${maxHeight}px;`);
+		const dimensions = this.configuration?.getValueByAlias<{ width?: number; height?: number }>('dimensions');
+		if (dimensions?.width) this.setAttribute('style', `max-width: ${dimensions.width}px;`);
+		if (dimensions?.height) element.setAttribute('style', `max-height: ${dimensions.height}px;`);
 
 		this._toolbar = this.configuration?.getValueByAlias<string[][][]>('toolbar') ?? [[[]]];
 

--- a/src/packages/rte/tiptap/property-editors/tiptap/manifests.ts
+++ b/src/packages/rte/tiptap/property-editors/tiptap/manifests.ts
@@ -28,18 +28,11 @@ export const manifests: Array<ManifestPropertyEditorUi> = [
 						weight: 10,
 					},
 					{
-						alias: 'maxWidth',
-						label: 'MaxWidth',
-						description: 'Editor max width',
-						propertyEditorUiAlias: 'Umb.PropertyEditorUi.Integer',
+						alias: 'dimensions',
+						label: 'Dimensions',
+						description: 'Set the maximum width and height of the editor',
+						propertyEditorUiAlias: 'Umb.PropertyEditorUI.TinyMCE.DimensionsConfiguration',
 						weight: 20,
-					},
-					{
-						alias: 'maxHeight',
-						label: 'MaxHeight',
-						description: 'Editor max height',
-						propertyEditorUiAlias: 'Umb.PropertyEditorUi.Integer',
-						weight: 30,
 					},
 					{
 						alias: 'maxImageSize',


### PR DESCRIPTION
## Description

Follows similar pattern as our TinyMCE configuration where the height/width of the editor can be defined in a combined field for Dimensions. 

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
