### PR TITLE
Remove z-index from header in content type design editor property

### DIFF
--- a/src/packages/core/content-type/workspace/views/design/content-type-design-editor-property.element.ts
+++ b/src/packages/core/content-type/workspace/views/design/content-type-design-editor-property.element.ts
@@ -414,7 +414,6 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 				position: sticky;
 				top: var(--uui-size-space-4);
 				height: min-content;
-				z-index: 2;
 			}
 
 			#editor {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When opening the infinite editing in several layer, e.g. when opening the icon picker as third layer in infinite editing the properties are shown above backdrop.

![image](https://github.com/user-attachments/assets/ebf52c73-4771-41a1-9166-0eb74d77bbc5)

Removing this solves this. I don't see a specific need for this?

![image](https://github.com/user-attachments/assets/4d1cdd49-20e3-4330-ac04-77619bbbb823)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
