### PR TITLE
Bugfix: Tiptap RTE custom dimensions configuration

### DIFF
--- a/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -183,7 +183,6 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 				box-sizing: border-box;
 				height: 100%;
 				width: 100%;
-				min-height: 400px;
 				display: grid; /* Don't ask me why this is needed, but it is. */
 				pre {
 					background-color: var(--uui-color-surface-alt);

--- a/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -173,6 +173,8 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 			}
 
 			#editor {
+				/* Required as overflow is set to auto, so that the scrollbars don't appear. */
+				display: flex;
 				overflow: auto;
 				border-radius: var(--uui-border-radius);
 				border: 1px solid var(--uui-color-border);
@@ -183,7 +185,7 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 				box-sizing: border-box;
 				height: 100%;
 				width: 100%;
-				display: grid; /* Don't ask me why this is needed, but it is. */
+
 				pre {
 					background-color: var(--uui-color-surface-alt);
 					padding: var(--uui-size-space-2) var(--uui-size-space-4);

--- a/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -93,7 +93,7 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 
 		const dimensions = this.configuration?.getValueByAlias<{ width?: number; height?: number }>('dimensions');
 		if (dimensions?.width) this.setAttribute('style', `max-width: ${dimensions.width}px;`);
-		if (dimensions?.height) element.setAttribute('style', `min-height: ${dimensions.height}px;`);
+		if (dimensions?.height) element.setAttribute('style', `height: ${dimensions.height}px;`);
 
 		this._toolbar = this.configuration?.getValueByAlias<UmbTiptapToolbarValue>('toolbar') ?? [[[]]];
 

--- a/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -93,7 +93,7 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 
 		const dimensions = this.configuration?.getValueByAlias<{ width?: number; height?: number }>('dimensions');
 		if (dimensions?.width) this.setAttribute('style', `max-width: ${dimensions.width}px;`);
-		if (dimensions?.height) element.setAttribute('style', `max-height: ${dimensions.height}px;`);
+		if (dimensions?.height) element.setAttribute('style', `min-height: ${dimensions.height}px;`);
 
 		this._toolbar = this.configuration?.getValueByAlias<UmbTiptapToolbarValue>('toolbar') ?? [[[]]];
 


### PR DESCRIPTION
An [issue](https://github.com/umbraco/Umbraco-CMS/issues/17259) has been raised about Tiptap height is not changing when changing it from the dimensions in settings. This PR makes it happen.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and context
Solves issue https://github.com/umbraco/Umbraco-CMS/issues/17259

## How to test?
Add a tiptop property editor to any doc type
Change it's dimensions by clicking on it
Save
Go to the content tree, find your document type, see the property editor's dimensions changed


## Checklist

- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.

