### PR TITLE
V15: Hotfix: Create dictionary collection action wrong path

### DIFF
--- a/src/packages/dictionary/collection/action/manifests.ts
+++ b/src/packages/dictionary/collection/action/manifests.ts
@@ -1,5 +1,11 @@
 import { UMB_DICTIONARY_ROOT_ENTITY_TYPE } from '../../entity.js';
+import { UMB_CREATE_DICTIONARY_WORKSPACE_PATH_PATTERN } from '../../workspace/index.js';
 import { UMB_COLLECTION_ALIAS_CONDITION } from '@umbraco-cms/backoffice/collection';
+
+const createPath = UMB_CREATE_DICTIONARY_WORKSPACE_PATH_PATTERN.generateAbsolute({
+	parentEntityType: UMB_DICTIONARY_ROOT_ENTITY_TYPE,
+	parentUnique: null,
+});
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -10,7 +16,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		weight: 200,
 		meta: {
 			label: '#general_create',
-			href: `section/dictionary/workspace/dictionary/create/parent/${UMB_DICTIONARY_ROOT_ENTITY_TYPE}/null`,
+			href: createPath,
 		},
 		conditions: [
 			{

--- a/src/packages/translation/menu/manifests.ts
+++ b/src/packages/translation/menu/manifests.ts
@@ -14,7 +14,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		name: 'Translation Sidebar Menu',
 		weight: 100,
 		meta: {
-			label: '#sections_translation',
+			label: '#general_dictionary', // We are using dictionary here on purpose until dictionary has its own menu item.
 			menu: UMB_TRANSLATION_MENU_ALIAS,
 			entityType: 'dictionary-root', // hard-coded on purpose to avoid circular dependency. We need another way to add actions to a menu kind.
 		},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Fixes the create dictionary collection action path
* Changes the Section Sidebar Menu title to dictionary until we have a dictionary menu item.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
