### PR TITLE
Bugfix: Allow/disallow multiple files for dropzone

### DIFF
--- a/src/packages/media/media/collection/media-collection.element.ts
+++ b/src/packages/media/media/collection/media-collection.element.ts
@@ -54,6 +54,7 @@ export class UmbMediaCollectionElement extends UmbCollectionDefaultElement {
 			<umb-media-collection-toolbar slot="header"></umb-media-collection-toolbar>
 			${when(this._progress >= 0, () => html`<uui-loader-bar progress=${this._progress}></uui-loader-bar>`)}
 			<umb-dropzone
+				multiple
 				.parentUnique=${this._unique}
 				@complete=${this.#onComplete}
 				@progress=${this.#onProgress}></umb-dropzone>

--- a/src/packages/media/media/collection/media-collection.element.ts
+++ b/src/packages/media/media/collection/media-collection.element.ts
@@ -54,7 +54,6 @@ export class UmbMediaCollectionElement extends UmbCollectionDefaultElement {
 			<umb-media-collection-toolbar slot="header"></umb-media-collection-toolbar>
 			${when(this._progress >= 0, () => html`<uui-loader-bar progress=${this._progress}></uui-loader-bar>`)}
 			<umb-dropzone
-				multiple
 				.parentUnique=${this._unique}
 				@complete=${this.#onComplete}
 				@progress=${this.#onProgress}></umb-dropzone>

--- a/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
+++ b/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
@@ -346,7 +346,7 @@ export class UmbInputRichMediaElement extends UUIFormControlMixin(UmbLitElement,
 	#renderDropzone() {
 		if (this.readonly) return nothing;
 		if (this._cards && this._cards.length >= this.max) return;
-		return html`<umb-dropzone @complete=${this.#onUploadCompleted}></umb-dropzone>`;
+		return html`<umb-dropzone ?multiple=${this.max > 1} @complete=${this.#onUploadCompleted}></umb-dropzone>`;
 	}
 
 	#renderItems() {

--- a/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
+++ b/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
@@ -346,7 +346,7 @@ export class UmbInputRichMediaElement extends UUIFormControlMixin(UmbLitElement,
 	#renderDropzone() {
 		if (this.readonly) return nothing;
 		if (this._cards && this._cards.length >= this.max) return;
-		return html`<umb-dropzone ?multiple=${this.max > 1} @complete=${this.#onUploadCompleted}></umb-dropzone>`;
+		return html`<umb-dropzone @complete=${this.#onUploadCompleted}></umb-dropzone>`;
 	}
 
 	#renderItems() {

--- a/src/packages/media/media/dropzone/dropzone.element.ts
+++ b/src/packages/media/media/dropzone/dropzone.element.ts
@@ -10,13 +10,13 @@ export class UmbDropzoneElement extends UmbLitElement {
 	parentUnique: string | null = null;
 
 	@property({ type: Boolean })
-	multiple: boolean = true;
-
-	@property({ type: Boolean })
 	createAsTemporary: boolean = false;
 
 	@property({ type: String })
 	accept?: string;
+
+	@property({ type: Boolean, reflect: true })
+	multiple: boolean = false;
 
 	@property({ type: Boolean, reflect: true })
 	disabled = false;

--- a/src/packages/media/media/dropzone/dropzone.element.ts
+++ b/src/packages/media/media/dropzone/dropzone.element.ts
@@ -10,13 +10,13 @@ export class UmbDropzoneElement extends UmbLitElement {
 	parentUnique: string | null = null;
 
 	@property({ type: Boolean })
+	multiple: boolean = true;
+
+	@property({ type: Boolean })
 	createAsTemporary: boolean = false;
 
 	@property({ type: String })
 	accept?: string;
-
-	@property({ type: Boolean, reflect: true })
-	multiple: boolean = false;
 
 	@property({ type: Boolean, reflect: true })
 	disabled = false;

--- a/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
+++ b/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
@@ -168,7 +168,7 @@ export class UmbMediaPickerModalElement extends UmbModalBaseElement<
 
 	#renderBody() {
 		return html`${this.#renderToolbar()}
-		<umb-dropzone id="dropzone" @complete=${() => this.#loadMediaFolder()} .parentUnique=${this._currentMediaEntity.unique}></umb-dropzone>
+		<umb-dropzone id="dropzone" multiple @complete=${() => this.#loadMediaFolder()} .parentUnique=${this._currentMediaEntity.unique}></umb-dropzone>
 				${
 					!this._mediaFilteredList.length
 						? html`<div class="container"><p>${this.localize.term('content_listViewNoItems')}</p></div>`

--- a/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
+++ b/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
@@ -168,7 +168,7 @@ export class UmbMediaPickerModalElement extends UmbModalBaseElement<
 
 	#renderBody() {
 		return html`${this.#renderToolbar()}
-		<umb-dropzone id="dropzone" multiple @complete=${() => this.#loadMediaFolder()} .parentUnique=${this._currentMediaEntity.unique}></umb-dropzone>
+		<umb-dropzone id="dropzone" @complete=${() => this.#loadMediaFolder()} .parentUnique=${this._currentMediaEntity.unique}></umb-dropzone>
 				${
 					!this._mediaFilteredList.length
 						? html`<div class="container"><p>${this.localize.term('content_listViewNoItems')}</p></div>`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Original text from [PR #2258](https://github.com/umbraco/Umbraco.CMS.Backoffice/pull/2258)
From my testing it is not possible to make a boolean property `false` if it's by default `true` therefore the default for `multiple` has to be `false` which also makes more sense when looking at the usage: `<umb-dropzone multiple></umb-dropzone>`

<!--- Describe the changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
