### PR TITLE
Bugfix: Hide template input when there are no allowed templates

### DIFF
--- a/src/packages/documents/documents/workspace/views/info/document-workspace-view-info.element.ts
+++ b/src/packages/documents/documents/workspace/views/info/document-workspace-view-info.element.ts
@@ -206,7 +206,6 @@ export class UmbDocumentWorkspaceViewInfoElement extends UmbLitElement {
 
 	#renderGeneralSection() {
 		const editDocumentTypePath = this._routeBuilder?.({ entityType: 'document-type' }) ?? '';
-		const editTemplatePath = this._routeBuilder?.({ entityType: 'template' }) ?? '';
 
 		return html`
 			<div class="general-item">
@@ -224,6 +223,20 @@ export class UmbDocumentWorkspaceViewInfoElement extends UmbLitElement {
 					<umb-icon slot="icon" name=${ifDefined(this._documentTypeIcon)}></umb-icon>
 				</uui-ref-node-document-type>
 			</div>
+			${this.#renderTemplateInput()}
+			<div class="general-item">
+				<strong><umb-localize key="template_id">Id</umb-localize></strong>
+				<span>${this._documentUnique}</span>
+			</div>
+		`;
+	}
+
+	#renderTemplateInput() {
+		if (this._allowedTemplates?.length === 0) return nothing;
+
+		const editTemplatePath = this._routeBuilder?.({ entityType: 'template' }) ?? '';
+
+		return html`
 			<div class="general-item">
 				<strong><umb-localize key="template_template">Template</umb-localize></strong>
 				${this._templateUnique
@@ -246,10 +259,6 @@ export class UmbDocumentWorkspaceViewInfoElement extends UmbLitElement {
 								look="placeholder"
 								@click=${this.#openTemplatePicker}></uui-button>
 						`}
-			</div>
-			<div class="general-item">
-				<strong><umb-localize key="template_id">Id</umb-localize></strong>
-				<span>${this._documentUnique}</span>
 			</div>
 		`;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR hides the template input on a document info view when there are no configured allowed templates. We do this to prevent an experience where the editor opens an empty template picker or a template picker with only disabled items in it. The same UX will be useful when the CMS is fully headless and there are no templates.

Here is a screenshot of something that is not there  😄 

<img width="1228" alt="Screenshot 2024-10-24 at 23 39 23" src="https://github.com/user-attachments/assets/6039e355-164a-4056-8f44-2dab960217ce">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
