### PR TITLE
Bugfix: Uploadfield file preview shows file extension

### DIFF
--- a/src/packages/media/media/components/input-upload-field/preview/input-upload-field-file.element.ts
+++ b/src/packages/media/media/components/input-upload-field/preview/input-upload-field-file.element.ts
@@ -24,6 +24,8 @@ export default class UmbInputUploadFieldFileElement extends UmbLitElement {
 
 	#serverUrl = '';
 
+	#loadingText = `(${this.localize.term('general_loading')}...)`;
+
 	/**
 	 *
 	 */
@@ -37,8 +39,8 @@ export default class UmbInputUploadFieldFileElement extends UmbLitElement {
 	protected override updated(_changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>): void {
 		super.updated(_changedProperties);
 		if (_changedProperties.has('file') && this.file) {
-			this.extension = this.#getExtensionFromMime(this.file.type) ?? '';
-			this.label = this.file.name || 'loading...';
+			this.extension = this.file.name.split('.').pop() ?? '';
+			this.label = this.file.name || this.#loadingText;
 		}
 
 		if (_changedProperties.has('path')) {
@@ -46,19 +48,8 @@ export default class UmbInputUploadFieldFileElement extends UmbLitElement {
 				if (this.file) return;
 
 				this.extension = this.path.split('.').pop() ?? '';
-				this.label = this.#serverUrl ? this.path.substring(this.#serverUrl.length) : 'loading...';
+				this.label = this.#serverUrl ? this.path.substring(this.#serverUrl.length) : this.#loadingText;
 			}
-		}
-	}
-
-	#getExtensionFromMime(mime: string): string {
-		if (!mime) return ''; //folders
-
-		const extension = mime.split('/')[1];
-		if (extension === 'svg+xml') {
-			return 'svg';
-		} else {
-			return extension;
 		}
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed a bug where the file extension type would not be shown on custom files (forexample `.udt` files).
Added localization

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

Example (not fixed):
![image](https://github.com/user-attachments/assets/a6c8d278-3f75-41e9-ad04-fdb42ae5a0c3)

Example (fixed):
![image](https://github.com/user-attachments/assets/8b7b7547-db0f-49d9-8cb0-61bc2387d4dc)


