### PR TITLE
Bugfix: TinyMCE anchor links without base URL

### DIFF
--- a/src/packages/tiny-mce/plugins/tiny-mce-code-editor.plugin.ts
+++ b/src/packages/tiny-mce/plugins/tiny-mce-code-editor.plugin.ts
@@ -25,13 +25,15 @@ export default class UmbTinyMceCodeEditorPlugin extends UmbTinyMcePluginBase {
 			},
 		});
 
-		if (!modal) return;
+		const value = await modal.onSubmit().catch(() => undefined);
+		if (!value) {
+			return;
+		}
 
-		const { content } = await modal.onSubmit();
-		if (!content) {
+		if (!value.content) {
 			this.editor.resetContent();
 		} else {
-			this.editor.setContent(content.toString());
+			this.editor.setContent(value.content.toString());
 		}
 
 		this.editor.dispatch('Change');


### PR DESCRIPTION
## Description

When adding/editing a link in TinyMCE that has an anchor or querystring, but no URL part, the link markup would include the current backoffice path, along with an `undefined` suffix.

Fixes https://github.com/umbraco/Umbraco-CMS/issues/17009

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## How to test?

Add/edit a link without entering a URL, but adding either an anchor hash or querystring value. The link's `href` should **not contain** either `undefined` or the current backoffice path.
