### PR TITLE
Hotfix: System information should be visible to anyone

### DIFF
--- a/src/apps/backoffice/components/backoffice-header-logo.element.ts
+++ b/src/apps/backoffice/components/backoffice-header-logo.element.ts
@@ -73,12 +73,7 @@ export class UmbBackofficeHeaderLogoElement extends UmbLitElement {
 
 						<a href="https://umbraco.com" target="_blank" rel="noopener">Umbraco.com</a>
 
-						${this._isUserAdmin
-							? html`<uui-button
-									@click=${this.#openSystemInformation}
-									look="secondary"
-									label="System information"></uui-button>`
-							: ''}
+						<uui-button @click=${this.#openSystemInformation} look="secondary" label="System information"></uui-button>
 					</div>
 				</umb-popover-layout>
 			</uui-popover-container>


### PR DESCRIPTION
## Description

None of the supporting endpoints for System Information are access restricted, and thus, the UI button "System information" does not need to be restricted either. It is, in fact, helpful to be able to get information from non-admins when debugging as well, and they should be able to paste this information into a GitHub issue report.

We also fix a few SonarCloud issues and add some more useful information to the output namely information related to the current user, which could be very helpful when debugging.