### PR TITLE
hotfix: Rename condition config map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@umbraco-cms/backoffice",
-	"version": "15.0.0-rc1",
+	"version": "15.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@umbraco-cms/backoffice",
-			"version": "15.0.0-rc1",
+			"version": "15.1.0",
 			"license": "MIT",
 			"workspaces": [
 				"./src/packages/*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@umbraco-cms/backoffice",
-	"version": "15.1.0",
+	"version": "15.0.0-rc1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@umbraco-cms/backoffice",
-			"version": "15.1.0",
+			"version": "15.0.0-rc1",
 			"license": "MIT",
 			"workspaces": [
 				"./src/packages/*"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@umbraco-cms/backoffice",
 	"license": "MIT",
-	"version": "15.1.0",
+	"version": "15.0.0-rc1",
 	"type": "module",
 	"exports": {
 		".": null,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@umbraco-cms/backoffice",
 	"license": "MIT",
-	"version": "15.0.0-rc1",
+	"version": "15.1.0",
 	"type": "module",
 	"exports": {
 		".": null,

--- a/src/libs/extension-api/types/condition.types.ts
+++ b/src/libs/extension-api/types/condition.types.ts
@@ -4,23 +4,23 @@ export interface UmbConditionConfigBase<AliasType extends string = string> {
 	alias: AliasType;
 }
 
-export type ConditionTypeMap<ConditionTypes extends UmbConditionConfigBase> = {
-	[Condition in ConditionTypes as Condition['alias']]: Condition;
+export type ConditionTypeMap<ConditionConfigs extends UmbConditionConfigBase> = {
+	[Condition in ConditionConfigs as Condition['alias']]: Condition;
 } & {
 	[key: string]: UmbConditionConfigBase;
 };
 
 export type SpecificConditionTypeOrUmbConditionConfigBase<
-	ConditionTypes extends UmbConditionConfigBase,
-	T extends keyof ConditionTypeMap<ConditionTypes> | string,
-> = T extends keyof ConditionTypeMap<ConditionTypes> ? ConditionTypeMap<ConditionTypes>[T] : UmbConditionConfigBase;
+	ConditionConfigs extends UmbConditionConfigBase,
+	T extends keyof ConditionTypeMap<ConditionConfigs> | string,
+> = T extends keyof ConditionTypeMap<ConditionConfigs> ? ConditionTypeMap<ConditionConfigs>[T] : UmbConditionConfigBase;
 
-export interface ManifestWithDynamicConditions<ConditionTypes extends UmbConditionConfigBase = UmbConditionConfigBase>
+export interface ManifestWithDynamicConditions<ConditionConfigs extends UmbConditionConfigBase = UmbConditionConfigBase>
 	extends ManifestBase {
 	/**
 	 * Set the conditions for when the extension should be loaded
 	 */
-	conditions?: Array<ConditionTypes>;
+	conditions?: Array<ConditionConfigs>;
 	/**
 	 * Define one or more extension aliases that this extension should overwrite.
 	 */

--- a/src/packages/block/block/conditions/types.ts
+++ b/src/packages/block/block/conditions/types.ts
@@ -12,7 +12,7 @@ export interface BlockEntryIsExposedConditionConfig
 }
 
 declare global {
-	interface UmbExtensionConditionMap {
+	interface UmbExtensionConditionConfigMap {
 		umbBlock:
 			| BlockEntryShowContentEditConditionConfig
 			| BlockWorkspaceHasSettingsConditionConfig

--- a/src/packages/core/collection/extensions/collection-action.extension.ts
+++ b/src/packages/core/collection/extensions/collection-action.extension.ts
@@ -7,7 +7,7 @@ import type { ManifestElementAndApi, ManifestWithDynamicConditions } from '@umbr
 // TODO: create interface for API
 export interface ManifestCollectionAction
 	extends ManifestElementAndApi,
-		ManifestWithDynamicConditions<UmbExtensionCondition> {
+		ManifestWithDynamicConditions<UmbExtensionConditionConfig> {
 	type: 'collectionAction';
 	meta: MetaCollectionAction;
 }

--- a/src/packages/core/collection/extensions/collection-view.extension.ts
+++ b/src/packages/core/collection/extensions/collection-view.extension.ts
@@ -1,6 +1,8 @@
 import type { ManifestElement, ManifestWithDynamicConditions } from '@umbraco-cms/backoffice/extension-api';
 
-export interface ManifestCollectionView extends ManifestElement, ManifestWithDynamicConditions<UmbExtensionCondition> {
+export interface ManifestCollectionView
+	extends ManifestElement,
+		ManifestWithDynamicConditions<UmbExtensionConditionConfig> {
 	type: 'collectionView';
 	meta: MetaCollectionView;
 }

--- a/src/packages/core/collection/extensions/collection.extension.ts
+++ b/src/packages/core/collection/extensions/collection.extension.ts
@@ -2,7 +2,7 @@ import type { ManifestElementAndApi, ManifestWithDynamicConditions } from '@umbr
 
 export interface ManifestCollection
 	extends ManifestElementAndApi,
-		ManifestWithDynamicConditions<UmbExtensionCondition> {
+		ManifestWithDynamicConditions<UmbExtensionConditionConfig> {
 	type: 'collection';
 	meta: MetaCollection;
 }

--- a/src/packages/core/dashboard/dashboard.extension.ts
+++ b/src/packages/core/dashboard/dashboard.extension.ts
@@ -3,7 +3,7 @@ import type { ManifestElement, ManifestWithDynamicConditions } from '@umbraco-cm
 
 export interface ManifestDashboard
 	extends ManifestElement<UmbDashboardElement>,
-		ManifestWithDynamicConditions<UmbExtensionCondition> {
+		ManifestWithDynamicConditions<UmbExtensionConditionConfig> {
 	type: 'dashboard';
 	meta: MetaDashboard;
 }

--- a/src/packages/core/entity-action/entity-action.extension.ts
+++ b/src/packages/core/entity-action/entity-action.extension.ts
@@ -7,7 +7,7 @@ import type { UmbEntityAction, UmbEntityActionElement } from '@umbraco-cms/backo
  */
 export interface ManifestEntityAction<MetaType extends MetaEntityAction = MetaEntityAction>
 	extends ManifestElementAndApi<UmbEntityActionElement, UmbEntityAction<MetaType>>,
-		ManifestWithDynamicConditions<UmbExtensionCondition> {
+		ManifestWithDynamicConditions<UmbExtensionConditionConfig> {
 	type: 'entityAction';
 	forEntityTypes: Array<string>;
 	meta: MetaType;

--- a/src/packages/core/extension-registry/conditions/index.ts
+++ b/src/packages/core/extension-registry/conditions/index.ts
@@ -1,4 +1,4 @@
 export { UmbSwitchCondition } from './switch.condition.js';
 export { UmbConditionBase } from './condition-base.controller.js';
 
-export type { ConditionTypes } from './types.js';
+export type { UmbCoreConditionConfigs } from './types.js';

--- a/src/packages/core/extension-registry/conditions/types.ts
+++ b/src/packages/core/extension-registry/conditions/types.ts
@@ -3,11 +3,16 @@ import type { CollectionBulkActionPermissionConditionConfig } from '../../collec
 import type { SwitchConditionConfig } from './switch.condition.js';
 import type { UmbConditionConfigBase } from '@umbraco-cms/backoffice/extension-api';
 
-export type ConditionTypes =
+export type UmbCoreConditionConfigs =
 	| CollectionAliasConditionConfig
 	| CollectionBulkActionPermissionConditionConfig
 	| SwitchConditionConfig
 	| UmbConditionConfigBase;
+
+/**
+ * @deprecated instead use global UmbExtensionConditionConfig
+ */
+export type ConditionTypes = UmbCoreConditionConfigs;
 
 type UnionOfProperties<T> = T extends object ? T[keyof T] : never;
 
@@ -17,7 +22,7 @@ declare global {
 	 * @example
 	 ```js
  	 	declare global {
- 	 		interface UmbExtensionConditionMap {
+ 	 		interface UmbExtensionConditionConfigMap {
  	 			My_UNIQUE_CONDITION_NAME: MyExtensionConditionType;
   		}
   	}
@@ -25,19 +30,19 @@ declare global {
 	 If you have multiple types, you can declare them in this way:
 	 ```js
 		declare global {
-			interface UmbExtensionConditionMap {
+			interface UmbExtensionConditionConfigMap {
 				My_UNIQUE_CONDITION_NAME: MyExtensionConditionTypeA | MyExtensionConditionTypeB;
 			}
 		}
 	 ```
 	 */
-	interface UmbExtensionConditionMap {
-		UMB_CORE: ConditionTypes;
+	interface UmbExtensionConditionConfigMap {
+		UMB_CORE: UmbCoreConditionConfigs;
 	}
 
 	/**
 	 * This global type provides a union of all declared manifest types.
 	 * If this is a local package that declares additional Manifest Types, then these will also be included in this union.
 	 */
-	type UmbExtensionCondition = UnionOfProperties<UmbExtensionConditionMap>;
+	type UmbExtensionConditionConfig = UnionOfProperties<UmbExtensionConditionConfigMap>;
 }

--- a/src/packages/core/extension-registry/extensions/entity-bulk-action.extension.ts
+++ b/src/packages/core/extension-registry/extensions/entity-bulk-action.extension.ts
@@ -8,7 +8,7 @@ import type { ManifestElementAndApi, ManifestWithDynamicConditions } from '@umbr
  */
 export interface ManifestEntityBulkAction<MetaType extends MetaEntityBulkAction = MetaEntityBulkAction>
 	extends ManifestElementAndApi<UmbEntityBulkActionElement, UmbEntityBulkAction<MetaType>>,
-		ManifestWithDynamicConditions<UmbExtensionCondition> {
+		ManifestWithDynamicConditions<UmbExtensionConditionConfig> {
 	type: 'entityBulkAction';
 	forEntityTypes: Array<string>;
 	meta: MetaType;

--- a/src/packages/core/extension-registry/extensions/repository.extension.ts
+++ b/src/packages/core/extension-registry/extensions/repository.extension.ts
@@ -2,7 +2,7 @@ import type { UmbApi, ManifestApi, ManifestWithDynamicConditions } from '@umbrac
 // TODO: Consider adding a ClassType for this manifest. (Currently we cannot know the scope of a repository, therefor we are going with ExtensionApi for now.)
 export interface ManifestRepository<ApiType extends UmbApi = UmbApi>
 	extends ManifestApi<ApiType>,
-		ManifestWithDynamicConditions<UmbExtensionCondition> {
+		ManifestWithDynamicConditions<UmbExtensionConditionConfig> {
 	type: 'repository';
 }
 

--- a/src/packages/core/menu/menu-item.extension.ts
+++ b/src/packages/core/menu/menu-item.extension.ts
@@ -3,7 +3,7 @@ import type { ManifestWithDynamicConditions, ManifestElement } from '@umbraco-cm
 
 export interface ManifestMenuItem
 	extends ManifestElement<UmbMenuItemElement>,
-		ManifestWithDynamicConditions<UmbExtensionCondition> {
+		ManifestWithDynamicConditions<UmbExtensionConditionConfig> {
 	type: 'menuItem';
 	meta: MetaMenuItem;
 }

--- a/src/packages/core/property-action/extensions/property-action.extension.ts
+++ b/src/packages/core/property-action/extensions/property-action.extension.ts
@@ -4,7 +4,7 @@ import type { ManifestElementAndApi, ManifestWithDynamicConditions } from '@umbr
 
 export interface ManifestPropertyAction<MetaType extends MetaPropertyAction = MetaPropertyAction>
 	extends ManifestElementAndApi<UmbControllerHostElement, UmbPropertyAction<MetaType>>,
-		ManifestWithDynamicConditions<UmbExtensionCondition> {
+		ManifestWithDynamicConditions<UmbExtensionConditionConfig> {
 	type: 'propertyAction';
 	forPropertyEditorUis: string[];
 	meta: MetaType;

--- a/src/packages/core/section/conditions/types.ts
+++ b/src/packages/core/section/conditions/types.ts
@@ -25,7 +25,7 @@ export type SectionAliasConditionConfig = UmbConditionConfigBase<'Umb.Condition.
 };
 
 declare global {
-	interface UmbExtensionConditionMap {
+	interface UmbExtensionConditionConfigMap {
 		UmbSectionUserPermissionConditionConfig: UmbSectionUserPermissionConditionConfig;
 		UmbSectionAliasConditionConfig: SectionAliasConditionConfig;
 	}

--- a/src/packages/core/section/extensions/section-sidebar-app.extension.ts
+++ b/src/packages/core/section/extensions/section-sidebar-app.extension.ts
@@ -3,6 +3,6 @@ import type { UmbSectionSidebarAppElement } from '@umbraco-cms/backoffice/sectio
 
 export interface ManifestSectionSidebarApp
 	extends ManifestElement<UmbSectionSidebarAppElement>,
-		ManifestWithDynamicConditions<UmbExtensionCondition> {
+		ManifestWithDynamicConditions<UmbExtensionConditionConfig> {
 	type: 'sectionSidebarApp';
 }

--- a/src/packages/core/section/extensions/section-view.extension.ts
+++ b/src/packages/core/section/extensions/section-view.extension.ts
@@ -3,7 +3,7 @@ import type { ManifestElement, ManifestWithDynamicConditions } from '@umbraco-cm
 
 export interface ManifestSectionView
 	extends ManifestElement<UmbSectionViewElement>,
-		ManifestWithDynamicConditions<UmbExtensionCondition> {
+		ManifestWithDynamicConditions<UmbExtensionConditionConfig> {
 	type: 'sectionView';
 	meta: MetaSectionView;
 }

--- a/src/packages/core/section/extensions/section.extension.ts
+++ b/src/packages/core/section/extensions/section.extension.ts
@@ -3,7 +3,7 @@ import type { ManifestElement, ManifestWithDynamicConditions } from '@umbraco-cm
 
 export interface ManifestSection
 	extends ManifestElement<UmbSectionElement>,
-		ManifestWithDynamicConditions<UmbExtensionCondition> {
+		ManifestWithDynamicConditions<UmbExtensionConditionConfig> {
 	type: 'section';
 	meta: MetaSection;
 }

--- a/src/packages/core/tree/extensions/tree.extension.ts
+++ b/src/packages/core/tree/extensions/tree.extension.ts
@@ -1,6 +1,8 @@
 import type { ManifestElementAndApi, ManifestWithDynamicConditions } from '@umbraco-cms/backoffice/extension-api';
 
-export interface ManifestTree extends ManifestElementAndApi, ManifestWithDynamicConditions<UmbExtensionCondition> {
+export interface ManifestTree
+	extends ManifestElementAndApi,
+		ManifestWithDynamicConditions<UmbExtensionConditionConfig> {
 	type: 'tree';
 	meta: MetaTree;
 }

--- a/src/packages/core/workspace/conditions/types.ts
+++ b/src/packages/core/workspace/conditions/types.ts
@@ -51,7 +51,7 @@ export interface WorkspaceEntityIsNewConditionConfig
 }
 
 declare global {
-	interface UmbExtensionConditionMap {
+	interface UmbExtensionConditionConfigMap {
 		umbWorkspaceAlias: WorkspaceAliasConditionConfig;
 		umbWorkspaceContentTypeAlias: WorkspaceContentTypeAliasConditionConfig;
 		umbWorkspaceEntityType: WorkspaceEntityTypeConditionConfig;

--- a/src/packages/core/workspace/conditions/workspace-alias.condition.ts
+++ b/src/packages/core/workspace/conditions/workspace-alias.condition.ts
@@ -2,11 +2,7 @@ import { UMB_WORKSPACE_CONTEXT } from '../workspace.context-token.js';
 import type { UmbWorkspaceContext } from '../workspace-context.interface.js';
 import type { WorkspaceAliasConditionConfig } from './types.js';
 import { UmbConditionBase } from '@umbraco-cms/backoffice/extension-registry';
-import type {
-	ManifestCondition,
-	UmbConditionControllerArguments,
-	UmbExtensionCondition,
-} from '@umbraco-cms/backoffice/extension-api';
+import type { UmbConditionControllerArguments, UmbExtensionCondition } from '@umbraco-cms/backoffice/extension-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
 export class UmbWorkspaceAliasCondition
@@ -35,7 +31,7 @@ export class UmbWorkspaceAliasCondition
 	}
 }
 
-export const manifest: ManifestCondition = {
+export const manifest: UmbExtensionManifest = {
 	type: 'condition',
 	name: 'Workspace Alias Condition',
 	alias: 'Umb.Condition.WorkspaceAlias',

--- a/src/packages/core/workspace/conditions/workspace-content-type-alias.condition.ts
+++ b/src/packages/core/workspace/conditions/workspace-content-type-alias.condition.ts
@@ -2,11 +2,7 @@ import { UmbConditionBase } from '../../extension-registry/conditions/condition-
 import type { WorkspaceContentTypeAliasConditionConfig } from './types.js';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UMB_PROPERTY_STRUCTURE_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/workspace';
-import type {
-	ManifestCondition,
-	UmbConditionControllerArguments,
-	UmbExtensionCondition,
-} from '@umbraco-cms/backoffice/extension-api';
+import type { UmbConditionControllerArguments, UmbExtensionCondition } from '@umbraco-cms/backoffice/extension-api';
 
 const ObserveSymbol = Symbol();
 
@@ -49,7 +45,7 @@ export class UmbWorkspaceContentTypeAliasCondition
 	}
 }
 
-export const manifest: ManifestCondition = {
+export const manifest: UmbExtensionManifest = {
 	type: 'condition',
 	name: 'Workspace Content Type Alias Condition',
 	alias: 'Umb.Condition.WorkspaceContentTypeAlias',

--- a/src/packages/core/workspace/conditions/workspace-entity-is-new.condition.ts
+++ b/src/packages/core/workspace/conditions/workspace-entity-is-new.condition.ts
@@ -2,11 +2,7 @@ import { UMB_SUBMITTABLE_WORKSPACE_CONTEXT } from '../index.js';
 import type { WorkspaceEntityIsNewConditionConfig } from './types.js';
 import { UMB_WORKSPACE_ENTITY_IS_NEW_CONDITION } from './const.js';
 import { UmbConditionBase } from '@umbraco-cms/backoffice/extension-registry';
-import type {
-	ManifestCondition,
-	UmbConditionControllerArguments,
-	UmbExtensionCondition,
-} from '@umbraco-cms/backoffice/extension-api';
+import type { UmbConditionControllerArguments, UmbExtensionCondition } from '@umbraco-cms/backoffice/extension-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
 const ObserveSymbol = Symbol();
@@ -33,7 +29,7 @@ export class UmbWorkspaceEntityIsNewCondition
 	}
 }
 
-export const manifest: ManifestCondition = {
+export const manifest: UmbExtensionManifest = {
 	type: 'condition',
 	name: 'Workspace Entity Is New Condition',
 	alias: UMB_WORKSPACE_ENTITY_IS_NEW_CONDITION,

--- a/src/packages/core/workspace/conditions/workspace-entity-type.condition.ts
+++ b/src/packages/core/workspace/conditions/workspace-entity-type.condition.ts
@@ -1,11 +1,7 @@
 import { UMB_WORKSPACE_CONTEXT } from '../workspace.context-token.js';
 import type { WorkspaceEntityTypeConditionConfig } from './types.js';
 import { UmbConditionBase } from '@umbraco-cms/backoffice/extension-registry';
-import type {
-	ManifestCondition,
-	UmbConditionControllerArguments,
-	UmbExtensionCondition,
-} from '@umbraco-cms/backoffice/extension-api';
+import type { UmbConditionControllerArguments, UmbExtensionCondition } from '@umbraco-cms/backoffice/extension-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
 export class UmbWorkspaceEntityTypeCondition
@@ -20,7 +16,7 @@ export class UmbWorkspaceEntityTypeCondition
 	}
 }
 
-export const manifest: ManifestCondition = {
+export const manifest: UmbExtensionManifest = {
 	type: 'condition',
 	name: 'Workspace Entity Type Condition',
 	alias: 'Umb.Condition.WorkspaceEntityType',

--- a/src/packages/core/workspace/conditions/workspace-has-collection.condition.ts
+++ b/src/packages/core/workspace/conditions/workspace-has-collection.condition.ts
@@ -2,11 +2,7 @@ import { UMB_CONTENT_COLLECTION_WORKSPACE_CONTEXT } from '../../content/collecti
 import type { WorkspaceHasCollectionConditionConfig } from './types.js';
 import { UMB_WORKSPACE_HAS_COLLECTION_CONDITION } from './const.js';
 import { UmbConditionBase } from '@umbraco-cms/backoffice/extension-registry';
-import type {
-	ManifestCondition,
-	UmbConditionControllerArguments,
-	UmbExtensionCondition,
-} from '@umbraco-cms/backoffice/extension-api';
+import type { UmbConditionControllerArguments, UmbExtensionCondition } from '@umbraco-cms/backoffice/extension-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
 const ObserveSymbol = Symbol();
@@ -30,7 +26,7 @@ export class UmbWorkspaceHasCollectionCondition
 	}
 }
 
-export const manifest: ManifestCondition = {
+export const manifest: UmbExtensionManifest = {
 	type: 'condition',
 	name: 'Workspace Has Collection Condition',
 	alias: UMB_WORKSPACE_HAS_COLLECTION_CONDITION,

--- a/src/packages/core/workspace/extensions/workspace-action-menu-item.model.ts
+++ b/src/packages/core/workspace/extensions/workspace-action-menu-item.model.ts
@@ -5,7 +5,7 @@ import type { ManifestElementAndApi, ManifestWithDynamicConditions } from '@umbr
 export interface ManifestWorkspaceActionMenuItem<
 	MetaType extends MetaWorkspaceActionMenuItem = MetaWorkspaceActionMenuItem,
 > extends ManifestElementAndApi<UmbControllerHostElement, UmbWorkspaceActionMenuItem<MetaType>>,
-		ManifestWithDynamicConditions<UmbExtensionCondition> {
+		ManifestWithDynamicConditions<UmbExtensionConditionConfig> {
 	type: 'workspaceActionMenuItem';
 	/**
 	 * Define which workspace actions this menu item should be shown for.

--- a/src/packages/core/workspace/extensions/workspace-action.model.ts
+++ b/src/packages/core/workspace/extensions/workspace-action.model.ts
@@ -5,7 +5,7 @@ import type { UmbControllerHostElement } from '@umbraco-cms/backoffice/controlle
 
 export interface ManifestWorkspaceAction<MetaType extends MetaWorkspaceAction = MetaWorkspaceAction>
 	extends ManifestElementAndApi<UmbControllerHostElement, UmbWorkspaceAction<MetaType>>,
-		ManifestWithDynamicConditions<UmbExtensionCondition> {
+		ManifestWithDynamicConditions<UmbExtensionConditionConfig> {
 	type: 'workspaceAction';
 	meta: MetaType;
 }

--- a/src/packages/core/workspace/extensions/workspace-context.model.ts
+++ b/src/packages/core/workspace/extensions/workspace-context.model.ts
@@ -1,7 +1,7 @@
 import type { ManifestApi, ManifestWithDynamicConditions, UmbApi } from '@umbraco-cms/backoffice/extension-api';
 
 export interface ManifestWorkspaceContext
-	extends ManifestWithDynamicConditions<UmbExtensionCondition>,
+	extends ManifestWithDynamicConditions<UmbExtensionConditionConfig>,
 		ManifestApi<UmbApi> {
 	type: 'workspaceContext';
 }

--- a/src/packages/core/workspace/extensions/workspace-footer-app.model.ts
+++ b/src/packages/core/workspace/extensions/workspace-footer-app.model.ts
@@ -3,7 +3,7 @@ import type { ManifestElementAndApi, ManifestWithDynamicConditions } from '@umbr
 
 export interface ManifestWorkspaceFooterApp
 	extends ManifestElementAndApi<UmbControllerHostElement, any>,
-		ManifestWithDynamicConditions<UmbExtensionCondition> {
+		ManifestWithDynamicConditions<UmbExtensionConditionConfig> {
 	type: 'workspaceFooterApp';
 }
 

--- a/src/packages/core/workspace/extensions/workspace-view.model.ts
+++ b/src/packages/core/workspace/extensions/workspace-view.model.ts
@@ -10,7 +10,7 @@ export interface UmbWorkspaceViewElement extends HTMLElement {
 
 export interface ManifestWorkspaceView<MetaType extends MetaWorkspaceView = MetaWorkspaceView>
 	extends ManifestWithView<UmbWorkspaceViewElement>,
-		ManifestWithDynamicConditions<UmbExtensionCondition> {
+		ManifestWithDynamicConditions<UmbExtensionConditionConfig> {
 	type: 'workspaceView';
 	meta: MetaType;
 }

--- a/src/packages/documents/documents/user-permissions/conditions/types.ts
+++ b/src/packages/documents/documents/user-permissions/conditions/types.ts
@@ -18,7 +18,7 @@ export type UmbDocumentUserPermissionConditionConfig =
 	};
 
 declare global {
-	interface UmbExtensionConditionMap {
+	interface UmbExtensionConditionConfigMap {
 		UmbDocumentUserPermissionConditionConfig: UmbDocumentUserPermissionConditionConfig;
 	}
 }

--- a/src/packages/user/current-user/current-user-action.extension.ts
+++ b/src/packages/user/current-user/current-user-action.extension.ts
@@ -23,7 +23,7 @@ export interface UmbCurrentUserAction<ArgsMetaType = never> extends UmbAction<Um
 
 export interface ManifestCurrentUserAction<MetaType extends MetaCurrentUserAction = MetaCurrentUserAction>
 	extends ManifestElementAndApi<UmbControllerHostElement, UmbCurrentUserAction<MetaType>>,
-		ManifestWithDynamicConditions<UmbExtensionCondition> {
+		ManifestWithDynamicConditions<UmbExtensionConditionConfig> {
 	type: 'currentUserAction';
 	meta: MetaType;
 }


### PR DESCRIPTION
Renames a few interfaces so it becomes more clear what the intend is — easier to understand as a extension developer.

`global`:
`UmbExtensionConditionMap` -> `UmbExtensionConditionConfigMap`
`UmbExtensionCondition` -> `UmbExtensionConditionConfig`

`@umbraco-cms/backoffice/extension-registry`:
`ConditionTypes`-> `UmbCoreConditionConfigs` (still available as deprecated interface, but should in general not be used as of v15, instead implementations should use `UmbExtensionConditionConfig`)

## Description

<!--- Describe the changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
