### PR TITLE
Feature: Collection Toolbar Filter Field

### DIFF
--- a/src/packages/core/collection/components/collection-action-bundle.element.ts
+++ b/src/packages/core/collection/components/collection-action-bundle.element.ts
@@ -1,4 +1,4 @@
-import { html, customElement } from '@umbraco-cms/backoffice/external/lit';
+import { html, customElement, css } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 
 @customElement('umb-collection-action-bundle')
@@ -6,6 +6,14 @@ export class UmbCollectionActionBundleElement extends UmbLitElement {
 	override render() {
 		return html`<umb-extension-slot type="collectionAction"></umb-extension-slot>`;
 	}
+
+	static override readonly styles = [
+		css`
+			:host {
+				display: contents;
+			}
+		`,
+	];
 }
 
 declare global {

--- a/src/packages/core/collection/components/collection-action-bundle.element.ts
+++ b/src/packages/core/collection/components/collection-action-bundle.element.ts
@@ -1,9 +1,7 @@
 import { css, customElement, html } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 
-const elementName = 'umb-collection-action-bundle';
-
-@customElement(elementName)
+@customElement('umb-collection-action-bundle')
 export class UmbCollectionActionBundleElement extends UmbLitElement {
 	override render() {
 		return html`<umb-extension-slot type="collectionAction"></umb-extension-slot>`;
@@ -20,6 +18,6 @@ export class UmbCollectionActionBundleElement extends UmbLitElement {
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbCollectionActionBundleElement;
+		'umb-collection-action-bundle': UmbCollectionActionBundleElement;
 	}
 }

--- a/src/packages/core/collection/components/collection-action-bundle.element.ts
+++ b/src/packages/core/collection/components/collection-action-bundle.element.ts
@@ -1,4 +1,4 @@
-import { html, customElement, css } from '@umbraco-cms/backoffice/external/lit';
+import { css, customElement, html } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 
 const elementName = 'umb-collection-action-bundle';

--- a/src/packages/core/collection/components/collection-action-bundle.element.ts
+++ b/src/packages/core/collection/components/collection-action-bundle.element.ts
@@ -1,7 +1,9 @@
 import { html, customElement, css } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 
-@customElement('umb-collection-action-bundle')
+const elementName = 'umb-collection-action-bundle';
+
+@customElement(elementName)
 export class UmbCollectionActionBundleElement extends UmbLitElement {
 	override render() {
 		return html`<umb-extension-slot type="collectionAction"></umb-extension-slot>`;
@@ -18,6 +20,6 @@ export class UmbCollectionActionBundleElement extends UmbLitElement {
 
 declare global {
 	interface HTMLElementTagNameMap {
-		'umb-collection-action-bundle': UmbCollectionActionBundleElement;
+		[elementName]: UmbCollectionActionBundleElement;
 	}
 }

--- a/src/packages/core/collection/components/collection-filter-field.element.ts
+++ b/src/packages/core/collection/components/collection-filter-field.element.ts
@@ -1,0 +1,49 @@
+import { UMB_COLLECTION_CONTEXT } from '../default/index.js';
+import { css, customElement, html } from '@umbraco-cms/backoffice/external/lit';
+import { debounce } from '@umbraco-cms/backoffice/utils';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+
+const elementName = 'umb-collection-filter-field';
+
+@customElement(elementName)
+export class UmbCollectionFilterFieldElement extends UmbLitElement {
+	#collectionContext?: typeof UMB_COLLECTION_CONTEXT.TYPE;
+
+	constructor() {
+		super();
+
+		this.consumeContext(UMB_COLLECTION_CONTEXT, (context) => {
+			this.#collectionContext = context;
+		});
+	}
+
+	#debouncedFilter = debounce((filter: string) => this.#collectionContext?.setFilter({ filter }), 500);
+
+	#onInput(event: InputEvent & { target: HTMLInputElement }) {
+		const filter = event.target.value ?? '';
+		this.#debouncedFilter(filter);
+	}
+
+	override render() {
+		return html`
+			<uui-input
+				label=${this.localize.term('general_search')}
+				placeholder=${this.localize.term('placeholders_search')}
+				@input=${this.#onInput}></uui-input>
+		`;
+	}
+
+	static override readonly styles = [
+		css`
+			uui-input {
+				display: block;
+			}
+		`,
+	];
+}
+
+declare global {
+	interface HTMLElementTagNameMap {
+		[elementName]: UmbCollectionFilterFieldElement;
+	}
+}

--- a/src/packages/core/collection/components/collection-filter-field.element.ts
+++ b/src/packages/core/collection/components/collection-filter-field.element.ts
@@ -3,9 +3,7 @@ import { css, customElement, html } from '@umbraco-cms/backoffice/external/lit';
 import { debounce } from '@umbraco-cms/backoffice/utils';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 
-const elementName = 'umb-collection-filter-field';
-
-@customElement(elementName)
+@customElement('umb-collection-filter-field')
 export class UmbCollectionFilterFieldElement extends UmbLitElement {
 	#collectionContext?: typeof UMB_COLLECTION_CONTEXT.TYPE;
 
@@ -44,6 +42,6 @@ export class UmbCollectionFilterFieldElement extends UmbLitElement {
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbCollectionFilterFieldElement;
+		'umb-collection-filter-field': UmbCollectionFilterFieldElement;
 	}
 }

--- a/src/packages/core/collection/components/collection-view-bundle.element.ts
+++ b/src/packages/core/collection/components/collection-view-bundle.element.ts
@@ -1,8 +1,7 @@
-import type { UmbDefaultCollectionContext } from '../default/index.js';
 import { UMB_COLLECTION_CONTEXT } from '../default/index.js';
-import type { UmbCollectionLayoutConfiguration } from '../types.js';
 import type { ManifestCollectionView } from '../extensions/index.js';
-import { css, html, customElement, state, nothing, repeat, query } from '@umbraco-cms/backoffice/external/lit';
+import type { UmbCollectionLayoutConfiguration } from '../types.js';
+import { css, customElement, html, nothing, query, repeat, state } from '@umbraco-cms/backoffice/external/lit';
 import { observeMultiple } from '@umbraco-cms/backoffice/observable-api';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
@@ -16,7 +15,9 @@ interface UmbCollectionViewLayout {
 	pathName: string;
 }
 
-@customElement('umb-collection-view-bundle')
+const elementName = 'umb-collection-view-bundle';
+
+@customElement(elementName)
 export class UmbCollectionViewBundleElement extends UmbLitElement {
 	@state()
 	_views: Array<UmbCollectionViewLayout> = [];
@@ -30,7 +31,7 @@ export class UmbCollectionViewBundleElement extends UmbLitElement {
 	@state()
 	private _entityUnique?: string;
 
-	#collectionContext?: UmbDefaultCollectionContext<any, any>;
+	#collectionContext?: typeof UMB_COLLECTION_CONTEXT.TYPE;
 
 	constructor() {
 		super();
@@ -171,6 +172,6 @@ export class UmbCollectionViewBundleElement extends UmbLitElement {
 
 declare global {
 	interface HTMLElementTagNameMap {
-		'umb-collection-view-bundle': UmbCollectionViewBundleElement;
+		[elementName]: UmbCollectionViewBundleElement;
 	}
 }

--- a/src/packages/core/collection/components/collection-view-bundle.element.ts
+++ b/src/packages/core/collection/components/collection-view-bundle.element.ts
@@ -15,9 +15,7 @@ interface UmbCollectionViewLayout {
 	pathName: string;
 }
 
-const elementName = 'umb-collection-view-bundle';
-
-@customElement(elementName)
+@customElement('umb-collection-view-bundle')
 export class UmbCollectionViewBundleElement extends UmbLitElement {
 	@state()
 	_views: Array<UmbCollectionViewLayout> = [];
@@ -172,6 +170,6 @@ export class UmbCollectionViewBundleElement extends UmbLitElement {
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbCollectionViewBundleElement;
+		'umb-collection-view-bundle': UmbCollectionViewBundleElement;
 	}
 }

--- a/src/packages/core/collection/components/index.ts
+++ b/src/packages/core/collection/components/index.ts
@@ -1,11 +1,13 @@
-import './pagination/collection-pagination.element.js';
+import './collection-action-bundle.element.js';
+import './collection-filter-field.element.js';
 import './collection-selection-actions.element.js';
 import './collection-toolbar.element.js';
 import './collection-view-bundle.element.js';
-import './collection-action-bundle.element.js';
+import './pagination/collection-pagination.element.js';
 
-export * from './pagination/collection-pagination.element.js';
+export * from './collection-action-bundle.element.js';
+export * from './collection-filter-field.element.js';
 export * from './collection-selection-actions.element.js';
 export * from './collection-toolbar.element.js';
 export * from './collection-view-bundle.element.js';
-export * from './collection-action-bundle.element.js';
+export * from './pagination/collection-pagination.element.js';

--- a/src/packages/dictionary/collection/dictionary-collection.element.ts
+++ b/src/packages/dictionary/collection/dictionary-collection.element.ts
@@ -1,49 +1,17 @@
-import { css, customElement, html } from '@umbraco-cms/backoffice/external/lit';
-import { UmbCollectionDefaultElement, UMB_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
-import type { UmbDefaultCollectionContext } from '@umbraco-cms/backoffice/collection';
+import { customElement, html } from '@umbraco-cms/backoffice/external/lit';
+import { UmbCollectionDefaultElement } from '@umbraco-cms/backoffice/collection';
 
 const elementName = 'umb-dictionary-collection';
 
 @customElement(elementName)
 export class UmbDictionaryCollectionElement extends UmbCollectionDefaultElement {
-	#collectionContext?: UmbDefaultCollectionContext;
-
-	#inputTimer?: NodeJS.Timeout;
-	#inputTimerAmount = 500;
-
-	constructor() {
-		super();
-
-		this.consumeContext(UMB_COLLECTION_CONTEXT, (context) => {
-			this.#collectionContext = context;
-		});
-	}
-
-	#onInput(event: InputEvent & { target: HTMLInputElement }) {
-		const filter = event.target.value ?? '';
-		clearTimeout(this.#inputTimer);
-		this.#inputTimer = setTimeout(() => this.#collectionContext?.setFilter({ filter }), this.#inputTimerAmount);
-	}
-
 	protected override renderToolbar() {
 		return html`
 			<umb-collection-toolbar slot="header">
-				<uui-input
-					id="input-search"
-					label=${this.localize.term('general_search')}
-					placeholder=${this.localize.term('placeholders_search')}
-					@input=${this.#onInput}></uui-input>
+				<umb-collection-filter-field></umb-collection-filter-field>
 			</umb-collection-toolbar>
 		`;
 	}
-
-	static override readonly styles = [
-		css`
-			#input-search {
-				display: block;
-			}
-		`,
-	];
 }
 
 export { UmbDictionaryCollectionElement as element };

--- a/src/packages/dictionary/collection/dictionary-collection.element.ts
+++ b/src/packages/dictionary/collection/dictionary-collection.element.ts
@@ -1,9 +1,7 @@
 import { customElement, html } from '@umbraco-cms/backoffice/external/lit';
 import { UmbCollectionDefaultElement } from '@umbraco-cms/backoffice/collection';
 
-const elementName = 'umb-dictionary-collection';
-
-@customElement(elementName)
+@customElement('umb-dictionary-collection')
 export class UmbDictionaryCollectionElement extends UmbCollectionDefaultElement {
 	protected override renderToolbar() {
 		return html`
@@ -18,6 +16,6 @@ export { UmbDictionaryCollectionElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbDictionaryCollectionElement;
+		'umb-dictionary-collection': UmbDictionaryCollectionElement;
 	}
 }

--- a/src/packages/dictionary/collection/dictionary-collection.element.ts
+++ b/src/packages/dictionary/collection/dictionary-collection.element.ts
@@ -1,54 +1,55 @@
 import { css, customElement, html } from '@umbraco-cms/backoffice/external/lit';
-import {
-	UMB_COLLECTION_CONTEXT,
-	UmbCollectionDefaultElement,
-	type UmbDefaultCollectionContext,
-} from '@umbraco-cms/backoffice/collection';
+import { UmbCollectionDefaultElement, UMB_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
+import type { UmbDefaultCollectionContext } from '@umbraco-cms/backoffice/collection';
 
-@customElement('umb-dictionary-collection')
+const elementName = 'umb-dictionary-collection';
+
+@customElement(elementName)
 export class UmbDictionaryCollectionElement extends UmbCollectionDefaultElement {
 	#collectionContext?: UmbDefaultCollectionContext;
+
 	#inputTimer?: NodeJS.Timeout;
 	#inputTimerAmount = 500;
 
 	constructor() {
 		super();
+
 		this.consumeContext(UMB_COLLECTION_CONTEXT, (context) => {
 			this.#collectionContext = context;
 		});
 	}
 
-	#updateSearch(event: InputEvent) {
-		const target = event.target as HTMLInputElement;
-		const filter = target.value || '';
+	#onInput(event: InputEvent & { target: HTMLInputElement }) {
+		const filter = event.target.value ?? '';
 		clearTimeout(this.#inputTimer);
 		this.#inputTimer = setTimeout(() => this.#collectionContext?.setFilter({ filter }), this.#inputTimerAmount);
 	}
 
 	protected override renderToolbar() {
-		return html`<umb-collection-toolbar slot="header">${this.#renderSearch()}</umb-collection-toolbar>`;
+		return html`
+			<umb-collection-toolbar slot="header">
+				<uui-input
+					id="input-search"
+					label=${this.localize.term('general_search')}
+					placeholder=${this.localize.term('placeholders_search')}
+					@input=${this.#onInput}></uui-input>
+			</umb-collection-toolbar>
+		`;
 	}
 
-	#renderSearch() {
-		return html`<uui-input
-			id="input-search"
-			@input=${this.#updateSearch}
-			placeholder=${this.localize.term('placeholders_search')}></uui-input>`;
-	}
-
-	static override styles = [
+	static override readonly styles = [
 		css`
 			#input-search {
-				width: 100%;
+				display: block;
 			}
 		`,
 	];
 }
 
-export default UmbDictionaryCollectionElement;
+export { UmbDictionaryCollectionElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		'umb-dictionary-collection': UmbDictionaryCollectionElement;
+		[elementName]: UmbDictionaryCollectionElement;
 	}
 }

--- a/src/packages/documents/documents/collection/document-collection-toolbar.element.ts
+++ b/src/packages/documents/documents/collection/document-collection-toolbar.element.ts
@@ -3,6 +3,7 @@ import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UMB_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
 import type { UmbDefaultCollectionContext } from '@umbraco-cms/backoffice/collection';
 
+/** @deprecated This component is no longer used in core; to be removed in Umbraco 17. */
 @customElement('umb-document-collection-toolbar')
 export class UmbDocumentCollectionToolbarElement extends UmbLitElement {
 	#collectionContext?: UmbDefaultCollectionContext;

--- a/src/packages/documents/documents/collection/document-collection.element.ts
+++ b/src/packages/documents/documents/collection/document-collection.element.ts
@@ -1,9 +1,7 @@
 import { customElement, html } from '@umbraco-cms/backoffice/external/lit';
 import { UmbCollectionDefaultElement } from '@umbraco-cms/backoffice/collection';
 
-const elementName = 'umb-document-collection';
-
-@customElement(elementName)
+@customElement('umb-document-collection')
 export class UmbDocumentCollectionElement extends UmbCollectionDefaultElement {
 	protected override renderToolbar() {
 		return html`
@@ -21,6 +19,6 @@ export { UmbDocumentCollectionElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbDocumentCollectionElement;
+		'umb-document-collection': UmbDocumentCollectionElement;
 	}
 }

--- a/src/packages/documents/documents/collection/document-collection.element.ts
+++ b/src/packages/documents/documents/collection/document-collection.element.ts
@@ -1,19 +1,58 @@
-import { html, customElement } from '@umbraco-cms/backoffice/external/lit';
-import { UmbCollectionDefaultElement } from '@umbraco-cms/backoffice/collection';
+import { css, customElement, html } from '@umbraco-cms/backoffice/external/lit';
+import { UmbCollectionDefaultElement, UMB_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
+import type { UmbDefaultCollectionContext } from '@umbraco-cms/backoffice/collection';
 
-import './document-collection-toolbar.element.js';
+const elementName = 'umb-document-collection';
 
-@customElement('umb-document-collection')
+@customElement(elementName)
 export class UmbDocumentCollectionElement extends UmbCollectionDefaultElement {
-	protected override renderToolbar() {
-		return html`<umb-document-collection-toolbar slot="header"></umb-document-collection-toolbar>`;
+	#collectionContext?: UmbDefaultCollectionContext;
+
+	#inputTimer?: NodeJS.Timeout;
+	#inputTimerAmount = 500;
+
+	constructor() {
+		super();
+
+		this.consumeContext(UMB_COLLECTION_CONTEXT, (context) => {
+			this.#collectionContext = context;
+		});
 	}
+
+	#onInput(event: InputEvent & { target: HTMLInputElement }) {
+		const filter = event.target.value ?? '';
+		clearTimeout(this.#inputTimer);
+		this.#inputTimer = setTimeout(() => this.#collectionContext?.setFilter({ filter }), this.#inputTimerAmount);
+	}
+
+	protected override renderToolbar() {
+		return html`
+			<umb-collection-toolbar slot="header">
+				<uui-input
+					id="input-search"
+					label=${this.localize.term('general_search')}
+					placeholder=${this.localize.term('placeholders_search')}
+					@input=${this.#onInput}></uui-input>
+			</umb-collection-toolbar>
+		`;
+	}
+
+	static override readonly styles = [
+		css`
+			#input-search {
+				display: block;
+			}
+		`,
+	];
 }
 
+/** @deprecated Should be exported as `element` only; to be removed in Umbraco 17. */
 export default UmbDocumentCollectionElement;
+
+export { UmbDocumentCollectionElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		'umb-document-collection': UmbDocumentCollectionElement;
+		[elementName]: UmbDocumentCollectionElement;
 	}
 }

--- a/src/packages/documents/documents/collection/document-collection.element.ts
+++ b/src/packages/documents/documents/collection/document-collection.element.ts
@@ -1,49 +1,17 @@
-import { css, customElement, html } from '@umbraco-cms/backoffice/external/lit';
-import { UmbCollectionDefaultElement, UMB_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
-import type { UmbDefaultCollectionContext } from '@umbraco-cms/backoffice/collection';
+import { customElement, html } from '@umbraco-cms/backoffice/external/lit';
+import { UmbCollectionDefaultElement } from '@umbraco-cms/backoffice/collection';
 
 const elementName = 'umb-document-collection';
 
 @customElement(elementName)
 export class UmbDocumentCollectionElement extends UmbCollectionDefaultElement {
-	#collectionContext?: UmbDefaultCollectionContext;
-
-	#inputTimer?: NodeJS.Timeout;
-	#inputTimerAmount = 500;
-
-	constructor() {
-		super();
-
-		this.consumeContext(UMB_COLLECTION_CONTEXT, (context) => {
-			this.#collectionContext = context;
-		});
-	}
-
-	#onInput(event: InputEvent & { target: HTMLInputElement }) {
-		const filter = event.target.value ?? '';
-		clearTimeout(this.#inputTimer);
-		this.#inputTimer = setTimeout(() => this.#collectionContext?.setFilter({ filter }), this.#inputTimerAmount);
-	}
-
 	protected override renderToolbar() {
 		return html`
 			<umb-collection-toolbar slot="header">
-				<uui-input
-					id="input-search"
-					label=${this.localize.term('general_search')}
-					placeholder=${this.localize.term('placeholders_search')}
-					@input=${this.#onInput}></uui-input>
+				<umb-collection-filter-field></umb-collection-filter-field>
 			</umb-collection-toolbar>
 		`;
 	}
-
-	static override readonly styles = [
-		css`
-			#input-search {
-				display: block;
-			}
-		`,
-	];
 }
 
 /** @deprecated Should be exported as `element` only; to be removed in Umbraco 17. */

--- a/src/packages/extension-insights/collection/extension-collection.element.ts
+++ b/src/packages/extension-insights/collection/extension-collection.element.ts
@@ -75,7 +75,10 @@ export class UmbExtensionCollectionElement extends UmbCollectionDefaultElement {
 	];
 }
 
+/** @deprecated Should be exported as `element` only; to be removed in Umbraco 17. */
 export default UmbExtensionCollectionElement;
+
+export { UmbExtensionCollectionElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {

--- a/src/packages/extension-insights/collection/extension-collection.element.ts
+++ b/src/packages/extension-insights/collection/extension-collection.element.ts
@@ -43,27 +43,27 @@ export class UmbExtensionCollectionElement extends UmbCollectionDefaultElement {
 
 	protected override renderToolbar() {
 		return html`
-			<div id="toolbar" slot="header">
-				<uui-input @input=${this.#onSearch} label="Search" placeholder="Search..." id="input-search"></uui-input>
-				<uui-select
-					label="Select type..."
-					placeholder="Select type..."
-					.options=${this.#options}
-					@change=${this.#onChange}></uui-select>
-			</div>
+			<umb-collection-toolbar slot="header">
+				<div id="toolbar">
+					<uui-input @input=${this.#onSearch} label="Search" placeholder="Search..." id="input-search"></uui-input>
+					<uui-select
+						label="Select type..."
+						placeholder="Select type..."
+						.options=${this.#options}
+						@change=${this.#onChange}></uui-select>
+				</div>
+			</umb-collection-toolbar>
 		`;
 	}
 
 	static override styles = [
 		css`
 			#toolbar {
+				flex: 1;
 				display: flex;
 				gap: var(--uui-size-space-5);
 				justify-content: space-between;
 				align-items: center;
-				padding-left: var(--uui-size-space-4);
-				padding-right: var(--uui-size-space-6);
-				width: 100%;
 			}
 			uui-input {
 				width: 100%;

--- a/src/packages/extension-insights/collection/extension-collection.element.ts
+++ b/src/packages/extension-insights/collection/extension-collection.element.ts
@@ -1,17 +1,14 @@
-import type { UmbExtensionCollectionFilterModel } from './types.js';
-import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
-import { html, customElement, css } from '@umbraco-cms/backoffice/external/lit';
+import type { UmbExtensionCollectionFilterModel, UmbExtensionDetailModel } from './types.js';
+import { css, customElement, html } from '@umbraco-cms/backoffice/external/lit';
 import { fromCamelCase } from '@umbraco-cms/backoffice/utils';
+import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { UMB_COLLECTION_CONTEXT, UmbCollectionDefaultElement } from '@umbraco-cms/backoffice/collection';
 import type { UmbDefaultCollectionContext } from '@umbraco-cms/backoffice/collection';
 import type { UUISelectEvent } from '@umbraco-cms/backoffice/external/uui';
 
 @customElement('umb-extension-collection')
 export class UmbExtensionCollectionElement extends UmbCollectionDefaultElement {
-	#collectionContext?: UmbDefaultCollectionContext<any, UmbExtensionCollectionFilterModel>;
-
-	#inputTimer?: NodeJS.Timeout;
-	#inputTimerAmount = 500;
+	#collectionContext?: UmbDefaultCollectionContext<UmbExtensionDetailModel, UmbExtensionCollectionFilterModel>;
 
 	#options: Array<Option> = [];
 
@@ -34,18 +31,11 @@ export class UmbExtensionCollectionElement extends UmbCollectionDefaultElement {
 		this.#collectionContext?.setFilter({ type: extensionType });
 	}
 
-	#onSearch(event: InputEvent) {
-		const target = event.target as HTMLInputElement;
-		const filter = target.value || '';
-		clearTimeout(this.#inputTimer);
-		this.#inputTimer = setTimeout(() => this.#collectionContext?.setFilter({ filter }), this.#inputTimerAmount);
-	}
-
 	protected override renderToolbar() {
 		return html`
 			<umb-collection-toolbar slot="header">
 				<div id="toolbar">
-					<uui-input @input=${this.#onSearch} label="Search" placeholder="Search..." id="input-search"></uui-input>
+					<umb-collection-filter-field></umb-collection-filter-field>
 					<uui-select
 						label="Select type..."
 						placeholder="Select type..."
@@ -65,9 +55,11 @@ export class UmbExtensionCollectionElement extends UmbCollectionDefaultElement {
 				justify-content: space-between;
 				align-items: center;
 			}
-			uui-input {
+
+			umb-collection-filter-field {
 				width: 100%;
 			}
+
 			uui-select {
 				width: 100%;
 			}

--- a/src/packages/media/media/collection/media-collection-toolbar.element.ts
+++ b/src/packages/media/media/collection/media-collection-toolbar.element.ts
@@ -3,6 +3,7 @@ import { UMB_MEDIA_COLLECTION_CONTEXT } from './media-collection.context-token.j
 import { css, html, customElement } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 
+/** @deprecated This component is no longer used in core; to be removed in Umbraco 17. */
 @customElement('umb-media-collection-toolbar')
 export class UmbMediaCollectionToolbarElement extends UmbLitElement {
 	#collectionContext?: UmbMediaCollectionContext;

--- a/src/packages/media/media/collection/media-collection.element.ts
+++ b/src/packages/media/media/collection/media-collection.element.ts
@@ -8,9 +8,7 @@ import { UmbCollectionDefaultElement } from '@umbraco-cms/backoffice/collection'
 import { UmbRequestReloadChildrenOfEntityEvent } from '@umbraco-cms/backoffice/entity-action';
 import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
 
-const elementName = 'umb-media-collection';
-
-@customElement(elementName)
+@customElement('umb-media-collection')
 export class UmbMediaCollectionElement extends UmbCollectionDefaultElement {
 	#collectionContext?: typeof UMB_MEDIA_COLLECTION_CONTEXT.TYPE;
 
@@ -106,6 +104,6 @@ export { UmbMediaCollectionElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbMediaCollectionElement;
+		'umb-media-collection': UmbMediaCollectionElement;
 	}
 }

--- a/src/packages/media/media/collection/media-collection.element.ts
+++ b/src/packages/media/media/collection/media-collection.element.ts
@@ -2,17 +2,21 @@ import { UMB_MEDIA_ENTITY_TYPE, UMB_MEDIA_ROOT_ENTITY_TYPE } from '../entity.js'
 import { UMB_MEDIA_WORKSPACE_CONTEXT } from '../workspace/media-workspace.context-token.js';
 import { UmbFileDropzoneItemStatus, type UmbUploadableItem } from '../dropzone/types.js';
 import type { UmbDropzoneElement } from '../dropzone/dropzone.element.js';
-import type { UmbMediaCollectionContext } from './media-collection.context.js';
 import { UMB_MEDIA_COLLECTION_CONTEXT } from './media-collection.context-token.js';
-import { customElement, html, query, state, when } from '@umbraco-cms/backoffice/external/lit';
+import type { UmbMediaCollectionContext } from './media-collection.context.js';
+import { css, customElement, html, query, state, when } from '@umbraco-cms/backoffice/external/lit';
 import { UmbCollectionDefaultElement } from '@umbraco-cms/backoffice/collection';
-import './media-collection-toolbar.element.js';
-import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
 import { UmbRequestReloadChildrenOfEntityEvent } from '@umbraco-cms/backoffice/entity-action';
+import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
 
-@customElement('umb-media-collection')
+const elementName = 'umb-media-collection';
+
+@customElement(elementName)
 export class UmbMediaCollectionElement extends UmbCollectionDefaultElement {
-	#mediaCollection?: UmbMediaCollectionContext;
+	#collectionContext?: UmbMediaCollectionContext;
+
+	#inputTimer?: NodeJS.Timeout;
+	#inputTimerAmount = 500;
 
 	@state()
 	private _progress = -1;
@@ -25,9 +29,11 @@ export class UmbMediaCollectionElement extends UmbCollectionDefaultElement {
 
 	constructor() {
 		super();
-		this.consumeContext(UMB_MEDIA_COLLECTION_CONTEXT, (instance) => {
-			this.#mediaCollection = instance;
+
+		this.consumeContext(UMB_MEDIA_COLLECTION_CONTEXT, (context) => {
+			this.#collectionContext = context;
 		});
+
 		this.consumeContext(UMB_MEDIA_WORKSPACE_CONTEXT, (instance) => {
 			this.observe(instance.unique, (unique) => {
 				this._unique = unique ?? null;
@@ -42,7 +48,7 @@ export class UmbMediaCollectionElement extends UmbCollectionDefaultElement {
 				progressItems.forEach((item) => {
 					if (item.status === UmbFileDropzoneItemStatus.COMPLETE && !item.folder?.name) {
 						// We do not update folders as it may have children still being uploaded.
-						this.#mediaCollection?.updatePlaceholderStatus(item.unique, UmbFileDropzoneItemStatus.COMPLETE);
+						this.#collectionContext?.updatePlaceholderStatus(item.unique, UmbFileDropzoneItemStatus.COMPLETE);
 					}
 				});
 			},
@@ -57,13 +63,13 @@ export class UmbMediaCollectionElement extends UmbCollectionDefaultElement {
 			.filter((p) => p.parentUnique === this._unique)
 			.map((p) => ({ unique: p.unique, status: p.status, name: p.temporaryFile?.file.name ?? p.folder?.name }));
 
-		this.#mediaCollection?.setPlaceholders(placeholders);
+		this.#collectionContext?.setPlaceholders(placeholders);
 		this.#observeProgressItems();
 	}
 
 	async #onComplete() {
 		this._progress = -1;
-		this.#mediaCollection?.requestCollection();
+		this.#collectionContext?.requestCollection();
 
 		const eventContext = await this.getContext(UMB_ACTION_EVENT_CONTEXT);
 		const event = new UmbRequestReloadChildrenOfEntityEvent({
@@ -71,6 +77,12 @@ export class UmbMediaCollectionElement extends UmbCollectionDefaultElement {
 			unique: this._unique,
 		});
 		eventContext.dispatchEvent(event);
+	}
+
+	#onInput(event: InputEvent & { target: HTMLInputElement }) {
+		const filter = event.target.value ?? '';
+		clearTimeout(this.#inputTimer);
+		this.#inputTimer = setTimeout(() => this.#collectionContext?.setFilter({ filter }), this.#inputTimerAmount);
 	}
 
 	#onProgress(event: ProgressEvent) {
@@ -82,7 +94,13 @@ export class UmbMediaCollectionElement extends UmbCollectionDefaultElement {
 
 	protected override renderToolbar() {
 		return html`
-			<umb-media-collection-toolbar slot="header"></umb-media-collection-toolbar>
+			<umb-collection-toolbar slot="header">
+				<uui-input
+					id="input-search"
+					label=${this.localize.term('general_search')}
+					placeholder=${this.localize.term('placeholders_search')}
+					@input=${this.#onInput}></uui-input>
+			</umb-collection-toolbar>
 			${when(this._progress >= 0, () => html`<uui-loader-bar progress=${this._progress}></uui-loader-bar>`)}
 			<umb-dropzone
 				id="dropzone"
@@ -93,12 +111,23 @@ export class UmbMediaCollectionElement extends UmbCollectionDefaultElement {
 				@progress=${this.#onProgress}></umb-dropzone>
 		`;
 	}
+
+	static override readonly styles = [
+		css`
+			#input-search {
+				display: block;
+			}
+		`,
+	];
 }
 
+/** @deprecated Should be exported as `element` only; to be removed in Umbraco 17. */
 export default UmbMediaCollectionElement;
+
+export { UmbMediaCollectionElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		'umb-media-collection': UmbMediaCollectionElement;
+		[elementName]: UmbMediaCollectionElement;
 	}
 }

--- a/src/packages/media/media/collection/media-collection.element.ts
+++ b/src/packages/media/media/collection/media-collection.element.ts
@@ -3,8 +3,7 @@ import { UMB_MEDIA_WORKSPACE_CONTEXT } from '../workspace/media-workspace.contex
 import { UmbFileDropzoneItemStatus, type UmbUploadableItem } from '../dropzone/types.js';
 import type { UmbDropzoneElement } from '../dropzone/dropzone.element.js';
 import { UMB_MEDIA_COLLECTION_CONTEXT } from './media-collection.context-token.js';
-import type { UmbMediaCollectionContext } from './media-collection.context.js';
-import { css, customElement, html, query, state, when } from '@umbraco-cms/backoffice/external/lit';
+import { customElement, html, query, state, when } from '@umbraco-cms/backoffice/external/lit';
 import { UmbCollectionDefaultElement } from '@umbraco-cms/backoffice/collection';
 import { UmbRequestReloadChildrenOfEntityEvent } from '@umbraco-cms/backoffice/entity-action';
 import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
@@ -13,10 +12,7 @@ const elementName = 'umb-media-collection';
 
 @customElement(elementName)
 export class UmbMediaCollectionElement extends UmbCollectionDefaultElement {
-	#collectionContext?: UmbMediaCollectionContext;
-
-	#inputTimer?: NodeJS.Timeout;
-	#inputTimerAmount = 500;
+	#collectionContext?: typeof UMB_MEDIA_COLLECTION_CONTEXT.TYPE;
 
 	@state()
 	private _progress = -1;
@@ -79,12 +75,6 @@ export class UmbMediaCollectionElement extends UmbCollectionDefaultElement {
 		eventContext.dispatchEvent(event);
 	}
 
-	#onInput(event: InputEvent & { target: HTMLInputElement }) {
-		const filter = event.target.value ?? '';
-		clearTimeout(this.#inputTimer);
-		this.#inputTimer = setTimeout(() => this.#collectionContext?.setFilter({ filter }), this.#inputTimerAmount);
-	}
-
 	#onProgress(event: ProgressEvent) {
 		this._progress = (event.loaded / event.total) * 100;
 		if (this._progress >= 100) {
@@ -95,11 +85,7 @@ export class UmbMediaCollectionElement extends UmbCollectionDefaultElement {
 	protected override renderToolbar() {
 		return html`
 			<umb-collection-toolbar slot="header">
-				<uui-input
-					id="input-search"
-					label=${this.localize.term('general_search')}
-					placeholder=${this.localize.term('placeholders_search')}
-					@input=${this.#onInput}></uui-input>
+				<umb-collection-filter-field></umb-collection-filter-field>
 			</umb-collection-toolbar>
 			${when(this._progress >= 0, () => html`<uui-loader-bar progress=${this._progress}></uui-loader-bar>`)}
 			<umb-dropzone
@@ -111,14 +97,6 @@ export class UmbMediaCollectionElement extends UmbCollectionDefaultElement {
 				@progress=${this.#onProgress}></umb-dropzone>
 		`;
 	}
-
-	static override readonly styles = [
-		css`
-			#input-search {
-				display: block;
-			}
-		`,
-	];
 }
 
 /** @deprecated Should be exported as `element` only; to be removed in Umbraco 17. */

--- a/src/packages/members/member/collection/member-collection-header.element.ts
+++ b/src/packages/members/member/collection/member-collection-header.element.ts
@@ -1,21 +1,18 @@
 import { UmbMemberTypeTreeRepository } from '../../member-type/tree/member-type-tree.repository.js';
 import type { UmbMemberTypeItemModel } from '../../member-type/repository/item/types.js';
-import type { UmbMemberCollectionContext } from './member-collection.context.js';
 import { UMB_MEMBER_COLLECTION_CONTEXT } from './member-collection.context-token.js';
 import { css, customElement, html, ifDefined, repeat, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 
 @customElement('umb-member-collection-header')
 export class UmbMemberCollectionHeaderElement extends UmbLitElement {
-	@state()
-	private _contentTypes: Array<UmbMemberTypeItemModel> = [];
+	#collectionContext?: typeof UMB_MEMBER_COLLECTION_CONTEXT.TYPE;
 
-	#inputTimer?: NodeJS.Timeout;
-	#inputTimerAmount = 300;
-
-	#collectionContext?: UmbMemberCollectionContext;
 	// TODO: Should we make a collection repository for member types?
 	#contentTypeRepository = new UmbMemberTypeTreeRepository(this);
+
+	@state()
+	private _contentTypes: Array<UmbMemberTypeItemModel> = [];
 
 	@state()
 	private _selectedContentTypeUnique?: string;
@@ -45,18 +42,10 @@ export class UmbMemberCollectionHeaderElement extends UmbLitElement {
 
 	get #getContentTypeFilterLabel() {
 		if (!this._selectedContentTypeUnique) return this.localize.term('general_all') + ' Member types';
-
 		return (
 			this._contentTypes.find((type) => type.unique === this._selectedContentTypeUnique)?.name ||
 			this.localize.term('general_all')
 		);
-	}
-
-	#onSearch(event: InputEvent) {
-		const target = event.target as HTMLInputElement;
-		const filter = target.value || '';
-		clearTimeout(this.#inputTimer);
-		this.#inputTimer = setTimeout(() => this.#collectionContext?.setFilter({ filter }), this.#inputTimerAmount);
 	}
 
 	#onContentTypeFilterChange(contentTypeUnique: string) {
@@ -65,13 +54,11 @@ export class UmbMemberCollectionHeaderElement extends UmbLitElement {
 	}
 
 	override render() {
-		return html`<umb-collection-action-bundle></umb-collection-action-bundle>
-			<uui-input
-				@input=${this.#onSearch}
-				label=${this.localize.term('general_search')}
-				placeholder=${this.localize.term('general_search')}
-				id="input-search"></uui-input>
-			${this.#renderContentTypeFilter()} `;
+		return html`
+			<umb-collection-action-bundle></umb-collection-action-bundle>
+			<umb-collection-filter-field></umb-collection-filter-field>
+			${this.#renderContentTypeFilter()}
+		`;
 	}
 
 	#renderContentTypeFilter() {
@@ -117,7 +104,7 @@ export class UmbMemberCollectionHeaderElement extends UmbLitElement {
 				--uui-button-content-align: left;
 			}
 
-			uui-input {
+			umb-collection-filter-field {
 				width: 100%;
 			}
 		`,

--- a/src/packages/members/member/collection/member-collection.element.ts
+++ b/src/packages/members/member/collection/member-collection.element.ts
@@ -3,9 +3,7 @@ import { UmbCollectionDefaultElement } from '@umbraco-cms/backoffice/collection'
 
 import './member-collection-header.element.js';
 
-const elementName = 'umb-member-collection';
-
-@customElement(elementName)
+@customElement('umb-member-collection')
 export class UmbMemberCollectionElement extends UmbCollectionDefaultElement {
 	protected override renderToolbar() {
 		return html`<umb-member-collection-header slot="header"></umb-member-collection-header>`;
@@ -19,6 +17,6 @@ export { UmbMemberCollectionElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbMemberCollectionElement;
+		'umb-member-collection': UmbMemberCollectionElement;
 	}
 }

--- a/src/packages/members/member/collection/member-collection.element.ts
+++ b/src/packages/members/member/collection/member-collection.element.ts
@@ -10,7 +10,10 @@ export class UmbMemberCollectionElement extends UmbCollectionDefaultElement {
 	}
 }
 
+/** @deprecated Should be exported as `element` only; to be removed in Umbraco 17. */
 export default UmbMemberCollectionElement;
+
+export { UmbMemberCollectionElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {

--- a/src/packages/members/member/collection/member-collection.element.ts
+++ b/src/packages/members/member/collection/member-collection.element.ts
@@ -3,10 +3,12 @@ import { UmbCollectionDefaultElement } from '@umbraco-cms/backoffice/collection'
 
 import './member-collection-header.element.js';
 
-@customElement('umb-member-collection')
+const elementName = 'umb-member-collection';
+
+@customElement(elementName)
 export class UmbMemberCollectionElement extends UmbCollectionDefaultElement {
 	protected override renderToolbar() {
-		return html`<umb-member-collection-header slot="header"></umb-member-collection-header> `;
+		return html`<umb-member-collection-header slot="header"></umb-member-collection-header>`;
 	}
 }
 
@@ -17,6 +19,6 @@ export { UmbMemberCollectionElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		'umb-member-collection': UmbMemberCollectionElement;
+		[elementName]: UmbMemberCollectionElement;
 	}
 }

--- a/src/packages/relations/relation-types/collection/relation-type-collection.element.ts
+++ b/src/packages/relations/relation-types/collection/relation-type-collection.element.ts
@@ -2,6 +2,7 @@ import { customElement, html } from '@umbraco-cms/backoffice/external/lit';
 import { UmbCollectionDefaultElement } from '@umbraco-cms/backoffice/collection';
 
 const elementName = 'umb-relation-type-collection';
+
 @customElement(elementName)
 export class UmbRelationTypeCollectionElement extends UmbCollectionDefaultElement {
 	// NOTE: Returns empty toolbar, so to remove the header padding.

--- a/src/packages/relations/relation-types/collection/relation-type-collection.element.ts
+++ b/src/packages/relations/relation-types/collection/relation-type-collection.element.ts
@@ -10,7 +10,10 @@ export class UmbRelationTypeCollectionElement extends UmbCollectionDefaultElemen
 	}
 }
 
+/** @deprecated Should be exported as `element` only; to be removed in Umbraco 17. */
 export default UmbRelationTypeCollectionElement;
+
+export { UmbRelationTypeCollectionElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {

--- a/src/packages/relations/relation-types/collection/relation-type-collection.element.ts
+++ b/src/packages/relations/relation-types/collection/relation-type-collection.element.ts
@@ -1,9 +1,7 @@
 import { customElement, html } from '@umbraco-cms/backoffice/external/lit';
 import { UmbCollectionDefaultElement } from '@umbraco-cms/backoffice/collection';
 
-const elementName = 'umb-relation-type-collection';
-
-@customElement(elementName)
+@customElement('umb-relation-type-collection')
 export class UmbRelationTypeCollectionElement extends UmbCollectionDefaultElement {
 	// NOTE: Returns empty toolbar, so to remove the header padding.
 	protected override renderToolbar() {
@@ -18,6 +16,6 @@ export { UmbRelationTypeCollectionElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbRelationTypeCollectionElement;
+		'umb-relation-type-collection': UmbRelationTypeCollectionElement;
 	}
 }

--- a/src/packages/user/user-group/collection/user-group-collection-header.element.ts
+++ b/src/packages/user/user-group/collection/user-group-collection-header.element.ts
@@ -5,6 +5,8 @@ import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { debounce } from '@umbraco-cms/backoffice/utils';
 
 const elementName = 'umb-user-group-collection-header';
+
+/** @deprecated This component is no longer used in core; to be removed in Umbraco 17. */
 @customElement(elementName)
 export class UmbUserGroupCollectionHeaderElement extends UmbLitElement {
 	#collectionContext: UmbUserGroupCollectionContext | undefined;

--- a/src/packages/user/user-group/collection/user-group-collection.element.ts
+++ b/src/packages/user/user-group/collection/user-group-collection.element.ts
@@ -1,4 +1,6 @@
-import { html, customElement } from '@umbraco-cms/backoffice/external/lit';
+import { UMB_USER_GROUP_COLLECTION_CONTEXT } from './user-group-collection.context-token.js';
+import { css, customElement, html } from '@umbraco-cms/backoffice/external/lit';
+import { debounce } from '@umbraco-cms/backoffice/utils';
 import { UmbCollectionDefaultElement } from '@umbraco-cms/backoffice/collection';
 
 import './user-group-collection-header.element.js';
@@ -7,9 +9,42 @@ const elementName = 'umb-user-group-collection';
 
 @customElement(elementName)
 export class UmbUserGroupCollectionElement extends UmbCollectionDefaultElement {
-	protected override renderToolbar() {
-		return html`<umb-user-group-collection-header slot="header"></umb-user-group-collection-header>`;
+	#collectionContext?: typeof UMB_USER_GROUP_COLLECTION_CONTEXT.TYPE;
+
+	constructor() {
+		super();
+		this.consumeContext(UMB_USER_GROUP_COLLECTION_CONTEXT, (instance) => {
+			this.#collectionContext = instance;
+		});
 	}
+
+	#onSearch(event: InputEvent) {
+		const target = event.target as HTMLInputElement;
+		const query = target.value || '';
+		this.#debouncedSearch(query);
+	}
+
+	#debouncedSearch = debounce((query: string) => this.#collectionContext?.setFilter({ query }), 500);
+
+	protected override renderToolbar() {
+		return html`
+			<umb-collection-toolbar slot="header">
+				<uui-input
+					@input=${this.#onSearch}
+					label=${this.localize.term('general_search')}
+					placeholder=${this.localize.term('general_search')}
+					id="input-search"></uui-input>
+			</umb-collection-toolbar>
+		`;
+	}
+
+	static override styles = [
+		css`
+			uui-input {
+				display: block;
+			}
+		`,
+	];
 }
 
 export { UmbUserGroupCollectionElement as element };

--- a/src/packages/user/user-group/collection/user-group-collection.element.ts
+++ b/src/packages/user/user-group/collection/user-group-collection.element.ts
@@ -5,9 +5,7 @@ import { UmbCollectionDefaultElement } from '@umbraco-cms/backoffice/collection'
 
 import './user-group-collection-header.element.js';
 
-const elementName = 'umb-user-group-collection';
-
-@customElement(elementName)
+@customElement('umb-user-group-collection')
 export class UmbUserGroupCollectionElement extends UmbCollectionDefaultElement {
 	#collectionContext?: typeof UMB_USER_GROUP_COLLECTION_CONTEXT.TYPE;
 
@@ -51,6 +49,6 @@ export { UmbUserGroupCollectionElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbUserGroupCollectionElement;
+		'umb-user-group-collection': UmbUserGroupCollectionElement;
 	}
 }

--- a/src/packages/user/user-group/collection/user-group-collection.element.ts
+++ b/src/packages/user/user-group/collection/user-group-collection.element.ts
@@ -4,10 +4,11 @@ import { UmbCollectionDefaultElement } from '@umbraco-cms/backoffice/collection'
 import './user-group-collection-header.element.js';
 
 const elementName = 'umb-user-group-collection';
+
 @customElement(elementName)
 export class UmbUserGroupCollectionElement extends UmbCollectionDefaultElement {
 	protected override renderToolbar() {
-		return html`<umb-user-group-collection-header slot="header"></umb-user-group-collection-header> `;
+		return html`<umb-user-group-collection-header slot="header"></umb-user-group-collection-header>`;
 	}
 }
 

--- a/src/packages/user/user/collection/user-collection-header.element.ts
+++ b/src/packages/user/user/collection/user-collection-header.element.ts
@@ -1,14 +1,13 @@
-import type { UmbUserCollectionContext } from './user-collection.context.js';
-import type { UmbUserOrderByOption } from './types.js';
-import type { UmbUserStateFilterType } from './utils/index.js';
 import { UmbUserStateFilter } from './utils/index.js';
 import { UMB_USER_COLLECTION_CONTEXT } from './user-collection.context-token.js';
-import type { UUIBooleanInputEvent, UUICheckboxElement } from '@umbraco-cms/backoffice/external/uui';
-import { css, html, customElement, state, repeat, ifDefined } from '@umbraco-cms/backoffice/external/lit';
-import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import type { UmbUserGroupDetailModel } from '@umbraco-cms/backoffice/user-group';
-import { UmbUserGroupCollectionRepository } from '@umbraco-cms/backoffice/user-group';
+import type { UmbUserOrderByOption } from './types.js';
+import type { UmbUserStateFilterType } from './utils/index.js';
+import { css, customElement, html, ifDefined, repeat, state } from '@umbraco-cms/backoffice/external/lit';
 import { observeMultiple } from '@umbraco-cms/backoffice/observable-api';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { UmbUserGroupCollectionRepository } from '@umbraco-cms/backoffice/user-group';
+import type { UmbUserGroupDetailModel } from '@umbraco-cms/backoffice/user-group';
+import type { UUIBooleanInputEvent, UUICheckboxElement } from '@umbraco-cms/backoffice/external/uui';
 
 @customElement('umb-user-collection-header')
 export class UmbUserCollectionHeaderElement extends UmbLitElement {
@@ -30,9 +29,7 @@ export class UmbUserCollectionHeaderElement extends UmbLitElement {
 	@state()
 	_activeOrderByOption?: UmbUserOrderByOption;
 
-	#collectionContext?: UmbUserCollectionContext;
-	#inputTimer?: NodeJS.Timeout;
-	#inputTimerAmount = 500;
+	#collectionContext?: typeof UMB_USER_COLLECTION_CONTEXT.TYPE;
 
 	#userGroupCollectionRepository = new UmbUserGroupCollectionRepository(this);
 
@@ -73,13 +70,6 @@ export class UmbUserCollectionHeaderElement extends UmbLitElement {
 		if (data) {
 			this._userGroups = data.items;
 		}
-	}
-
-	private _updateSearch(event: InputEvent) {
-		const target = event.target as HTMLInputElement;
-		const filter = target.value || '';
-		clearTimeout(this.#inputTimer);
-		this.#inputTimer = setTimeout(() => this.#collectionContext?.setFilter({ filter }), this.#inputTimerAmount);
 	}
 
 	#onStateFilterChange(event: UUIBooleanInputEvent) {
@@ -141,24 +131,13 @@ export class UmbUserCollectionHeaderElement extends UmbLitElement {
 
 	override render() {
 		return html`
-			<umb-collection-action-bundle></umb-collection-action-bundle>
-			${this.#renderSearch()}
-			<div>${this.#renderFilters()} ${this.#renderCollectionViews()}</div>
+			<umb-collection-toolbar slot="header">
+				<div id="toolbar">
+					<umb-collection-filter-field></umb-collection-filter-field>
+					${this.#renderStatusFilter()} ${this.#renderUserGroupFilter()} ${this.#renderOrderBy()}
+				</div>
+			</umb-collection-toolbar>
 		`;
-	}
-
-	#renderSearch() {
-		return html`
-			<uui-input
-				@input=${this._updateSearch}
-				label=${this.localize.term('visuallyHiddenTexts_userSearchLabel')}
-				placeholder=${this.localize.term('visuallyHiddenTexts_userSearchLabel')}
-				id="input-search"></uui-input>
-		`;
-	}
-
-	#renderFilters() {
-		return html` ${this.#renderStatusFilter()} ${this.#renderUserGroupFilter()} ${this.#renderOrderBy()} `;
 	}
 
 	#renderStatusFilter() {
@@ -230,10 +209,6 @@ export class UmbUserCollectionHeaderElement extends UmbLitElement {
 		`;
 	}
 
-	#renderCollectionViews() {
-		return html` <umb-collection-view-bundle></umb-collection-view-bundle> `;
-	}
-
 	static override styles = [
 		css`
 			:host {
@@ -246,7 +221,15 @@ export class UmbUserCollectionHeaderElement extends UmbLitElement {
 				align-items: center;
 			}
 
-			#input-search {
+			#toolbar {
+				flex: 1;
+				display: flex;
+				gap: var(--uui-size-space-5);
+				justify-content: space-between;
+				align-items: center;
+			}
+
+			umb-collection-filter-field {
 				width: 100%;
 			}
 

--- a/src/packages/user/user/collection/user-collection.element.ts
+++ b/src/packages/user/user/collection/user-collection.element.ts
@@ -3,10 +3,12 @@ import { UmbCollectionDefaultElement } from '@umbraco-cms/backoffice/collection'
 
 import './user-collection-header.element.js';
 
-@customElement('umb-user-collection')
+const elementName = 'umb-user-collection';
+
+@customElement(elementName)
 export class UmbUserCollectionElement extends UmbCollectionDefaultElement {
 	protected override renderToolbar() {
-		return html`<umb-user-collection-header slot="header"></umb-user-collection-header> `;
+		return html`<umb-user-collection-header slot="header"></umb-user-collection-header>`;
 	}
 }
 
@@ -17,6 +19,6 @@ export { UmbUserCollectionElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		'umb-user-collection': UmbUserCollectionElement;
+		[elementName]: UmbUserCollectionElement;
 	}
 }

--- a/src/packages/user/user/collection/user-collection.element.ts
+++ b/src/packages/user/user/collection/user-collection.element.ts
@@ -10,7 +10,10 @@ export class UmbUserCollectionElement extends UmbCollectionDefaultElement {
 	}
 }
 
+/** @deprecated Should be exported as `element` only; to be removed in Umbraco 17. */
 export default UmbUserCollectionElement;
+
+export { UmbUserCollectionElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {

--- a/src/packages/user/user/collection/user-collection.element.ts
+++ b/src/packages/user/user/collection/user-collection.element.ts
@@ -3,9 +3,7 @@ import { UmbCollectionDefaultElement } from '@umbraco-cms/backoffice/collection'
 
 import './user-collection-header.element.js';
 
-const elementName = 'umb-user-collection';
-
-@customElement(elementName)
+@customElement('umb-user-collection')
 export class UmbUserCollectionElement extends UmbCollectionDefaultElement {
 	protected override renderToolbar() {
 		return html`<umb-user-collection-header slot="header"></umb-user-collection-header>`;
@@ -19,6 +17,6 @@ export { UmbUserCollectionElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbUserCollectionElement;
+		'umb-user-collection': UmbUserCollectionElement;
 	}
 }


### PR DESCRIPTION
## Description

Since reviewing the Dictionary Collection toolbar filter (PR #2415) last week, I looked at the other Collection toolbars to see if we could de-duplicate the filter input code, to make a reusable component.

This PR introduces a `<umb-collection-filter-field>` component.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## How to test?

Try out the Collection toolbar filter field on the following areas, to make sure that it still works as expected.

- Dictionary
- Documents
- Extension Insights
- Media
- Members
- Users
- User Groups
