### PR TITLE
Fix/17179 block grid data label

### DIFF
--- a/src/packages/block/block-grid/components/block-grid-entries/block-grid-entries.element.ts
+++ b/src/packages/block/block-grid/components/block-grid-entries/block-grid-entries.element.ts
@@ -152,6 +152,7 @@ export class UmbBlockGridEntriesElement extends UmbFormControlMixin(UmbLitElemen
 			//new UmbBindServerValidationToFormControl(this, this, "$.values.[?(@.alias = 'my-input-alias')].value");
 		}
 	}
+
 	public get areaKey(): string | null | undefined {
 		return this._areaKey;
 	}
@@ -160,6 +161,7 @@ export class UmbBlockGridEntriesElement extends UmbFormControlMixin(UmbLitElemen
 	public set layoutColumns(value: number | undefined) {
 		this.#context.setLayoutColumns(value);
 	}
+
 	public get layoutColumns(): number | undefined {
 		return this.#context.getLayoutColumns();
 	}
@@ -396,6 +398,7 @@ export class UmbBlockGridEntriesElement extends UmbFormControlMixin(UmbLitElemen
 				display: grid;
 				gap: 1px;
 			}
+
 			:host([disallow-drop])::before {
 				content: '';
 				position: absolute;
@@ -405,6 +408,7 @@ export class UmbBlockGridEntriesElement extends UmbFormControlMixin(UmbLitElemen
 				border-radius: calc(var(--uui-border-radius) * 2);
 				pointer-events: none;
 			}
+
 			:host([disallow-drop])::after {
 				content: '';
 				position: absolute;
@@ -429,10 +433,12 @@ export class UmbBlockGridEntriesElement extends UmbFormControlMixin(UmbLitElemen
 			}
 
 			// Only when we are n an area, we like to hide the button on drag
+
 			:host([area-key]) #createButton {
 				--umb-block-grid--is-dragging--variable: var(--umb-block-grid--is-dragging) none;
 				display: var(--umb-block-grid--is-dragging--variable, grid);
 			}
+
 			:host(:not([pristine]):invalid) #createButton {
 				--uui-button-contrast: var(--uui-color-danger);
 				--uui-button-contrast-hover: var(--uui-color-danger);

--- a/src/packages/block/block-grid/context/block-grid-entries.context.ts
+++ b/src/packages/block/block-grid/context/block-grid-entries.context.ts
@@ -51,6 +51,9 @@ export class UmbBlockGridEntriesContext
 	#layoutColumns = new UmbNumberState(undefined);
 	readonly layoutColumns = this.#layoutColumns.asObservable();
 
+	#createLabel = new UmbStringState(undefined);
+	readonly createLabel = this.#createLabel.asObservable();
+
 	#areaType?: UmbBlockGridTypeAreaType;
 
 	#parentUnique?: string | null;
@@ -222,6 +225,14 @@ export class UmbBlockGridEntriesContext
 				this.#workspaceModal.setUniquePathValue('propertyAlias', alias ?? 'null');
 			},
 			'observePropertyAlias',
+		);
+
+		this.observe(
+			this._manager.createLabel,
+			(label) => {
+				this.#createLabel.setValue(label ?? 'Add Block');
+			},
+			'observeCreateLabel',
 		);
 	}
 

--- a/src/packages/block/block-grid/context/block-grid-manager.context.ts
+++ b/src/packages/block/block-grid/context/block-grid-manager.context.ts
@@ -62,9 +62,11 @@ export class UmbBlockGridManagerContext<
 	setBlockGroups(blockGroups: Array<UmbBlockTypeGroup>) {
 		this.#blockGroups.setValue(blockGroups);
 	}
+
 	getBlockGroups() {
 		return this.#blockGroups.value;
 	}
+
 	getBlockGroupName(unique: string) {
 		return this.#blockGroups.getValue().find((group) => group.key === unique)?.name;
 	}

--- a/src/packages/block/block-grid/context/block-grid-manager.context.ts
+++ b/src/packages/block/block-grid/context/block-grid-manager.context.ts
@@ -38,6 +38,9 @@ export class UmbBlockGridManagerContext<
 		const value = x?.getValueByAlias('gridColumns') as string | undefined;
 		return parseInt(value && value !== '' ? value : '12');
 	});
+	createLabel = this._editorConfiguration.asObservablePart((x) => {
+		return x?.getValueByAlias<string>('createLabel');
+	});
 
 	getMinAllowed() {
 		return this._editorConfiguration.getValue()?.getValueByAlias<UmbNumberRangeValueType>('validationLimit')?.min ?? 0;


### PR DESCRIPTION
## Description

This pull request introduces refactorings to the `UmbBlockGridEntriesElement` and related context classes. The most important changes include adding new state properties to manage labels, updating methods to utilize these properties

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

### Enhancements to Label Management:

* Added `@state` properties `_resolvedCreateLabel` and `_createLabel` to `UmbBlockGridEntriesElement` to manage dynamic label content. (`src/packages/block/block-grid/components/block-grid-entries/block-grid-entries.element.ts`)
** Introduced `#finalizeCreateLabel` method to determine the appropriate label text based on context and state. (`src/packages/block/block-grid/components/block-grid-entries/block-grid-entries.element.ts`)
* Updated the button label in the template to use `_resolvedCreateLabel`. (`src/packages/block/block-grid/components/block-grid-entries/block-grid-entries.element.ts`)

### Context Class Updates:

* Added `#createLabel` state and corresponding observable in `UmbBlockGridEntriesContext`. (`src/packages/block/block-grid/context/block-grid-entries.context.ts`)
* Observed `createLabel` from `UmbBlockGridManagerContext` and updated `#createLabel` in `UmbBlockGridEntriesContext`. (`src/packages/block/block-grid/context/block-grid-entries.context.ts`)
* Added `createLabel` observable part in `UmbBlockGridManagerContext` to provide label configuration. (`src/packages/block/block-grid/context/block-grid-manager.context.ts`)

fixes https://github.com/umbraco/Umbraco-CMS/issues/17179
