### PR TITLE
Tiptap: Renamed "umb-tiptap-fixed-menu" to "umb-tiptap-toolbar"

### DIFF
--- a/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -8,8 +8,8 @@ import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
 
-import './tiptap-fixed-menu.element.js';
 import './tiptap-hover-menu.element.js';
+import './tiptap-toolbar.element.js';
 
 const elementName = 'umb-input-tiptap';
 
@@ -121,11 +121,11 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 				!this._editor && !this._extensions?.length,
 				() => html`<div id="loader"><uui-loader></uui-loader></div>`,
 				() => html`
-					<umb-tiptap-fixed-menu
+					<umb-tiptap-toolbar
 						.toolbar=${this._toolbar}
 						.editor=${this._editor}
 						.configuration=${this.configuration}
-						?readonly=${this.readonly}></umb-tiptap-fixed-menu>
+						?readonly=${this.readonly}></umb-tiptap-toolbar>
 				`,
 			)}
 			<div id="editor"></div>

--- a/src/packages/tiptap/components/input-tiptap/tiptap-toolbar.element.ts
+++ b/src/packages/tiptap/components/input-tiptap/tiptap-toolbar.element.ts
@@ -8,10 +8,10 @@ import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/
 
 import '../toolbar/tiptap-toolbar-dropdown-base.element.js';
 
-const elementName = 'umb-tiptap-fixed-menu';
+const elementName = 'umb-tiptap-toolbar';
 
 @customElement(elementName)
-export class UmbTiptapFixedMenuElement extends UmbLitElement {
+export class UmbTiptapToolbarElement extends UmbLitElement {
 	#attached = false;
 	#extensionsController?: UmbExtensionsElementAndApiInitializer;
 
@@ -125,6 +125,6 @@ export class UmbTiptapFixedMenuElement extends UmbLitElement {
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbTiptapFixedMenuElement;
+		[elementName]: UmbTiptapToolbarElement;
 	}
 }


### PR DESCRIPTION
## Description

Renamed "umb-tiptap-fixed-menu" to "umb-tiptap-toolbar"
Since we refer to this as "toolbar" throughout the Tiptap feature.

## Types of changes

- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
