### PR TITLE
Tiptap: allow images to be uploaded from the clipboard

### DIFF
--- a/src/packages/core/temporary-file/temporary-file-manager.class.ts
+++ b/src/packages/core/temporary-file/temporary-file-manager.class.ts
@@ -61,8 +61,9 @@ export class UmbTemporaryFileManager<
 		for (const item of queue) {
 			if (!item.temporaryUnique) throw new Error(`Unique is missing for item ${item}`);
 
-			const { error } = await this.#temporaryFileRepository.upload(item.temporaryUnique, item.file);
-			//await new Promise((resolve) => setTimeout(resolve, (Math.random() + 0.5) * 1000)); // simulate small delay so that the upload badge is properly shown
+			const { error } = await this.#temporaryFileRepository
+				.upload(item.temporaryUnique, item.file)
+				.catch(() => ({ error: true }));
 
 			let status: TemporaryFileStatus;
 			if (error) {

--- a/src/packages/tiptap/extensions/core/media-upload.extension.ts
+++ b/src/packages/tiptap/extensions/core/media-upload.extension.ts
@@ -67,6 +67,13 @@ export default class UmbTiptapMediaUploadExtensionApi extends UmbTiptapExtension
 
 						self.#uploadTemporaryFile(files, this.editor);
 					});
+
+					host.addEventListener('paste', (event) => {
+						const files = event.clipboardData?.files;
+						if (!files) return;
+
+						self.#uploadTemporaryFile(files, this.editor);
+					});
 				},
 			}),
 		];


### PR DESCRIPTION
## Description

Add a listener for "paste" events and upload any files that might be included in the clipboard.

Fixes https://github.com/umbraco/Umbraco-CMS/issues/17258

## How to test

Take a screenshot or copy an image into the clipboard, then paste it (CTRL+V) into a Tiptap instance with the media upload extension enabled.