### PR TITLE
Adds gap between grouped buttons in settings welcome dashboard

### DIFF
--- a/src/packages/settings/welcome/settings-welcome-dashboard.element.ts
+++ b/src/packages/settings/welcome/settings-welcome-dashboard.element.ts
@@ -29,18 +29,21 @@ export class UmbSettingsWelcomeDashboardElement extends UmbLitElement {
 							Ask a question in the community forum or our Discord community
 						</umb-localize>
 					</p>
-					<uui-button
-						look="primary"
-						href="https://our.umbraco.com/forum"
-						label=${this.localize.term('settingsDashboard_goForum')}
-						target="_blank"
-						rel="noopener"></uui-button>
-					<uui-button
-						look="primary"
-						href="https://discord.umbraco.com"
-						label=${this.localize.term('settingsDashboard_chatWithCommunity')}
-						target="_blank"
-						rel="noopener"></uui-button>
+
+					<div class="button-group">
+						<uui-button
+							look="primary"
+							href="https://our.umbraco.com/forum"
+							label=${this.localize.term('settingsDashboard_goForum')}
+							target="_blank"
+							rel="noopener"></uui-button>
+						<uui-button
+							look="primary"
+							href="https://discord.umbraco.com"
+							label=${this.localize.term('settingsDashboard_chatWithCommunity')}
+							target="_blank"
+							rel="noopener"></uui-button>
+					</div>
 				</uui-box>
 
 				<uui-box class="training">
@@ -114,6 +117,12 @@ export class UmbSettingsWelcomeDashboardElement extends UmbLitElement {
 				#settings-dashboard {
 					grid-template-columns: repeat(1, 1fr);
 				}
+			}
+
+			.buttson-group {
+				display: flex;
+				flex-wrap: wrap;
+				gap: var(--uui-size-space-2);
 			}
 		`,
 	];

--- a/src/packages/settings/welcome/settings-welcome-dashboard.element.ts
+++ b/src/packages/settings/welcome/settings-welcome-dashboard.element.ts
@@ -119,7 +119,7 @@ export class UmbSettingsWelcomeDashboardElement extends UmbLitElement {
 				}
 			}
 
-			.buttson-group {
+			.button-group {
 				display: flex;
 				flex-wrap: wrap;
 				gap: var(--uui-size-space-2);


### PR DESCRIPTION
Noticed a couple of buttons were sticking together on small screens, so I wrapped them in flex with a gap between, to make sure they were nicely spaced.

See screenshots:

Before:
![thorium_90ZyrnAZoK](https://github.com/user-attachments/assets/32029b25-253c-422d-9338-36047aca7dc9)

After:
![thorium_gQQK5dcPi0](https://github.com/user-attachments/assets/6febb801-1b55-45a3-8c95-93d62b1a589b)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
