### PR TITLE
feat: Add validation hints to unnamed tabs

### DIFF
--- a/src/packages/core/content-type/workspace/views/design/content-type-design-editor.element.ts
+++ b/src/packages/core/content-type/workspace/views/design/content-type-design-editor.element.ts
@@ -478,7 +478,7 @@ export class UmbContentTypeDesignEditorElement extends UmbLitElement implements 
 		const ownedTab = this.#tabsStructureHelper.isOwnerChildContainer(tab.id!) ?? false;
 
 		return html`<uui-tab
-			label=${tab.name && tab.name !== '' ? tab.name : 'unnamed'}
+			label=${tab.name && tab.name !== '' ? tab.name : 'Unnamed'}
 			.active=${tabActive}
 			href=${path}
 			data-umb-tab-id=${ifDefined(tab.id)}
@@ -489,10 +489,12 @@ export class UmbContentTypeDesignEditorElement extends UmbLitElement implements 
 
 	renderTabInner(tab: UmbPropertyTypeContainerModel, tabActive: boolean, ownedTab: boolean) {
 		// TODO: Localize this:
+		const hasTabName = tab.name && tab.name !== '';
+		const tabName = hasTabName ? tab.name : 'Unnamed';
 		if (this._sortModeActive) {
 			return html`<div class="tab">
 				${ownedTab
-					? html`<uui-icon name="icon-navigation" class="drag-${tab.id}"> </uui-icon>${tab.name!}
+					? html`<uui-icon name="icon-navigation" class="drag-${tab.id}"> </uui-icon>${tabName}
 							<uui-input
 								label="sort order"
 								type="number"
@@ -512,6 +514,7 @@ export class UmbContentTypeDesignEditorElement extends UmbLitElement implements 
 					label=${tab.name!}
 					value="${tab.name!}"
 					auto-width
+					minlength="1"
 					@change=${(e: InputEvent) => this.#tabNameChanged(e, tab)}
 					@input=${(e: InputEvent) => this.#tabNameChanged(e, tab)}
 					@blur=${(e: FocusEvent) => this.#tabNameBlur(e, tab)}>
@@ -521,7 +524,11 @@ export class UmbContentTypeDesignEditorElement extends UmbLitElement implements 
 		}
 
 		if (ownedTab) {
-			return html`<div class="not-active">${tab.name!} ${this.renderDeleteFor(tab)}</div>`;
+			return html`<div class="not-active">
+				<span class=${hasTabName ? '' : 'invaild'}>${hasTabName ? tab.name : 'Unnamed'}</span> ${this.renderDeleteFor(
+					tab,
+				)}
+			</div>`;
 		} else {
 			return html`<div class="not-active"><uui-icon name="icon-merge"></uui-icon>${tab.name!}</div>`;
 		}
@@ -630,6 +637,10 @@ export class UmbContentTypeDesignEditorElement extends UmbLitElement implements 
 				gap: var(--uui-size-space-3);
 			}
 
+			.invaild {
+				color: var(--uui-color-danger, #d42054);
+			}
+
 			.trash {
 				opacity: 1;
 				transition: opacity 100ms;
@@ -640,7 +651,7 @@ export class UmbContentTypeDesignEditorElement extends UmbLitElement implements 
 				transition: opacity 100ms;
 			}
 
-			uui-input:not(:focus, :hover) {
+			uui-input:not(:focus, :hover, :invalid) {
 				border: 1px solid transparent;
 			}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe the changes in detail -->

This adds simple validation hints (Red text) when a tab is unnamed

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Helps visualize where the error is coming from. (An error is shown if you try to save without naming the tab)

## How to test?

## Screenshots (if appropriate)

https://github.com/user-attachments/assets/62fd6f83-7f3c-4fe8-b2eb-75c9f76ce546


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
