### PR TITLE
Bugfix: Allow breadcrumb for variant root items

### DIFF
--- a/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.ts
+++ b/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.ts
@@ -45,7 +45,7 @@ export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends Um
 		let structureItems: Array<UmbVariantStructureItemModel> = [];
 
 		const unique = (await this.observe(uniqueObservable, () => {})?.asPromise()) as string;
-		if (!unique) throw new Error('Unique is not available');
+		if (unique === undefined) throw new Error('Unique is not available');
 
 		const entityType = (await this.observe(entityTypeObservable, () => {})?.asPromise()) as string;
 		if (!entityType) throw new Error('Entity type is not available');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We currently get a js error in the console when creating a document in the root. This is caused because the unique is `null` and we throw an error when falsy. This fix changes the code to only check for `undefined`.

![Screenshot 2024-10-24 at 12 09 59](https://github.com/user-attachments/assets/dd77eae5-c21c-45ab-87fd-8c22160f62bb)

## How to test
* Create a document in the root. You will see the error in the console.
* After the fix is applied the error is gone.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
