### PR TITLE
style: increase z-index of element in installer layout

### DIFF
--- a/src/apps/installer/shared/layout/installer-layout.element.ts
+++ b/src/apps/installer/shared/layout/installer-layout.element.ts
@@ -49,6 +49,7 @@ export class UmbInstallerLayoutElement extends LitElement {
 				top: var(--uui-size-space-5);
 				left: var(--uui-size-space-5);
 				height: 30px;
+				z-index: 10;
 			}
 
 			#logo img {


### PR DESCRIPTION
## Description

This adds a z-index: 10 to the logo so it's always on top, this behaves nicely on multiple dimensions. 

Fixes:[#17105](https://github.com/umbraco/Umbraco-CMS/issues/17105)


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Screenshots (if appropriate)
At raised issue dimensions:
![image](https://github.com/user-attachments/assets/faef09fc-a46b-4e07-9656-fe5fddce3d1e)

1024 x 894
![image](https://github.com/user-attachments/assets/04960ad6-4929-4235-8375-bd0cfd95921f)
