### PR TITLE
V15 Hotfix: Media previews are not shown for anything other than images

### DIFF
--- a/src/packages/media/media/components/input-upload-field/input-upload-field.element.ts
+++ b/src/packages/media/media/components/input-upload-field/input-upload-field.element.ts
@@ -79,6 +79,8 @@ export class UmbInputUploadFieldElement extends UmbLitElement {
 	}
 
 	async #getManifests() {
+		if (this.#manifests.length) return this.#manifests;
+
 		await new UmbExtensionsManifestInitializer(this, umbExtensionsRegistry, 'fileUploadPreview', null, (exts) => {
 			this.#manifests = exts.map((exts) => exts.manifest);
 		}).asPromise();

--- a/src/packages/media/media/components/input-upload-field/input-upload-field.element.ts
+++ b/src/packages/media/media/components/input-upload-field/input-upload-field.element.ts
@@ -13,6 +13,7 @@ import {
 	property,
 	query,
 	state,
+	type PropertyValueMap,
 } from '@umbraco-cms/backoffice/external/lit';
 import type { UUIFileDropzoneElement, UUIFileDropzoneEvent } from '@umbraco-cms/backoffice/external/uui';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
@@ -20,6 +21,7 @@ import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 
 import { UmbExtensionsManifestInitializer } from '@umbraco-cms/backoffice/extension-api';
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
+import { stringOrStringArrayContains } from '@umbraco-cms/backoffice/utils';
 
 @customElement('umb-input-upload-field')
 export class UmbInputUploadFieldElement extends UmbLitElement {

--- a/src/packages/media/media/components/input-upload-field/input-upload-field.element.ts
+++ b/src/packages/media/media/components/input-upload-field/input-upload-field.element.ts
@@ -73,7 +73,7 @@ export class UmbInputUploadFieldElement extends UmbLitElement {
 
 	override updated(changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>) {
 		super.updated(changedProperties);
-		if (changedProperties.has('value')) {
+		if (changedProperties.has('value') && changedProperties.get('value')?.src !== this.value.src) {
 			this.#setPreviewAlias();
 		}
 	}

--- a/src/packages/media/media/components/input-upload-field/input-upload-field.element.ts
+++ b/src/packages/media/media/components/input-upload-field/input-upload-field.element.ts
@@ -74,6 +74,14 @@ export class UmbInputUploadFieldElement extends UmbLitElement {
 
 	constructor() {
 		super();
+	}
+
+	override updated(changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>) {
+		super.updated(changedProperties);
+		if (changedProperties.has('value')) {
+			this.#setPreviewAlias();
+		}
+	}
 
 	async #getManifests() {
 		await new UmbExtensionsManifestInitializer(this, umbExtensionsRegistry, 'fileUploadPreview', null, (exts) => {
@@ -90,6 +98,10 @@ export class UmbInputUploadFieldElement extends UmbLitElement {
 		}
 		// TODO: The dropzone uui component does not support file extensions without a dot. Remove this when it does.
 		this._extensions = extensions?.map((extension) => `.${extension}`);
+	}
+
+	async #setPreviewAlias(): Promise<void> {
+		this._previewAlias = await this.#getPreviewElementAlias();
 	}
 
 	async #getPreviewElementAlias() {

--- a/src/packages/media/media/components/input-upload-field/input-upload-field.element.ts
+++ b/src/packages/media/media/components/input-upload-field/input-upload-field.element.ts
@@ -27,12 +27,16 @@ import { stringOrStringArrayContains } from '@umbraco-cms/backoffice/utils';
 export class UmbInputUploadFieldElement extends UmbLitElement {
 	@property({ type: Object })
 	set value(value: MediaValueType) {
-		if (!value?.src) return;
-		this.src = value.src;
+		this.#src = value?.src ?? '';
 	}
 	get value(): MediaValueType {
-		return !this.temporaryFile ? { src: this._src } : { temporaryFileId: this.temporaryFile.temporaryUnique };
+		return {
+			src: this.#src,
+			temporaryFileId: this.temporaryFile?.temporaryUnique,
+		};
 	}
+
+	#src = '';
 
 	/**
 	 * @description Allowed file extensions. Allow all if empty.
@@ -49,17 +53,6 @@ export class UmbInputUploadFieldElement extends UmbLitElement {
 
 	@state()
 	public temporaryFile?: UmbTemporaryFileModel;
-
-	public set src(src: string) {
-		this._src = src;
-		this._previewAlias = this.#getPreviewElementAlias();
-	}
-	public get src() {
-		return this._src;
-	}
-
-	@state()
-	private _src = '';
 
 	@state()
 	private _extensions?: string[];
@@ -162,7 +155,7 @@ export class UmbInputUploadFieldElement extends UmbLitElement {
 
 		const reader = new FileReader();
 		reader.onload = () => {
-			this.src = reader.result as string;
+			this.value = { src: reader.result as string };
 		};
 		reader.readAsDataURL(item.file);
 
@@ -180,8 +173,8 @@ export class UmbInputUploadFieldElement extends UmbLitElement {
 	}
 
 	override render() {
-		if (this.src && this._previewAlias) {
-			return this.#renderFile(this.src, this._previewAlias, this.temporaryFile?.file);
+		if (this.value.src && this._previewAlias) {
+			return this.#renderFile(this.value.src, this._previewAlias, this.temporaryFile?.file);
 		} else {
 			return this.#renderDropzone();
 		}
@@ -200,7 +193,7 @@ export class UmbInputUploadFieldElement extends UmbLitElement {
 		`;
 	}
 
-	#renderFile(src: string, previewAlias?: string, file?: File) {
+	#renderFile(src: string, previewAlias: string, file?: File) {
 		if (!previewAlias) return 'An error occurred. No previewer found for the file type.';
 		return html`
 			<div id="wrapper">
@@ -226,7 +219,7 @@ export class UmbInputUploadFieldElement extends UmbLitElement {
 	}
 
 	#handleRemove() {
-		this.src = '';
+		this.value = { src: undefined };
 		this.temporaryFile = undefined;
 		this.dispatchEvent(new UmbChangeEvent());
 	}


### PR DESCRIPTION
## Description

This fix adds an `await` to the manifests initializer so we are sure the manifests have been loaded before trying to calculate which preview element to show.

It also optimizes the element slightly to get rid of the `_src` state and to rely more on the `value` property.