### PR TITLE
Bugfix: Detail repository base `save()` returns updated model

### DIFF
--- a/src/packages/core/repository/detail/detail-repository-base.ts
+++ b/src/packages/core/repository/detail/detail-repository-base.ts
@@ -124,7 +124,7 @@ export abstract class UmbDetailRepositoryBase<
 			this.#notificationContext!.peek('positive', notification);
 		}
 
-		return { data: model, error };
+		return { data: updatedData, error };
 	}
 
 	/**


### PR DESCRIPTION
## Description

I'd noticed on a Media item workspace (on the Info/General panel) that the "Last edited" (updated date) property wasn't updating. Drilling down, I found that the base class `UmbDetailRepositoryBase.save()` method was returning the original model value, not the updated model (from the backend/server). Meaning properties that are updated by the server weren't being reflected on the client side.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## How to test?

Go to an existing Media item, go to the Info workspace view, press the Save button, notice that the "Last edited" date has updated (without refresh).