### PR TITLE
Make Tree Title Section Clickable 

### DIFF
--- a/src/packages/core/menu/section-sidebar-menu-with-entity-actions/section-sidebar-menu-with-entity-actions.element.ts
+++ b/src/packages/core/menu/section-sidebar-menu-with-entity-actions/section-sidebar-menu-with-entity-actions.element.ts
@@ -21,7 +21,12 @@ export class UmbSectionSidebarMenuWithEntityActionsElement extends UmbSectionSid
 	override renderHeader() {
 		return html`
 			<div id="header">
-				<h3>${this.localize.string(this.manifest?.meta?.label ?? '')}</h3>
+			${this.manifest?.meta?.path 
+			? html`<a id="default-nav" href="${this.localize.string(this.manifest.meta.path)}">
+					 <h3>${this.localize.string(this.manifest.meta.label ?? '')}</h3>
+				   </a>`
+			: html`<h3>${this.localize.string(this.manifest?.meta?.label ?? '')}</h3>`
+		  }
 				<umb-entity-actions-bundle
 					slot="actions"
 					.unique=${null}
@@ -42,6 +47,15 @@ export class UmbSectionSidebarMenuWithEntityActionsElement extends UmbSectionSid
 			}
 			#header > :first-child {
 				flex-grow: 1;
+			}
+			#default-nav {
+				text-decoration: none;
+				color: inherit;
+			}
+
+			#default-nav:hover {
+				text-decoration: none;
+				color: inherit;
 			}
 		`,
 	];

--- a/src/packages/core/menu/section-sidebar-menu/section-sidebar-menu.element.ts
+++ b/src/packages/core/menu/section-sidebar-menu/section-sidebar-menu.element.ts
@@ -27,8 +27,15 @@ export class UmbSectionSidebarMenuElement<
 	manifest?: ManifestType;
 
 	renderHeader() {
-		return html`<h3>${this.localize.string(this.manifest?.meta?.label ?? '')}</h3>`;
-	}
+		return html`
+		  ${this.manifest?.meta?.path 
+			? html`<a id="default-nav" href="${this.localize.string(this.manifest.meta.path)}">
+					 <h3>${this.localize.string(this.manifest.meta.label ?? '')}</h3>
+				   </a>`
+			: html`<h3>${this.localize.string(this.manifest?.meta?.label ?? '')}</h3>`
+		  }
+		`;
+	  }
 
 	override render() {
 		return html`
@@ -45,6 +52,15 @@ export class UmbSectionSidebarMenuElement<
 		css`
 			h3 {
 				padding: var(--uui-size-4) var(--uui-size-8);
+			}
+			#default-nav {
+				text-decoration: none;
+				color: inherit;
+			}
+
+			#default-nav:hover {
+				text-decoration: none;
+				color: inherit;
 			}
 		`,
 	];

--- a/src/packages/core/menu/section-sidebar-menu/types.ts
+++ b/src/packages/core/menu/section-sidebar-menu/types.ts
@@ -3,6 +3,7 @@ import type { ManifestSectionSidebarApp } from '@umbraco-cms/backoffice/section'
 export interface MetaSectionSidebarAppMenuKind {
 	label: string;
 	menu: string;
+	path:string;
 }
 
 export interface ManifestSectionSidebarAppBaseMenu extends ManifestSectionSidebarApp {

--- a/src/packages/documents/section/manifests.ts
+++ b/src/packages/documents/section/manifests.ts
@@ -26,6 +26,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		weight: 100,
 		meta: {
 			label: '#sections_content',
+			path: '/section/content/dashboard/dashboardTabsContentIntro',
 			menu: UMB_CONTENT_MENU_ALIAS,
 			entityType: UMB_DOCUMENT_ROOT_ENTITY_TYPE,
 		},

--- a/src/packages/media/media-section/manifests.ts
+++ b/src/packages/media/media-section/manifests.ts
@@ -1,3 +1,4 @@
+import { path } from '@umbraco-cms/backoffice/router';
 import { UMB_MEDIA_ROOT_ENTITY_TYPE, UMB_MEDIA_MENU_ALIAS } from '../media/index.js';
 
 const sectionAlias = 'Umb.Section.Media';
@@ -29,6 +30,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: '#sections_media',
 			menu: UMB_MEDIA_MENU_ALIAS,
 			entityType: UMB_MEDIA_ROOT_ENTITY_TYPE,
+			path:'/section/media/view/media/collection/grid'
 		},
 		conditions: [
 			{

--- a/src/packages/media/media-section/manifests.ts
+++ b/src/packages/media/media-section/manifests.ts
@@ -1,4 +1,3 @@
-import { path } from '@umbraco-cms/backoffice/router';
 import { UMB_MEDIA_ROOT_ENTITY_TYPE, UMB_MEDIA_MENU_ALIAS } from '../media/index.js';
 
 const sectionAlias = 'Umb.Section.Media';

--- a/src/packages/settings/structure/manifests.ts
+++ b/src/packages/settings/structure/manifests.ts
@@ -17,6 +17,7 @@ export const manifests: Array<UmbExtensionManifest | UmbExtensionManifestKind> =
 		meta: {
 			label: '#treeHeaders_structureGroup',
 			menu: UMB_STRUCTURE_SETTINGS_MENU_ALIAS,
+			path:'/section/settings/dashboard/welcome'
 		},
 		conditions: [
 			{

--- a/src/packages/translation/menu/manifests.ts
+++ b/src/packages/translation/menu/manifests.ts
@@ -1,4 +1,3 @@
-import { path } from '@umbraco-cms/backoffice/router';
 import { UMB_TRANSLATION_SECTION_ALIAS } from '../section/index.js';
 import { UMB_TRANSLATION_MENU_ALIAS } from './constants.js';
 

--- a/src/packages/translation/menu/manifests.ts
+++ b/src/packages/translation/menu/manifests.ts
@@ -1,3 +1,4 @@
+import { path } from '@umbraco-cms/backoffice/router';
 import { UMB_TRANSLATION_SECTION_ALIAS } from '../section/index.js';
 import { UMB_TRANSLATION_MENU_ALIAS } from './constants.js';
 
@@ -17,6 +18,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: '#general_dictionary', // We are using dictionary here on purpose until dictionary has its own menu item.
 			menu: UMB_TRANSLATION_MENU_ALIAS,
 			entityType: 'dictionary-root', // hard-coded on purpose to avoid circular dependency. We need another way to add actions to a menu kind.
+			path:'/section/translation/dashboard/dictionary-overview/table'
 		},
 		conditions: [
 			{

--- a/src/packages/user/section/sidebar-app/manifests.ts
+++ b/src/packages/user/section/sidebar-app/manifests.ts
@@ -1,4 +1,3 @@
-import { path } from '@umbraco-cms/backoffice/router';
 import { UMB_USER_MANAGEMENT_SECTION_ALIAS } from '../constants.js';
 import { UMB_USER_MANAGEMENT_MENU_ALIAS } from '../menu/index.js';
 

--- a/src/packages/user/section/sidebar-app/manifests.ts
+++ b/src/packages/user/section/sidebar-app/manifests.ts
@@ -1,3 +1,4 @@
+import { path } from '@umbraco-cms/backoffice/router';
 import { UMB_USER_MANAGEMENT_SECTION_ALIAS } from '../constants.js';
 import { UMB_USER_MANAGEMENT_MENU_ALIAS } from '../menu/index.js';
 
@@ -11,6 +12,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			label: '#treeHeaders_users',
 			menu: UMB_USER_MANAGEMENT_MENU_ALIAS,
+			path:'/section/user-management'
 		},
 		conditions: [
 			{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR fixes this issue on Umbraco-Cms Repo 

https://github.com/umbraco/Umbraco-CMS/issues/17203

this simply made the tree title clickable for a configurable href 


<!--- Describe the changes in detail -->

I have added a new property in the `MetaSectionSidebarAppMenuKind` called `path` in which we can provide the href that we would like the title to take us to. 

and I have added the path value for the current tree Title as in the PR Bellow.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
