### PR TITLE
Workaround: Ignore discard changes when in a workspace modal

### DIFF
--- a/src/packages/core/workspace/entity-detail/entity-detail-workspace-base.ts
+++ b/src/packages/core/workspace/entity-detail/entity-detail-workspace-base.ts
@@ -196,6 +196,12 @@ export abstract class UmbEntityDetailWorkspaceContextBase<
 	#onWillNavigate = async (e: CustomEvent) => {
 		const newUrl = e.detail.url;
 
+		/* TODO: temp removal of discard changes in workspace modals.
+		 The modal closes before the discard changes dialog is resolved.*/
+		if (newUrl.includes('/modal/umb-modal-workspace/')) {
+			return true;
+		}
+
 		if (this._checkWillNavigateAway(newUrl) && this._data.getHasUnpersistedChanges()) {
 			e.preventDefault();
 			const modalManager = await this.getContext(UMB_MODAL_MANAGER_CONTEXT);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We are currently experiencing an issue where a workspace modal closes before the discard changes dialog is resolved. As a temporary solution, I have removed the discard changes functionality when a workspace is open in a modal until we have a permanent fix.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
