### PR TITLE
Update Collection view's instruction text to match current Backoffice terminology

### DIFF
--- a/src/packages/property-editors/collection/manifests.ts
+++ b/src/packages/property-editors/collection/manifests.ts
@@ -26,7 +26,7 @@ const propertyEditorUiManifest: ManifestPropertyEditorUi = {
 				{
 					alias: 'orderBy',
 					label: 'Order By',
-					description: 'The default sort order for the list.',
+					description: 'The default sort order for the Collection.',
 					propertyEditorUiAlias: 'Umb.PropertyEditorUi.Collection.OrderBy',
 				},
 				{
@@ -44,25 +44,25 @@ const propertyEditorUiManifest: ManifestPropertyEditorUi = {
 				{
 					alias: 'bulkActionPermissions',
 					label: 'Bulk Action Permissions',
-					description: 'The bulk actions that are allowed from the list view.',
+					description: 'The bulk actions that are allowed on items in the Collection view.',
 					propertyEditorUiAlias: 'Umb.PropertyEditorUi.Collection.BulkActionPermissions',
 				},
 				{
 					alias: 'icon',
-					label: 'Content app icon',
-					description: 'The icon of the listview content app.',
+					label: 'Workspace View icon',
+					description: 'The icon for the Collection\'s Workspace View.',
 					propertyEditorUiAlias: 'Umb.PropertyEditorUi.IconPicker',
 				},
 				{
 					alias: 'tabName',
-					label: 'Content app name',
-					description: 'The name of the listview content app (default if empty: Child Items).',
+					label: 'Workspace View name',
+					description: 'The name of the Collection\'s Workspace View (default if empty: Child Items).',
 					propertyEditorUiAlias: 'Umb.PropertyEditorUi.TextBox',
 				},
 				{
 					alias: 'showContentFirst',
-					label: 'Show Content App First',
-					description: 'Enable this to show the content app by default instead of the list view app.',
+					label: 'Show Content Workspace View First',
+					description: 'Enable this to show the Content Workspace View by default instead of the Collection\'s.',
 					propertyEditorUiAlias: 'Umb.PropertyEditorUi.Toggle',
 				},
 			],


### PR DESCRIPTION
## Description

This PR partially fixes umbraco/Umbraco-CMS#17230 with an update to the manifest that provides the labels and descriptions for the properties with the outdated verbiage.  To fully address the original issue, I think we need to do a few more things:
- Update the [`ListView.spec.ts`](https://github.com/umbraco/Umbraco-CMS/blob/e4dbf4ce9ff9ca70ed7c82c0c735a4d576aad692/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataType/ListView.spec.ts) acceptance test that lives outside this submodule.  I'll make that update and submit it as a separate PR to its respective repo.
- Update the Collection/List View docs article that lives here: https://github.com/umbraco/UmbracoDocs/blob/main/14/umbraco-cms/fundamentals/backoffice/property-editors/built-in-umbraco-property-editors/listview.md

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

This change clarifies the functionality of the options that folks have when using a Collection to view and manage child items in Collection workspace view.

## How to test?

## Screenshots (if appropriate)

<img width="1508" alt="Screenshot 2024-10-13 at 12 55 26 PM" src="https://github.com/user-attachments/assets/19eb0e29-9365-4b0a-8684-fc4e07c0835d">


## Checklist

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
  - _Note: Updates to the docs need to be made in a separate PR to the UmbracoDocs repo_  
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
  - _Note: Acceptance tests will need to be updated in a separate PR to the Umbraco-CMS repo._ 
