### PR TITLE
Bugfix: TinyMCE toolbar config layout

### DIFF
--- a/src/packages/rte/tiny-mce/property-editors/tiny-mce/manifests.ts
+++ b/src/packages/rte/tiny-mce/property-editors/tiny-mce/manifests.ts
@@ -46,7 +46,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 									{ alias: 'alignleft', label: 'Align left', icon: 'align-left' },
 									{ alias: 'aligncenter', label: 'Align center', icon: 'align-center' },
 									{ alias: 'alignright', label: 'Align right', icon: 'align-right' },
-									{ alias: 'alignjustify', label: 'Justify justify', icon: 'align-justify' },
+									{ alias: 'alignjustify', label: 'Align justify', icon: 'align-justify' },
 									{ alias: 'bullist', label: 'Bullet list', icon: 'unordered-list' },
 									{ alias: 'numlist', label: 'Numbered list', icon: 'ordered-list' },
 									{ alias: 'outdent', label: 'Outdent', icon: 'outdent' },

--- a/src/packages/rte/tiny-mce/property-editors/toolbar/property-editor-ui-tiny-mce-toolbar-configuration.element.ts
+++ b/src/packages/rte/tiny-mce/property-editors/toolbar/property-editor-ui-tiny-mce-toolbar-configuration.element.ts
@@ -114,17 +114,17 @@ export class UmbPropertyEditorUITinyMceToolbarConfigurationElement
 
 	override render() {
 		return html`<ul>
-			${repeat(
-				this._toolbarConfig,
-				(v) => v.alias,
+				${repeat(
+					this._toolbarConfig,
+					(v) => v.alias,
 				(v) =>
 					html`<li>
-						<uui-checkbox label=${v.label} value=${v.alias} ?checked=${v.selected} @change=${this.onChange}>
-							<uui-icon .svg=${tinyIconSet?.icons[v.icon ?? 'alignjustify']}></uui-icon>
+							<uui-checkbox label=${v.label} value=${v.alias} ?checked=${v.selected} @change=${this.onChange}>
+								<uui-icon .svg=${tinyIconSet?.icons[v.icon ?? 'alignjustify']}></uui-icon>
 							${v.label}
-						</uui-checkbox>
+							</uui-checkbox>
 					</li>`,
-			)}
+				)}
 		</ul>`;
 	}
 
@@ -135,6 +135,12 @@ export class UmbPropertyEditorUITinyMceToolbarConfigurationElement
 				list-style: none;
 				padding: 0;
 				margin: 0;
+
+				uui-icon {
+					width: 1.5em;
+					height: 1.5em;
+					margin-right: 5px;
+				}
 			}
 		`,
 	];


### PR DESCRIPTION
## Description

The layout of the TinyMCE toolbar configuration was a bit squashed. This PR amends the layout to space it out.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots (if appropriate)

**Before**
![Screenshot 2024-10-01 112110](https://github.com/user-attachments/assets/186f6ab1-d939-4859-a95d-31004221f292)

**After**
![Screenshot 2024-10-01 112047](https://github.com/user-attachments/assets/39e2238f-f27e-4dcd-ba82-b4c3f56ff38b)

