### PR TITLE
Bugfix: Tiptap Link Picker, fixes anchor with an empty URL

### DIFF
--- a/src/packages/tiptap/extensions/toolbar/link.extension.ts
+++ b/src/packages/tiptap/extensions/toolbar/link.extension.ts
@@ -75,7 +75,7 @@ export default class UmbTiptapToolbarLinkExtensionApi extends UmbTiptapToolbarEl
 
 		const anchor = this.#getAnchorFromQueryString(queryString);
 
-		if (anchor) url += anchor;
+		if (anchor) url = (url ?? '') + anchor;
 
 		if (!url) return null;
 

--- a/src/packages/tiptap/extensions/toolbar/link.extension.ts
+++ b/src/packages/tiptap/extensions/toolbar/link.extension.ts
@@ -75,7 +75,9 @@ export default class UmbTiptapToolbarLinkExtensionApi extends UmbTiptapToolbarEl
 
 		const anchor = this.#getAnchorFromQueryString(queryString);
 
-		if (anchor) url = (url ?? '') + anchor;
+		if (anchor) {
+			url = (url ?? '') + anchor;
+		}
 
 		if (!url) return null;
 


### PR DESCRIPTION
## Description

In the Tiptap Link Picker extension, when adding a link with an anchor/querystring and empty URL (for in-page navigation), the `href` was being stringified with the URL's `null` value.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## How to test?

In the Tiptap editor, open the Link Picker modal, set an anchor/querystring value without setting the URL field, press Submit.
Select the link you've just created, edit in the Link Picker modal, notice that the URL value is empty and **not** set to a stringified `null` value.
