### PR TITLE
Feature: Document Workspace Info reload components

### DIFF
--- a/src/packages/core/components/history/history-item.element.ts
+++ b/src/packages/core/components/history/history-item.element.ts
@@ -63,6 +63,7 @@ export class UmbHistoryItemElement extends UmbLitElement {
 			.user-info div {
 				display: flex;
 				flex-direction: column;
+				min-width: var(--uui-size-60);
 			}
 
 			.detail {

--- a/src/packages/documents/documents/repository/index.ts
+++ b/src/packages/documents/documents/repository/index.ts
@@ -1,6 +1,7 @@
 export { UmbDocumentDetailRepository, UMB_DOCUMENT_DETAIL_REPOSITORY_ALIAS } from './detail/index.js';
 export { UmbDocumentItemRepository, UMB_DOCUMENT_ITEM_REPOSITORY_ALIAS } from './item/index.js';
 export { UmbDocumentPublishingRepository, UMB_DOCUMENT_PUBLISHING_REPOSITORY_ALIAS } from './publishing/index.js';
+export { UmbDocumentUrlRepository, UMB_DOCUMENT_URL_REPOSITORY_ALIAS } from './url/index.js';
 export { UmbDocumentPreviewRepository } from './preview/index.js';
 
 export type { UmbDocumentItemModel } from './item/types.js';

--- a/src/packages/documents/documents/repository/manifests.ts
+++ b/src/packages/documents/documents/repository/manifests.ts
@@ -1,5 +1,11 @@
 import { manifests as detailManifests } from './detail/manifests.js';
 import { manifests as itemManifests } from './item/manifests.js';
 import { manifests as publishingManifests } from './publishing/manifests.js';
+import { manifests as urlManifests } from './url/manifests.js';
 
-export const manifests: Array<UmbExtensionManifest> = [...detailManifests, ...itemManifests, ...publishingManifests];
+export const manifests: Array<UmbExtensionManifest> = [
+	...detailManifests,
+	...itemManifests,
+	...publishingManifests,
+	...urlManifests,
+];

--- a/src/packages/documents/documents/repository/url/constants.ts
+++ b/src/packages/documents/documents/repository/url/constants.ts
@@ -1,0 +1,2 @@
+export const UMB_DOCUMENT_URL_REPOSITORY_ALIAS = 'Umb.Repository.Document.Url';
+export const UMB_DOCUMENT_URL_STORE_ALIAS = 'Umb.Store.Document.Url';

--- a/src/packages/documents/documents/repository/url/document-url.repository.ts
+++ b/src/packages/documents/documents/repository/url/document-url.repository.ts
@@ -1,0 +1,13 @@
+import type { UmbDocumentUrlsModel } from './types.js';
+import { UMB_DOCUMENT_URL_STORE_CONTEXT } from './document-url.store.context-token.js';
+import { UmbDocumentUrlServerDataSource } from './document-url.server.data-source.js';
+import { UmbItemRepositoryBase } from '@umbraco-cms/backoffice/repository';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+
+export class UmbDocumentUrlRepository extends UmbItemRepositoryBase<UmbDocumentUrlsModel> {
+	constructor(host: UmbControllerHost) {
+		super(host, UmbDocumentUrlServerDataSource, UMB_DOCUMENT_URL_STORE_CONTEXT);
+	}
+}
+
+export { UmbDocumentUrlRepository as api };

--- a/src/packages/documents/documents/repository/url/document-url.server.data-source.ts
+++ b/src/packages/documents/documents/repository/url/document-url.server.data-source.ts
@@ -1,0 +1,29 @@
+import type { UmbDocumentUrlsModel } from './types.js';
+import { DocumentService } from '@umbraco-cms/backoffice/external/backend-api';
+import { UmbItemServerDataSourceBase } from '@umbraco-cms/backoffice/repository';
+import type { DocumentUrlInfoResponseModel } from '@umbraco-cms/backoffice/external/backend-api';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+
+/**
+ * A server data source for Document URLs
+ * @class UmbDocumentUrlServerDataSource
+ * @implements {DocumentTreeDataSource}
+ */
+export class UmbDocumentUrlServerDataSource extends UmbItemServerDataSourceBase<
+	DocumentUrlInfoResponseModel,
+	UmbDocumentUrlsModel
+> {
+	/**
+	 * Creates an instance of UmbDocumentUrlServerDataSource.
+	 * @param {UmbControllerHost} host - The controller host for this controller to be appended to
+	 * @memberof UmbDocumentUrlServerDataSource
+	 */
+	constructor(host: UmbControllerHost) {
+		super(host, { getItems, mapper });
+	}
+}
+
+/* eslint-disable local-rules/no-direct-api-import */
+const getItems = (uniques: Array<string>) => DocumentService.getDocumentUrls({ id: uniques });
+
+const mapper = (item: DocumentUrlInfoResponseModel): UmbDocumentUrlsModel => ({ unique: item.id, urls: item.urlInfos });

--- a/src/packages/documents/documents/repository/url/document-url.store.context-token.ts
+++ b/src/packages/documents/documents/repository/url/document-url.store.context-token.ts
@@ -1,0 +1,4 @@
+import type UmbDocumentUrlStore from './document-url.store.js';
+import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
+
+export const UMB_DOCUMENT_URL_STORE_CONTEXT = new UmbContextToken<UmbDocumentUrlStore>('UmbDocumentUrlStore');

--- a/src/packages/documents/documents/repository/url/document-url.store.ts
+++ b/src/packages/documents/documents/repository/url/document-url.store.ts
@@ -1,0 +1,23 @@
+import type { UmbDocumentDetailModel } from '../../types.js';
+import { UMB_DOCUMENT_URL_STORE_CONTEXT } from './document-url.store.context-token.js';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import { UmbItemStoreBase } from '@umbraco-cms/backoffice/store';
+
+/**
+ * @class UmbDocumentUrlStore
+ * @augments {UmbStoreBase}
+ * @description - Data Store for Document URLs
+ */
+
+export class UmbDocumentUrlStore extends UmbItemStoreBase<UmbDocumentDetailModel> {
+	/**
+	 * Creates an instance of UmbDocumentUrlStore.
+	 * @param {UmbControllerHost} host - The controller host for this controller to be appended to
+	 * @memberof UmbDocumentUrlStore
+	 */
+	constructor(host: UmbControllerHost) {
+		super(host, UMB_DOCUMENT_URL_STORE_CONTEXT.toString());
+	}
+}
+
+export default UmbDocumentUrlStore;

--- a/src/packages/documents/documents/repository/url/index.ts
+++ b/src/packages/documents/documents/repository/url/index.ts
@@ -1,0 +1,2 @@
+export { UmbDocumentUrlRepository } from './document-url.repository.js';
+export { UMB_DOCUMENT_URL_REPOSITORY_ALIAS } from './constants.js';

--- a/src/packages/documents/documents/repository/url/manifests.ts
+++ b/src/packages/documents/documents/repository/url/manifests.ts
@@ -1,0 +1,18 @@
+import { UMB_DOCUMENT_URL_REPOSITORY_ALIAS, UMB_DOCUMENT_URL_STORE_ALIAS } from './constants.js';
+import type { ManifestItemStore, ManifestRepository } from '@umbraco-cms/backoffice/extension-registry';
+
+const urlRepository: ManifestRepository = {
+	type: 'repository',
+	alias: UMB_DOCUMENT_URL_REPOSITORY_ALIAS,
+	name: 'Document Url Repository',
+	api: () => import('./document-url.repository.js'),
+};
+
+const urlStore: ManifestItemStore = {
+	type: 'itemStore',
+	alias: UMB_DOCUMENT_URL_STORE_ALIAS,
+	name: 'Document Url Store',
+	api: () => import('./document-url.store.js'),
+};
+
+export const manifests = [urlRepository, urlStore];

--- a/src/packages/documents/documents/repository/url/types.ts
+++ b/src/packages/documents/documents/repository/url/types.ts
@@ -1,0 +1,9 @@
+export interface UmbDocumentUrlsModel {
+	unique: string;
+	urls: Array<UmbDocumentUrlModel>;
+}
+
+export interface UmbDocumentUrlModel {
+	culture?: string | null;
+	url?: string;
+}

--- a/src/packages/documents/documents/workspace/views/info/document-workspace-view-info-links.element.ts
+++ b/src/packages/documents/documents/workspace/views/info/document-workspace-view-info-links.element.ts
@@ -1,0 +1,134 @@
+import { UmbDocumentUrlRepository } from '../../../repository/url/document-url.repository.js';
+import { UMB_DOCUMENT_WORKSPACE_CONTEXT } from '../../document-workspace.context-token.js';
+import type { UmbDocumentUrlModel } from '../../../repository/url/types.js';
+import { css, customElement, html, nothing, repeat, state, when } from '@umbraco-cms/backoffice/external/lit';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { UmbRequestReloadStructureForEntityEvent } from '@umbraco-cms/backoffice/entity-action';
+import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
+import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
+
+@customElement('umb-document-workspace-view-info-links')
+export class UmbDocumentWorkspaceViewInfoLinksElement extends UmbLitElement {
+	#documentUrlRepository = new UmbDocumentUrlRepository(this);
+
+	#workspaceContext?: typeof UMB_DOCUMENT_WORKSPACE_CONTEXT.TYPE;
+
+	@state()
+	private _invariantCulture = 'en-US';
+
+	@state()
+	private _items?: Array<UmbDocumentUrlModel>;
+
+	constructor() {
+		super();
+
+		this.consumeContext(UMB_ACTION_EVENT_CONTEXT, (context) => {
+			context.addEventListener(UmbRequestReloadStructureForEntityEvent.TYPE, () => {
+				this.#requestUrls();
+			});
+		});
+
+		this.consumeContext(UMB_DOCUMENT_WORKSPACE_CONTEXT, (context) => {
+			this.#workspaceContext = context;
+			this.#requestUrls();
+		});
+	}
+
+	async #requestUrls() {
+		const unique = this.#workspaceContext?.getUnique();
+		if (!unique) throw new Error('Document unique is required');
+
+		const { data } = await this.#documentUrlRepository.requestItems([unique]);
+
+		if (data?.length) {
+			this._items = data[0].urls;
+		}
+	}
+
+	override render() {
+		return html`
+			<uui-box headline=${this.localize.term('general_links')} style="--uui-box-default-padding: 0;">
+				<div id="link-section">
+					${when(
+						this._items?.length,
+						() => this.#renderUrls(),
+						() => this.#renderUnpublished(),
+					)}
+				</div>
+			</uui-box>
+		`;
+	}
+
+	#renderUrls() {
+		if (!this._items) return nothing;
+		return html`
+			${repeat(
+				this._items!,
+				(item) => item.culture,
+				(item) => html`
+					<a href=${item.url ?? '#'} target="_blank" class="link-item">
+						<span class="culture">${item.culture}</span>
+						<span class="url">${item.url}</span>
+						<uui-icon name="icon-out"></uui-icon>
+					</a>
+				`,
+			)}
+		`;
+	}
+
+	#renderUnpublished() {
+		return html`
+			<div class="link-item">
+				<span class="culture">${this._invariantCulture}</span>
+				<span class="url">
+					<em><umb-localize key="content_parentNotPublishedAnomaly"></umb-localize></em>
+				</span>
+			</div>
+		`;
+	}
+
+	static override styles = [
+		UmbTextStyles,
+		css`
+			#link-section {
+				display: flex;
+				flex-direction: column;
+				text-align: left;
+			}
+
+			.link-item {
+				padding: var(--uui-size-space-4) var(--uui-size-space-6);
+				display: grid;
+				grid-template-columns: auto 1fr auto;
+				gap: var(--uui-size-6);
+				color: inherit;
+				text-decoration: none;
+
+				&:is(a) {
+					cursor: pointer;
+				}
+
+				&:is(a):hover {
+					background: var(--uui-color-divider);
+				}
+
+				.culture {
+					color: var(--uui-color-divider-emphasis);
+				}
+
+				uui-icon {
+					margin-right: var(--uui-size-space-2);
+					vertical-align: middle;
+				}
+			}
+		`,
+	];
+}
+
+export default UmbDocumentWorkspaceViewInfoLinksElement;
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-document-workspace-view-info-links': UmbDocumentWorkspaceViewInfoLinksElement;
+	}
+}


### PR DESCRIPTION
## Description

Fixes https://github.com/umbraco/Umbraco-CMS/issues/17183.

Half feature, half bug fix. When saving/publishing a document, the components on the Info workspace view were not automatically updating. Using the Request Reload Structure event (from the workspace context), the Info components are refreshed on save/publish.

For the Links component, this makes use of a new dedicated Document URL Repository, (as opposed to observing the workspace context's `.urls` property).


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How to test?

Go to an existing document, go to the Info workspace view, rename the document (e.g. append a number), press Publish, notice that the URL is updated in the "Links" component and that the "History" component has the latest Save/Publish audit logs.