### PR TITLE
Content type group sorting placeholder

### DIFF
--- a/src/packages/core/content-type/workspace/views/design/content-type-design-editor-group.element.ts
+++ b/src/packages/core/content-type/workspace/views/design/content-type-design-editor-group.element.ts
@@ -228,8 +228,12 @@ export class UmbContentTypeWorkspaceViewEditGroupElement extends UmbLitElement {
 				opacity: 0.5;
 			}
 
-			:host([drag-placeholder]) > * {
+			:host([drag-placeholder]) > uui-box > * {
 				visibility: hidden;
+			}
+			
+			:host([drag-placeholder]) > uui-box > div[slot='header'] {
+				visibility: visible;
 			}
 
 			div[slot='header'] {

--- a/src/packages/core/content-type/workspace/views/design/content-type-design-editor-group.element.ts
+++ b/src/packages/core/content-type/workspace/views/design/content-type-design-editor-group.element.ts
@@ -231,10 +231,6 @@ export class UmbContentTypeWorkspaceViewEditGroupElement extends UmbLitElement {
 			:host([drag-placeholder]) > uui-box > * {
 				visibility: hidden;
 			}
-			
-			:host([drag-placeholder]) > uui-box > div[slot='header'] {
-				visibility: visible;
-			}
 
 			div[slot='header'] {
 				flex: 1;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe the changes in detail -->

Currently I don't think it is clear when a content type group is sorted as when `drag-placeholder` attribute is added the entire element is invisible.
Sorting is initially enabled (which is shouldn't be here) because the group has `draggable="true` - I think I created an issue for that in *Umbraco.CMS.Backoffice* repository, but the issue tracker were later disabled (and issues reported in *CMS* repository instead), so I can't access my own initially reported issues 😅

![image](https://github.com/user-attachments/assets/b713632b-8a5c-428d-9aeb-1059c8a03500)

I think it is best practice to have a drop placeholder indication where the sorted item is placed when releasing dropping item (normally using mouse, but could be touch as well).

![image](https://github.com/user-attachments/assets/e0257bab-8ce8-4374-b35d-3e31d39eb4a1)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
