### PR TITLE
Removes unnecessary margin in ufm-render-element

### DIFF
--- a/src/packages/ufm/components/ufm-render/ufm-render.element.ts
+++ b/src/packages/ufm/components/ufm-render/ufm-render.element.ts
@@ -59,6 +59,14 @@ export class UmbUfmRenderElement extends UmbLitElement {
 			pre {
 				overflow: auto;
 			}
+
+			:host > :first-child {
+				margin-block-start: 0;
+			}
+
+			:host > :last-child {
+				margin-block-end: 0;
+			}
 		`,
 	];
 }


### PR DESCRIPTION
I noticed that property labels now use umb-ufm-render, which (because of the nature of markdown I guess), turns simple text into paragraphs. This makes it have a top and bottom margin from the user agent stylesheet.

I added some css to remove the top margin from the first element and bottom margin from the last to combat this.

## Screenshots (if appropriate)

Before:

![thorium_OksH6ml63u](https://github.com/user-attachments/assets/dfe9274e-c065-4756-9fcc-e4a2668c0a33)

After:

![thorium_xNvOPDNZWy](https://github.com/user-attachments/assets/81a7aaef-f317-44ad-943d-acdcc4eb3cf5)

