### PR TITLE
Bugfix: creating new doc type properties sort order doesn't count existing properties - puts it at top (+1)

### DIFF
--- a/src/packages/core/content-type/workspace/views/design/content-type-design-editor-properties.element.ts
+++ b/src/packages/core/content-type/workspace/views/design/content-type-design-editor-properties.element.ts
@@ -193,7 +193,7 @@ export class UmbContentTypeDesignEditorPropertiesElement extends UmbLitElement {
 					}
 					preset.sortOrder = sortOrderInt;
 				}
-				return { data: { contentTypeUnique: this._ownerContentTypeUnique, preset: undefined } };
+				return { data: { contentTypeUnique: this._ownerContentTypeUnique, preset: preset } };
 			})
 			.observeRouteBuilder((routeBuilder) => {
 				this._newPropertyPath =


### PR DESCRIPTION
## Description

Fixes https://github.com/umbraco/Umbraco-CMS/issues/17457

Creating new doc type properties sort order doesn't count existing properties.

Looking at this it seems that the hardwork is done to workout the sort order and assign it to preset but it's not returned undefined was (probably as a dev placeholder that's gone unnoticed!).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## How to test?

## Checklist

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
