### PR TITLE
Fixes #17254 Making 'Umb.Section.Content' as a const UMB_CONTENT_SECT…

### DIFF
--- a/src/mocks/data/user-group/user-group.data.ts
+++ b/src/mocks/data/user-group/user-group.data.ts
@@ -1,4 +1,5 @@
 import type { UserGroupItemResponseModel, UserGroupResponseModel } from '@umbraco-cms/backoffice/external/backend-api';
+import { UMB_CONTENT_SECTION_ALIAS } from '@umbraco-cms/backoffice/content';
 
 export type UmbMockUserGroupModel = UserGroupResponseModel & UserGroupItemResponseModel;
 
@@ -34,7 +35,7 @@ export const data: Array<UmbMockUserGroupModel> = [
 			},
 		],
 		sections: [
-			'Umb.Section.Content',
+			UMB_CONTENT_SECTION_ALIAS,
 			'Umb.Section.Media',
 			'Umb.Section.Settings',
 			'Umb.Section.Members',
@@ -71,7 +72,7 @@ export const data: Array<UmbMockUserGroupModel> = [
 			'Umb.Document.Rollback',
 		],
 		permissions: [],
-		sections: ['Umb.Section.Content', 'Umb.Section.Media'],
+		sections: [UMB_CONTENT_SECTION_ALIAS, 'Umb.Section.Media'],
 		languages: [],
 		hasAccessToAllLanguages: true,
 		documentRootAccess: true,
@@ -124,7 +125,7 @@ export const data: Array<UmbMockUserGroupModel> = [
 			'Umb.Document.Notifications',
 		],
 		permissions: [],
-		sections: ['Umb.Section.Content'],
+		sections: [UMB_CONTENT_SECTION_ALIAS],
 		languages: [],
 		hasAccessToAllLanguages: true,
 		documentRootAccess: true,

--- a/src/packages/core/content/constants.ts
+++ b/src/packages/core/content/constants.ts
@@ -1,0 +1,1 @@
+export const UMB_CONTENT_SECTION_ALIAS = 'Umb.Section.Content';

--- a/src/packages/core/content/index.ts
+++ b/src/packages/core/content/index.ts
@@ -5,4 +5,5 @@ export * from './controller/merge-content-variant-data.controller.js';
 export * from './property-dataset-context/content-property-dataset.context.js';
 export * from './workspace/index.js';
 export * from './collection/index.js';
+export * from './constants.js';
 export type * from './types.js';

--- a/src/packages/documents/document-redirect-management/manifests.ts
+++ b/src/packages/documents/document-redirect-management/manifests.ts
@@ -1,3 +1,5 @@
+import { UMB_CONTENT_SECTION_ALIAS } from '@umbraco-cms/backoffice/content';
+
 export const manifests: Array<UmbExtensionManifest> = [
 	{
 		type: 'dashboard',
@@ -12,7 +14,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		conditions: [
 			{
 				alias: 'Umb.Condition.SectionAlias',
-				match: 'Umb.Section.Content',
+				match: UMB_CONTENT_SECTION_ALIAS,
 			},
 		],
 	},

--- a/src/packages/documents/section/constants.ts
+++ b/src/packages/documents/section/constants.ts
@@ -1,1 +1,0 @@
-export const UMB_CONTENT_SECTION_ALIAS = 'Umb.Section.Content';

--- a/src/packages/documents/section/manifests.ts
+++ b/src/packages/documents/section/manifests.ts
@@ -1,4 +1,4 @@
-import { UMB_CONTENT_SECTION_ALIAS } from './constants.js';
+import { UMB_CONTENT_SECTION_ALIAS } from '@umbraco-cms/backoffice/content';
 import { UMB_DOCUMENT_ROOT_ENTITY_TYPE, UMB_CONTENT_MENU_ALIAS } from '@umbraco-cms/backoffice/document';
 
 export const manifests: Array<UmbExtensionManifest> = [

--- a/src/packages/language/app-language-select/manifests.ts
+++ b/src/packages/language/app-language-select/manifests.ts
@@ -1,3 +1,4 @@
+import { UMB_CONTENT_SECTION_ALIAS } from '@umbraco-cms/backoffice/content';
 export const manifests: Array<UmbExtensionManifest> = [
 	{
 		type: 'sectionSidebarApp',
@@ -8,7 +9,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		conditions: [
 			{
 				alias: 'Umb.Condition.SectionAlias',
-				match: 'Umb.Section.Content',
+				match: UMB_CONTENT_SECTION_ALIAS,
 			},
 			{
 				alias: 'Umb.Condition.MultipleAppLanguages',

--- a/src/packages/umbraco-news/manifests.ts
+++ b/src/packages/umbraco-news/manifests.ts
@@ -1,4 +1,5 @@
 import type { ManifestDashboard } from '@umbraco-cms/backoffice/dashboard';
+import { UMB_CONTENT_SECTION_ALIAS } from '@umbraco-cms/backoffice/content';
 
 export const dashboard: ManifestDashboard = {
 	type: 'dashboard',
@@ -12,7 +13,7 @@ export const dashboard: ManifestDashboard = {
 	conditions: [
 		{
 			alias: 'Umb.Condition.SectionAlias',
-			match: 'Umb.Section.Content',
+			match: UMB_CONTENT_SECTION_ALIAS,
 		},
 	],
 };


### PR DESCRIPTION
Fixes #17254 Making 'Umb.Section.Content' as a const UMB_CONTENT_SECTION_ALIAS that can be imported

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe the changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
