### PR TITLE
Feature: Set the URL field as required and focus on it

### DIFF
--- a/src/packages/webhook/workspace/webhook/views/webhook-details-workspace-view.element.ts
+++ b/src/packages/webhook/workspace/webhook/views/webhook-details-workspace-view.element.ts
@@ -111,7 +111,7 @@ export class UmbWebhookDetailsWorkspaceViewElement extends UmbLitElement impleme
 			<uui-box>
 				<umb-property-layout
 					label=${this.localize.term('webhooks_url')}
-					description=${this.localize.term('webhooks_urlDescription')}>
+					description=${this.localize.term('webhooks_urlDescription')} mandatory="true">
 					<uui-input @input=${this.#onUrlChange} .value=${this._webhook.url} slot="editor" required="true" ${umbFocus()}></uui-input>
 				</umb-property-layout>
 				<umb-property-layout

--- a/src/packages/webhook/workspace/webhook/views/webhook-details-workspace-view.element.ts
+++ b/src/packages/webhook/workspace/webhook/views/webhook-details-workspace-view.element.ts
@@ -110,9 +110,15 @@ export class UmbWebhookDetailsWorkspaceViewElement extends UmbLitElement impleme
 		return html`
 			<uui-box>
 				<umb-property-layout
+					mandatory
 					label=${this.localize.term('webhooks_url')}
-					description=${this.localize.term('webhooks_urlDescription')} mandatory="true">
-					<uui-input @input=${this.#onUrlChange} .value=${this._webhook.url} slot="editor" required="true" ${umbFocus()}></uui-input>
+					description=${this.localize.term('webhooks_urlDescription')}>
+					<uui-input
+						@input=${this.#onUrlChange}
+						.value=${this._webhook.url}
+						slot="editor"
+						required="true"
+						${umbFocus()}></uui-input>
 				</umb-property-layout>
 				<umb-property-layout
 					label=${this.localize.term('webhooks_events')}

--- a/src/packages/webhook/workspace/webhook/views/webhook-details-workspace-view.element.ts
+++ b/src/packages/webhook/workspace/webhook/views/webhook-details-workspace-view.element.ts
@@ -2,7 +2,7 @@ import { UMB_WEBHOOK_WORKSPACE_CONTEXT } from '../webhook-workspace.context-toke
 import type { UmbInputWebhookHeadersElement } from '../../../components/input-webhook-headers.element.js';
 import type { UmbInputWebhookEventsElement } from '../../../components/input-webhook-events.element.js';
 import { css, customElement, html, state, nothing } from '@umbraco-cms/backoffice/external/lit';
-import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { UmbLitElement, umbFocus } from '@umbraco-cms/backoffice/lit-element';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import type { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import type { UmbInputDocumentTypeElement } from '@umbraco-cms/backoffice/document-type';
@@ -112,7 +112,7 @@ export class UmbWebhookDetailsWorkspaceViewElement extends UmbLitElement impleme
 				<umb-property-layout
 					label=${this.localize.term('webhooks_url')}
 					description=${this.localize.term('webhooks_urlDescription')}>
-					<uui-input @input=${this.#onUrlChange} .value=${this._webhook.url} slot="editor"></uui-input>
+					<uui-input @input=${this.#onUrlChange} .value=${this._webhook.url} slot="editor" required="true" ${umbFocus()}></uui-input>
 				</umb-property-layout>
 				<umb-property-layout
 					label=${this.localize.term('webhooks_events')}


### PR DESCRIPTION
## Description

This fixes [16388](https://github.com/umbraco/Umbraco-CMS/issues/16388)

Replicated on 15.1.0-rc1.preview.16.

## Types of changes

The URL is a mandatory field for a webhook, so I've set it as required. Additionally I have also set it to autofocus on load.

## Screenshots
https://github.com/user-attachments/assets/409b157c-505e-487f-8662-f65c06ae8c1e


