### PR TITLE
Bugfix: Set ?readonly only on color swatches, and not on the individual swatch

### DIFF
--- a/src/packages/core/components/input-color/input-color.element.ts
+++ b/src/packages/core/components/input-color/input-color.element.ts
@@ -51,11 +51,7 @@ export class UmbInputColorElement extends UUIFormControlMixin(UmbLitElement, '')
 		return map(
 			this.swatches,
 			(swatch) => html`
-				<uui-color-swatch
-					?readonly=${this.readonly}
-					label=${swatch.label}
-					value=${swatch.value}
-					.showLabel=${this.showLabels}></uui-color-swatch>
+				<uui-color-swatch label=${swatch.label} value=${swatch.value} .showLabel=${this.showLabels}></uui-color-swatch>
 			`,
 		);
 	}


### PR DESCRIPTION
## Description

fix: only set the ?readonly attribute on the swatches element since it handles setting it on the colors afterwards based on this comment: https://github.com/umbraco/Umbraco.CMS.Backoffice/pull/2451#discussion_r1798968698

CC @bjarnef - is this reasonable?