### PR TITLE
Hotfix: correct config field alias to 'useLiveEditing'

### DIFF
--- a/src/packages/block/block/context/block-manager.context.ts
+++ b/src/packages/block/block/context/block-manager.context.ts
@@ -75,7 +75,7 @@ export abstract class UmbBlockManagerContext<
 	setEditorConfiguration(configs: UmbPropertyEditorConfigCollection) {
 		this._editorConfiguration.setValue(configs);
 		if (this._liveEditingMode.getValue() === undefined) {
-			this._liveEditingMode.setValue(configs.getValueByAlias<boolean>('liveEditingMode'));
+			this._liveEditingMode.setValue(configs.getValueByAlias<boolean>('useLiveEditing'));
 		}
 	}
 	getEditorConfiguration(): UmbPropertyEditorConfigCollection | undefined {


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/17274