### PR TITLE
Correct the notification message when a user is enabled

### DIFF
--- a/src/packages/user/user/repository/enable/enable-user.repository.ts
+++ b/src/packages/user/user/repository/enable/enable-user.repository.ts
@@ -22,7 +22,7 @@ export class UmbEnableUserRepository extends UmbUserRepositoryBase {
 				this.detailStore?.updateItem(id, { state: UserStateModel.ACTIVE });
 			});
 
-			const notification = { data: { message: `User disabled` } };
+			const notification = { data: { message: `User enabled` } };
 			this.notificationContext?.peek('positive', notification);
 		}
 


### PR DESCRIPTION
## Description

This PR corrects the notification message when a user is enabled.

Previously it used to display "User disabled" when enabling a user.

Replicated on v15.1.0-rc1.preview.16

## How to test

* Go the Users section in the backoffice.
* Create a new user or use an existing user
* Disable the user.
* Enable the user.
* The correct notification message should be displayed.


https://github.com/user-attachments/assets/91ef7533-00d6-4358-91f4-3dadbba77302

