### PR TITLE
Hotfix: Block Type card thunbnail image path/URL

### DIFF
--- a/src/packages/block/block-type/components/block-type-card/block-type-card.element.ts
+++ b/src/packages/block/block-type/components/block-type-card/block-type-card.element.ts
@@ -6,14 +6,14 @@ import { html, customElement, property, state, ifDefined } from '@umbraco-cms/ba
 import { UmbRepositoryItemsManager } from '@umbraco-cms/backoffice/repository';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UMB_APP_CONTEXT } from '@umbraco-cms/backoffice/app';
-import { removeLastSlashFromPath, transformServerPathToClientPath } from '@umbraco-cms/backoffice/utils';
+import { transformServerPathToClientPath } from '@umbraco-cms/backoffice/utils';
 import { UUICardEvent } from '@umbraco-cms/backoffice/external/uui';
 
 @customElement('umb-block-type-card')
 export class UmbBlockTypeCardElement extends UmbLitElement {
 	//
 	#init: Promise<void>;
-	#appUrl: string = '';
+	#serverUrl: string = '';
 
 	#itemManager = new UmbRepositoryItemsManager<UmbDocumentTypeItemModel>(
 		this,
@@ -29,7 +29,8 @@ export class UmbBlockTypeCardElement extends UmbLitElement {
 		value = transformServerPathToClientPath(value);
 		if (value) {
 			this.#init.then(() => {
-				this._iconFile = removeLastSlashFromPath(this.#appUrl) + value;
+				const url = new URL(value, this.#serverUrl);
+				this._iconFile = url.href;
 			});
 		} else {
 			this._iconFile = undefined;
@@ -77,7 +78,7 @@ export class UmbBlockTypeCardElement extends UmbLitElement {
 		super();
 
 		this.#init = this.getContext(UMB_APP_CONTEXT).then((appContext) => {
-			this.#appUrl = appContext.getServerUrl() + appContext.getBackofficePath();
+			this.#serverUrl = appContext.getServerUrl();
 		});
 
 		this.observe(this.#itemManager.items, (items) => {


### PR DESCRIPTION
## Description

Fixes https://github.com/umbraco/Umbraco-CMS/issues/16985

When running the backoffice from the CMS code (non-Vite), the thumbnail image path/URL was incorrect; it included the backoffice path (e.g. `/umbraco/`) and stripped a trailing slash. Which led to a 404 error when attempting to load the image.

This PR removes the backoffice path from the base URL and makes use of the [`URL()` object](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) to join the paths.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## How to test?

Test that a Block Type card still shows the thumbnail image when running the backoffice via Vite; and that the it works when running the backoffice from the CMS, (e.g. `dotnet run` and `npm run build:for:cms`).
