### PR TITLE
Allow for the document create options to be opened on space/enter clicked

### DIFF
--- a/src/packages/documents/documents/entity-actions/create/document-create-options-modal.element.ts
+++ b/src/packages/documents/documents/entity-actions/create/document-create-options-modal.element.ts
@@ -176,7 +176,8 @@ export class UmbDocumentCreateOptionsModalElement extends UmbModalBaseElement<
 									.alias=${this.localize.string(documentType.description ?? '')}
 									select-only
 									selectable
-									@selected=${() => this.#onSelectDocumentType(documentType.unique)}>
+									@selected=${() => this.#onSelectDocumentType(documentType.unique)}
+									@open=${() => this.#onSelectDocumentType(documentType.unique)}>
 									<umb-icon slot="icon" name=${documentType.icon || 'icon-circle-dotted'}></umb-icon>
 								</uui-ref-node-document-type>
 							`,


### PR DESCRIPTION

## Description

I noticed this when I was trying to replicate [16207](https://github.com/umbraco/Umbraco-CMS/issues/16207)

Basically this allows for the document create options from the modal to be opened when the space or enter is pressed.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## How to test?

Open the Content tab
Using the keyboard, tab to the + icon to create a new document.
Press enter/space to start the action.
The 'document creation options' modal will open.
Tab to the document type you'd like to create & press enter/space.

## Screenshots
Before the change:

https://github.com/user-attachments/assets/32276da1-4d75-40f2-8e5d-e8d76ee892bf

After the change:

https://github.com/user-attachments/assets/651c7b3b-ca80-4dcf-86a5-dadcc994b85a

