### PR TITLE
Fixes duplicate alias in examples/ufm-custom-component/index.ts that fails npm run compile

### DIFF
--- a/examples/ufm-custom-component/index.ts
+++ b/examples/ufm-custom-component/index.ts
@@ -8,8 +8,7 @@ export const manifests: Array<ManifestUfmComponent> = [
 		api: () => import('./custom-ufm-component.js'),
 		meta: {
 			alias: 'myCustomComponent',
-			marker: '%',
-			alias: 'myCustomComponent',
+			marker: '%'
 		},
 	},
 ];


### PR DESCRIPTION
Fixes issue when running `npm run compile`

```
examples/ufm-custom-component/index.ts:12:4 - error TS1117: An object literal cannot have multiple properties with the same name.

12    alias: 'myCustomComponent',
      ~~~~~


Found 1 error in examples/ufm-custom-component/index.ts:12
```


<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes the repo building when running `npm run compile`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Make the repo & build happy

## How to test?

## Screenshots (if appropriate)
![image](https://github.com/user-attachments/assets/84b2b689-f14c-4e05-b100-b532769d1b94)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
