### PR TITLE
Cosmetic: Tiptap toolbar, background color + box shadow

### DIFF
--- a/src/packages/tiptap/components/input-tiptap/tiptap-toolbar.element.ts
+++ b/src/packages/tiptap/components/input-tiptap/tiptap-toolbar.element.ts
@@ -93,11 +93,16 @@ export class UmbTiptapToolbarElement extends UmbLitElement {
 			border: 1px solid var(--uui-color-border);
 			border-bottom-left-radius: 0;
 			border-bottom-right-radius: 0;
-			background-color: var(--uui-color-surface);
+			box-shadow:
+				0 2px 2px -2px rgba(34, 47, 62, 0.1),
+				0 8px 8px -4px rgba(34, 47, 62, 0.07);
+
+			background-color: var(--uui-color-surface-alt);
 			color: var(--color-text);
 			display: grid;
 			grid-template-columns: repeat(auto-fill, 10px);
 			grid-auto-flow: row;
+
 			position: sticky;
 			top: -25px;
 			left: 0px;


### PR DESCRIPTION
## Description

Experimenting with a background colour (plus box shadow) on the Tiptap RTE toolbar, to give it more definition and depth.

**Before**
![Screenshot 2024-10-29 071539](https://github.com/user-attachments/assets/8011030e-0c14-45c1-870a-82266d19655c)

**After**
![Screenshot 2024-10-29 071510](https://github.com/user-attachments/assets/4c4fd8a2-eb7e-4a54-a816-fde77d08429f)

## Types of changes

- [x] Cosmetic (because _life is beautiful_)

