### PR TITLE
Hotfix: Ensure scaffolding is done before initializing the redirect controller

### DIFF
--- a/src/packages/block/block-type/workspace/block-type-workspace.context.ts
+++ b/src/packages/block/block-type/workspace/block-type-workspace.context.ts
@@ -46,7 +46,7 @@ export class UmbBlockTypeWorkspaceContext<BlockTypeData extends UmbBlockTypeWith
 
 					const elementTypeKey = info.match.params.elementTypeKey;
 					const groupKey = info.match.params.groupKey === 'null' ? null : info.match.params.groupKey;
-					this.create(elementTypeKey, groupKey);
+					await this.create(elementTypeKey, groupKey);
 
 					new UmbWorkspaceIsNewRedirectController(
 						this,

--- a/src/packages/block/block/workspace/block-workspace.context.ts
+++ b/src/packages/block/block/workspace/block-workspace.context.ts
@@ -176,7 +176,7 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 					(component as UmbBlockWorkspaceEditorElement).workspaceAlias = manifest.alias;
 
 					const elementTypeKey = info.match.params.elementTypeKey;
-					this.create(elementTypeKey);
+					await this.create(elementTypeKey);
 
 					new UmbWorkspaceIsNewRedirectController(
 						this,

--- a/src/packages/core/property-type/workspace/property-type-workspace.context.ts
+++ b/src/packages/core/property-type/workspace/property-type-workspace.context.ts
@@ -63,7 +63,7 @@ export class UmbPropertyTypeWorkspaceContext<PropertyTypeData extends UmbPropert
 
 					const containerUnique =
 						info.match.params.containerUnique === 'null' ? null : info.match.params.containerUnique;
-					this.create(containerUnique);
+					await this.create(containerUnique);
 
 					new UmbWorkspaceIsNewRedirectController(
 						this,

--- a/src/packages/data-type/workspace/data-type-workspace.context.ts
+++ b/src/packages/data-type/workspace/data-type-workspace.context.ts
@@ -86,10 +86,10 @@ export class UmbDataTypeWorkspaceContext
 			{
 				path: 'create/parent/:entityType/:parentUnique',
 				component: UmbDataTypeWorkspaceEditorElement,
-				setup: (_component, info) => {
+				setup: async (_component, info) => {
 					const parentEntityType = info.match.params.entityType;
 					const parentUnique = info.match.params.parentUnique === 'null' ? null : info.match.params.parentUnique;
-					this.createScaffold({ parent: { entityType: parentEntityType, unique: parentUnique } });
+					await this.createScaffold({ parent: { entityType: parentEntityType, unique: parentUnique } });
 
 					new UmbWorkspaceIsNewRedirectController(
 						this,

--- a/src/packages/dictionary/workspace/dictionary-workspace.context.ts
+++ b/src/packages/dictionary/workspace/dictionary-workspace.context.ts
@@ -32,7 +32,7 @@ export class UmbDictionaryWorkspaceContext
 				setup: async (_component, info) => {
 					const parentEntityType = info.match.params.entityType;
 					const parentUnique = info.match.params.parentUnique === 'null' ? null : info.match.params.parentUnique;
-					this.createScaffold({ parent: { entityType: parentEntityType, unique: parentUnique } });
+					await this.createScaffold({ parent: { entityType: parentEntityType, unique: parentUnique } });
 
 					new UmbWorkspaceIsNewRedirectController(
 						this,

--- a/src/packages/documents/document-blueprints/workspace/document-blueprint-workspace.context.ts
+++ b/src/packages/documents/document-blueprints/workspace/document-blueprint-workspace.context.ts
@@ -189,7 +189,7 @@ export class UmbDocumentBlueprintWorkspaceContext
 					const parentEntityType = info.match.params.parentEntityType;
 					const parentUnique = info.match.params.parentUnique === 'null' ? null : info.match.params.parentUnique;
 					const documentTypeUnique = info.match.params.documentTypeUnique;
-					this.create({ entityType: parentEntityType, unique: parentUnique }, documentTypeUnique);
+					await this.create({ entityType: parentEntityType, unique: parentUnique }, documentTypeUnique);
 
 					new UmbWorkspaceIsNewRedirectController(
 						this,

--- a/src/packages/documents/document-types/workspace/document-type-workspace.context.ts
+++ b/src/packages/documents/document-types/workspace/document-type-workspace.context.ts
@@ -110,7 +110,7 @@ export class UmbDocumentTypeWorkspaceContext
 			{
 				path: UMB_CREATE_DOCUMENT_TYPE_WORKSPACE_PATH_PATTERN.toString(),
 				component: UmbDocumentTypeWorkspaceEditorElement,
-				setup: (_component, info) => {
+				setup: async (_component, info) => {
 					const params = info.match.params as unknown as UmbPathPatternTypeAsEncodedParamsType<
 						typeof UMB_CREATE_DOCUMENT_TYPE_WORKSPACE_PATH_PATTERN.PARAMS
 					>;
@@ -120,7 +120,7 @@ export class UmbDocumentTypeWorkspaceContext
 					if (parentUnique === undefined) {
 						throw new Error('ParentUnique url parameter is required to create a document type');
 					}
-					this.create({ entityType: parentEntityType, unique: parentUnique }, presetAlias);
+					await this.create({ entityType: parentEntityType, unique: parentUnique }, presetAlias);
 
 					new UmbWorkspaceIsNewRedirectController(
 						this,

--- a/src/packages/documents/documents/workspace/document-workspace.context.ts
+++ b/src/packages/documents/documents/workspace/document-workspace.context.ts
@@ -249,7 +249,11 @@ export class UmbDocumentWorkspaceContext
 					const documentTypeUnique = info.match.params.documentTypeUnique;
 					const blueprintUnique = info.match.params.blueprintUnique;
 
-					this.create({ entityType: parentEntityType, unique: parentUnique }, documentTypeUnique, blueprintUnique);
+					await this.create(
+						{ entityType: parentEntityType, unique: parentUnique },
+						documentTypeUnique,
+						blueprintUnique,
+					);
 					new UmbWorkspaceIsNewRedirectController(
 						this,
 						this,
@@ -264,7 +268,7 @@ export class UmbDocumentWorkspaceContext
 					const parentEntityType = info.match.params.parentEntityType;
 					const parentUnique = info.match.params.parentUnique === 'null' ? null : info.match.params.parentUnique;
 					const documentTypeUnique = info.match.params.documentTypeUnique;
-					this.create({ entityType: parentEntityType, unique: parentUnique }, documentTypeUnique);
+					await this.create({ entityType: parentEntityType, unique: parentUnique }, documentTypeUnique);
 
 					new UmbWorkspaceIsNewRedirectController(
 						this,

--- a/src/packages/language/workspace/language/language-workspace.context.ts
+++ b/src/packages/language/workspace/language/language-workspace.context.ts
@@ -32,7 +32,7 @@ export class UmbLanguageWorkspaceContext
 				path: 'create',
 				component: UmbLanguageWorkspaceEditorElement,
 				setup: async () => {
-					this.createScaffold({ parent: { entityType: UMB_LANGUAGE_ROOT_ENTITY_TYPE, unique: null } });
+					await this.createScaffold({ parent: { entityType: UMB_LANGUAGE_ROOT_ENTITY_TYPE, unique: null } });
 
 					new UmbWorkspaceIsNewRedirectController(
 						this,

--- a/src/packages/media/media-types/workspace/media-type-workspace.context.ts
+++ b/src/packages/media/media-types/workspace/media-type-workspace.context.ts
@@ -81,10 +81,10 @@ export class UmbMediaTypeWorkspaceContext
 			{
 				path: 'create/parent/:entityType/:parentUnique',
 				component: UmbMediaTypeWorkspaceEditorElement,
-				setup: (_component, info) => {
+				setup: async (_component, info) => {
 					const parentEntityType = info.match.params.entityType;
 					const parentUnique = info.match.params.parentUnique === 'null' ? null : info.match.params.parentUnique;
-					this.create({ entityType: parentEntityType, unique: parentUnique });
+					await this.create({ entityType: parentEntityType, unique: parentUnique });
 
 					new UmbWorkspaceIsNewRedirectController(
 						this,

--- a/src/packages/media/media/workspace/media-workspace.context.ts
+++ b/src/packages/media/media/workspace/media-workspace.context.ts
@@ -191,7 +191,7 @@ export class UmbMediaWorkspaceContext
 					const parentEntityType = info.match.params.entityType;
 					const parentUnique = info.match.params.parentUnique === 'null' ? null : info.match.params.parentUnique;
 					const mediaTypeUnique = info.match.params.mediaTypeUnique;
-					this.create({ entityType: parentEntityType, unique: parentUnique }, mediaTypeUnique);
+					await this.create({ entityType: parentEntityType, unique: parentUnique }, mediaTypeUnique);
 
 					new UmbWorkspaceIsNewRedirectController(
 						this,

--- a/src/packages/members/member-group/workspace/member-group/member-group-workspace.context.ts
+++ b/src/packages/members/member-group/workspace/member-group/member-group-workspace.context.ts
@@ -29,8 +29,8 @@ export class UmbMemberGroupWorkspaceContext
 			{
 				path: 'create',
 				component: UmbMemberGroupWorkspaceEditorElement,
-				setup: () => {
-					this.createScaffold({ parent: { entityType: UMB_USER_GROUP_ROOT_ENTITY_TYPE, unique: null } });
+				setup: async () => {
+					await this.createScaffold({ parent: { entityType: UMB_USER_GROUP_ROOT_ENTITY_TYPE, unique: null } });
 
 					new UmbWorkspaceIsNewRedirectController(
 						this,

--- a/src/packages/members/member-type/workspace/member-type-workspace.context.ts
+++ b/src/packages/members/member-type/workspace/member-type-workspace.context.ts
@@ -77,10 +77,10 @@ export class UmbMemberTypeWorkspaceContext
 			{
 				path: 'create/parent/:entityType/:parentUnique',
 				component: UmbMemberTypeWorkspaceEditorElement,
-				setup: (_component, info) => {
+				setup: async (_component, info) => {
 					const parentEntityType = info.match.params.entityType;
 					const parentUnique = info.match.params.parentUnique === 'null' ? null : info.match.params.parentUnique;
-					this.create({ entityType: parentEntityType, unique: parentUnique });
+					await this.create({ entityType: parentEntityType, unique: parentUnique });
 
 					new UmbWorkspaceIsNewRedirectController(
 						this,

--- a/src/packages/members/member/workspace/member/member-workspace.context.ts
+++ b/src/packages/members/member/workspace/member/member-workspace.context.ts
@@ -183,7 +183,7 @@ export class UmbMemberWorkspaceContext
 				component: () => new UmbMemberWorkspaceEditorElement(),
 				setup: async (_component, info) => {
 					const memberTypeUnique = info.match.params.memberTypeUnique;
-					this.create(memberTypeUnique);
+					await this.create(memberTypeUnique);
 
 					new UmbWorkspaceIsNewRedirectController(
 						this,

--- a/src/packages/templating/scripts/workspace/script-workspace.context.ts
+++ b/src/packages/templating/scripts/workspace/script-workspace.context.ts
@@ -33,7 +33,7 @@ export class UmbScriptWorkspaceContext
 				setup: async (component: PageComponent, info: IRoutingInfo) => {
 					const parentEntityType = info.match.params.entityType;
 					const parentUnique = info.match.params.parentUnique === 'null' ? null : info.match.params.parentUnique;
-					this.createScaffold({ parent: { entityType: parentEntityType, unique: parentUnique } });
+					await this.createScaffold({ parent: { entityType: parentEntityType, unique: parentUnique } });
 
 					new UmbWorkspaceIsNewRedirectController(
 						this,

--- a/src/packages/templating/stylesheets/workspace/stylesheet-workspace.context.ts
+++ b/src/packages/templating/stylesheets/workspace/stylesheet-workspace.context.ts
@@ -45,7 +45,7 @@ export class UmbStylesheetWorkspaceContext
 				setup: async (component: PageComponent, info: IRoutingInfo) => {
 					const parentEntityType = info.match.params.entityType;
 					const parentUnique = info.match.params.parentUnique === 'null' ? null : info.match.params.parentUnique;
-					this.create({ entityType: parentEntityType, unique: parentUnique });
+					await this.create({ entityType: parentEntityType, unique: parentUnique });
 
 					new UmbWorkspaceIsNewRedirectController(
 						this,

--- a/src/packages/templating/templates/workspace/template-workspace.context.ts
+++ b/src/packages/templating/templates/workspace/template-workspace.context.ts
@@ -41,10 +41,10 @@ export class UmbTemplateWorkspaceContext
 			{
 				path: 'create/parent/:entityType/:parentUnique',
 				component: UmbTemplateWorkspaceEditorElement,
-				setup: (component: PageComponent, info: IRoutingInfo) => {
+				setup: async (component: PageComponent, info: IRoutingInfo) => {
 					const parentEntityType = info.match.params.entityType;
 					const parentUnique = info.match.params.parentUnique === 'null' ? null : info.match.params.parentUnique;
-					this.create({ entityType: parentEntityType, unique: parentUnique });
+					await this.create({ entityType: parentEntityType, unique: parentUnique });
 
 					new UmbWorkspaceIsNewRedirectController(
 						this,

--- a/src/packages/user/user-group/workspace/user-group/user-group-workspace.context.ts
+++ b/src/packages/user/user-group/workspace/user-group/user-group-workspace.context.ts
@@ -42,8 +42,8 @@ export class UmbUserGroupWorkspaceContext
 			{
 				path: 'create',
 				component: UmbUserGroupWorkspaceEditorElement,
-				setup: () => {
-					this.createScaffold({ parent: { entityType: UMB_USER_GROUP_ROOT_ENTITY_TYPE, unique: null } });
+				setup: async () => {
+					await this.createScaffold({ parent: { entityType: UMB_USER_GROUP_ROOT_ENTITY_TYPE, unique: null } });
 
 					new UmbWorkspaceIsNewRedirectController(
 						this,

--- a/src/packages/webhook/workspace/webhook/webhook-workspace.context.ts
+++ b/src/packages/webhook/workspace/webhook/webhook-workspace.context.ts
@@ -28,7 +28,7 @@ export class UmbWebhookWorkspaceContext
 				path: 'create',
 				component: UmbWebhookWorkspaceEditorElement,
 				setup: async () => {
-					this.createScaffold({ parent: { entityType: UMB_WEBHOOK_ROOT_ENTITY_TYPE, unique: null } });
+					await this.createScaffold({ parent: { entityType: UMB_WEBHOOK_ROOT_ENTITY_TYPE, unique: null } });
 
 					new UmbWorkspaceIsNewRedirectController(
 						this,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR addresses an issue encountered when changing from editing an existing entity to creating a new one of the same type. In some workspaces, when users attempted to create a new entity, the `isNew` state, which should be set to true upon creation, was mistakenly retained as false from the editing state at first. This resulted in a redirect from the create URL back to the edit URL.

To fix this, this PR ensures that the redirect controller is initialized after the scaffolding logic is complete. Since the scaffolding/create method is already async, it makes sense to await this so we first start observing the "isNew" state afterward. This way, we ensure that the state we observe is correct.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
