### PR TITLE
Fixes icon alignment in links in redirect dashboard

### DIFF
--- a/src/packages/documents/document-redirect-management/dashboard-redirect-management.element.ts
+++ b/src/packages/documents/document-redirect-management/dashboard-redirect-management.element.ts
@@ -212,15 +212,19 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 			return html` <uui-table-row>
 				<uui-table-cell> ${data.culture || '*'} </uui-table-cell>
 				<uui-table-cell>
-					<a href="${data.originalUrl || '#'}" target="_blank"> ${data.originalUrl}</a>
-					<uui-icon name="icon-out"></uui-icon>
+					<a href="${data.originalUrl || '#'}" target="_blank">
+						<span>${data.originalUrl}</span>
+						<uui-icon name="icon-out"></uui-icon>
+					</a>
 				</uui-table-cell>
 				<uui-table-cell>
 					<uui-icon name="icon-arrow-right"></uui-icon>
 				</uui-table-cell>
 				<uui-table-cell>
-					<a href="${data.destinationUrl || '#'}" target="_blank"> ${data.destinationUrl}</a>
-					<uui-icon name="icon-out"></uui-icon>
+					<a href="${data.destinationUrl || '#'}" target="_blank">
+						<span>${data.destinationUrl}</span>
+						<uui-icon name="icon-out"></uui-icon>
+					</a>
 				</uui-table-cell>
 				<uui-table-cell>
 					<uui-action-bar style="justify-self: left;">
@@ -289,6 +293,12 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 				display: flex;
 				justify-content: center;
 				margin-top: var(--uui-size-space-5);
+			}
+
+			uui-table-cell a:has(span, uui-icon) {
+				display: inline-flex;
+				align-items: center;
+				gap: var(--uui-size-2);
 			}
 		`,
 	];


### PR DESCRIPTION
Icon alignment on links in the redirect seems off. I fixed it by making them inline-flex, and then aligning the content.

## Screenshots

Before:
![thorium_CIqqkMTWmj](https://github.com/user-attachments/assets/83414a39-dbb9-4e51-a3ce-b984bbd91312)

After:
![thorium_7MU2rsPl95](https://github.com/user-attachments/assets/0df0b8ad-a846-4457-a6dd-88a0a93bcea0)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
