### PR TITLE
Bugfix: Word wraps long Data Type names in picker

### DIFF
--- a/src/packages/data-type/modals/data-type-picker-flow/data-type-picker-flow-data-type-picker-modal.element.ts
+++ b/src/packages/data-type/modals/data-type-picker-flow/data-type-picker-flow-data-type-picker-modal.element.ts
@@ -169,6 +169,7 @@ export class UmbDataTypePickerFlowDataTypePickerModalElement extends UmbModalBas
 				grid-template-rows: 40px 1fr;
 				height: 100%;
 				width: 100%;
+				word-break: break-word;
 			}
 			.icon {
 				font-size: 2em;

--- a/src/packages/data-type/modals/data-type-picker-flow/data-type-picker-flow-modal.element.ts
+++ b/src/packages/data-type/modals/data-type-picker-flow/data-type-picker-flow-modal.element.ts
@@ -448,6 +448,7 @@ export class UmbDataTypePickerFlowModalElement extends UmbModalBaseElement<
 				grid-template-rows: 40px 1fr;
 				height: 100%;
 				width: 100%;
+				word-break: break-word;
 			}
 
 			#item-grid .item .icon {


### PR DESCRIPTION
This fixes [#17036](https://github.com/umbraco/Umbraco-CMS/issues/17036)

## Description

Having datatype names that are very long and without white-spaces makes the list af data types hard to read when picking a data type to a property on a document type.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)


## How to test?

1. Create a data-type with a long name without white-spaces - maybe create a couple of data type with long names/words
For example: BoxHalfWidthPosition
2. Create a document type and add a property and see the problem in the list of data types.

Problem:
![image](https://github.com/user-attachments/assets/0be1ffb7-ad8d-4335-a960-046160ec8bed)

Fix:
![image](https://github.com/user-attachments/assets/03270311-1458-4684-98c9-27ed11c4237d)



