### PR TITLE
Feature: Tiptap "Clear Formatting" toolbar action

### DIFF
--- a/src/packages/core/icon-registry/icon-dictionary.json
+++ b/src/packages/core/icon-registry/icon-dictionary.json
@@ -367,6 +367,10 @@
 			"file": "circuit-board.svg"
 		},
 		{
+			"name": "icon-clear-formatting",
+			"file": "remove-formatting.svg"
+		},
+		{
 			"name": "icon-client",
 			"file": "user.svg",
 			"legacy": true

--- a/src/packages/core/icon-registry/icons.ts
+++ b/src/packages/core/icon-registry/icons.ts
@@ -355,6 +355,10 @@ name: "icon-circuits",
 
 path: () => import("./icons/icon-circuits.js"),
 },{
+name: "icon-clear-formatting",
+
+path: () => import("./icons/icon-clear-formatting.js"),
+},{
 name: "icon-client",
 legacy: true,
 path: () => import("./icons/icon-client.js"),

--- a/src/packages/core/icon-registry/icons/icon-clear-formatting.ts
+++ b/src/packages/core/icon-registry/icons/icon-clear-formatting.ts
@@ -1,0 +1,18 @@
+export default `<!-- @license lucide-static v0.446.0 - ISC -->
+<svg
+  class="lucide lucide-remove-formatting"
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1.75"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M4 7V4h16v3" />
+  <path d="M5 20h6" />
+  <path d="M13 4 8 20" />
+  <path d="m15 15 5 5" />
+  <path d="m20 15-5 5" />
+</svg>
+`;

--- a/src/packages/tiptap/extensions/manifests.ts
+++ b/src/packages/tiptap/extensions/manifests.ts
@@ -196,6 +196,18 @@ const toolbarExtensions: Array<ManifestTiptapToolbarExtension> = [
 	{
 		type: 'tiptapToolbarExtension',
 		kind: 'button',
+		alias: 'Umb.Tiptap.Toolbar.ClearFormatting',
+		name: 'Clear Formatting Tiptap Extension',
+		api: () => import('./toolbar/clear-formatting.extension.js'),
+		meta: {
+			alias: 'clear-formatting',
+			icon: 'icon-clear-formatting',
+			label: 'Clear Formatting',
+		},
+	},
+	{
+		type: 'tiptapToolbarExtension',
+		kind: 'button',
 		alias: 'Umb.Tiptap.Toolbar.TextAlignLeft',
 		name: 'Text Align Left Tiptap Extension',
 		api: () => import('./toolbar/text-align-left.extension.js'),

--- a/src/packages/tiptap/extensions/toolbar/clear-formatting.extension.ts
+++ b/src/packages/tiptap/extensions/toolbar/clear-formatting.extension.ts
@@ -1,0 +1,8 @@
+import { UmbTiptapToolbarElementApiBase } from '../types.js';
+import type { Editor } from '@umbraco-cms/backoffice/external/tiptap';
+
+export default class UmbTiptapToolbarClearFormattingExtensionApi extends UmbTiptapToolbarElementApiBase {
+	override execute(editor?: Editor) {
+		editor?.chain().focus().unsetAllMarks().run();
+	}
+}


### PR DESCRIPTION
## Description

Adds a **Clear Formatting** feature for the Tiptap RTE toolbar.

Introduces the Lucide icon "[remove-formatting](https://lucide.dev/icons/remove-formatting)" to the backoffice.


## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## How to test?

Enable the "Clear Formatting" action on a Tiptap toolbar configuration. Go to the Tiptap RTE, highlight text that has formatting, e.g. bold, italic, etc. Press the "Clear Formatting" button and notice that the text formatting has been removed.

## Screenshots (if appropriate)

![Screenshot 2024-10-29 070453](https://github.com/user-attachments/assets/d9d8bf41-ccc2-423e-a5ee-dc4268b5cc75)

